### PR TITLE
EES-7008 release series searching

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.module.scss
@@ -1,0 +1,5 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.pageSizeSelect {
+  min-width: 6ch;
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -10,7 +10,6 @@ import {
   PublicationReleaseSeriesItem,
   PublicationSummary,
 } from '@common/services/publicationService';
-import { PaginatedList } from '@common/services/types/pagination';
 import { formatPartialDate } from '@common/utils/date/partialDate';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
@@ -24,7 +23,7 @@ import React, { useMemo, useState } from 'react';
 
 interface Props {
   publicationSummary: PublicationSummary;
-  allReleases: PaginatedList<PublicationReleaseSeriesItem>;
+  allReleases: PublicationReleaseSeriesItem[];
 }
 
 const MIN_PAGE_SIZE = 10;
@@ -35,8 +34,6 @@ const PublicationReleaseListPage = ({
   publicationSummary,
   allReleases,
 }: Props) => {
-  const { results } = allReleases ?? {};
-
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [searchTerm, setSearchTerm] = useState<string>();
@@ -44,11 +41,11 @@ const PublicationReleaseListPage = ({
   const filteredResults = useMemo(
     () =>
       searchTerm
-        ? results.filter(item =>
+        ? allReleases.filter(item =>
             item.title.toLowerCase().includes(searchTerm.toLowerCase()),
           )
-        : results,
-    [results, searchTerm],
+        : allReleases,
+    [allReleases, searchTerm],
   );
 
   const paginatedReleasesPages = useMemo(
@@ -272,7 +269,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
   const queryClient = new QueryClient();
 
   try {
-    const [publicationSummary, allReleases] = await Promise.all([
+    const [publicationSummary, releases] = await Promise.all([
       queryClient.fetchQuery(
         publicationQueries.getPublicationSummary(publicationSlug),
       ),
@@ -284,7 +281,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
     return {
       props: {
         publicationSummary,
-        allReleases,
+        allReleases: releases.results,
       },
     };
   } catch (error) {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -1,8 +1,11 @@
 import ButtonText from '@common/components/ButtonText';
 import { FormGroup, FormSelect } from '@common/components/form';
+import FormSearchBar from '@common/components/form/FormSearchBar';
 import FormattedDate from '@common/components/FormattedDate';
 import Pagination from '@common/components/Pagination';
 import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
 import {
   PublicationReleaseSeriesItem,
   PublicationSummary,
@@ -26,6 +29,7 @@ interface Props {
 
 const MIN_PAGE_SIZE = 10;
 const DEFAULT_PAGE_SIZE = 25;
+const formId = 'releases-search';
 
 const PublicationReleaseListPage = ({
   publicationSummary,
@@ -35,10 +39,21 @@ const PublicationReleaseListPage = ({
 
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [searchTerm, setSearchTerm] = useState<string>();
+
+  const filteredResults = useMemo(
+    () =>
+      searchTerm
+        ? results.filter(item =>
+            item.title.toLowerCase().includes(searchTerm.toLowerCase()),
+          )
+        : results,
+    [results, searchTerm],
+  );
 
   const paginatedReleasesPages = useMemo(
-    () => chunk(results, pageSize),
-    [results, pageSize],
+    () => chunk(filteredResults, pageSize),
+    [filteredResults, pageSize],
   );
 
   const totalPages = paginatedReleasesPages.length;
@@ -54,6 +69,11 @@ const PublicationReleaseListPage = ({
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
+
+  const [handleSearch] = useDebouncedCallback((term: string) => {
+    setSearchTerm(term);
+    setCurrentPage(1);
+  }, 800);
 
   return (
     <Page
@@ -96,11 +116,42 @@ const PublicationReleaseListPage = ({
             Release home (latest release)
           </Link>
 
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-one-half">
+              <form
+                id={formId}
+                className="govuk-!-margin-bottom-8"
+                onSubmit={e => {
+                  e.preventDefault();
+                }}
+              >
+                <FormSearchBar
+                  id={`${formId}-search`}
+                  label="Search release periods"
+                  labelSize="s"
+                  min={0}
+                  name="search"
+                  onChange={handleSearch}
+                  onReset={() => handleSearch('')}
+                />
+              </form>
+              <VisuallyHidden>
+                <p aria-atomic aria-live="polite">
+                  {`${filteredResults.length} result${
+                    filteredResults.length > 1 ? 's' : ''
+                  }, showing page ${currentPage} of ${totalPages}`}
+                </p>
+              </VisuallyHidden>
+            </div>
+          </div>
+
           {paginatedReleasesPages.length > 0 ? (
             <div className="table-container">
               <table data-testid="release-updates-table">
-                <caption className="govuk-table__caption--m">
-                  Table showing all published releases in this series
+                <caption className="govuk-table__caption--m" aria-live="polite">
+                  {searchTerm
+                    ? `Table showing release periods with search term ‘${searchTerm}’`
+                    : 'Table showing all published releases in this series'}
                 </caption>
 
                 <thead>
@@ -147,11 +198,21 @@ const PublicationReleaseListPage = ({
               </table>
             </div>
           ) : (
-            'No results found.'
+            <>
+              <p className="govuk-!-font-weight-bold">
+                There are no matching results.
+              </p>
+              <p>Improve your search results by:</p>
+              <ul>
+                <li>double-checking your spelling</li>
+                <li>using fewer keywords</li>
+                <li>searching for something less specific</li>
+              </ul>
+            </>
           )}
 
-          {results.length > MIN_PAGE_SIZE && (
-            <FormGroup>
+          {filteredResults.length > MIN_PAGE_SIZE && (
+            <FormGroup className="govuk-!-margin-top-4">
               <FormSelect
                 className={styles.pageSizeSelect}
                 id="pagination-size-select"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -1,4 +1,7 @@
+import ButtonText from '@common/components/ButtonText';
+import { FormGroup, FormSelect } from '@common/components/form';
 import FormattedDate from '@common/components/FormattedDate';
+import Pagination from '@common/components/Pagination';
 import Tag from '@common/components/Tag';
 import {
   PublicationReleaseSeriesItem,
@@ -8,31 +11,55 @@ import { PaginatedList } from '@common/services/types/pagination';
 import { formatPartialDate } from '@common/utils/date/partialDate';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
-import Pagination from '@frontend/components/Pagination';
+import styles from '@frontend/modules/find-statistics/PublicationReleaseListPage.module.scss';
 import publicationQueries from '@frontend/queries/publicationQueries';
-import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { Dictionary } from '@frontend/types';
 import { QueryClient } from '@tanstack/react-query';
+import { chunk } from 'lodash';
 import { GetServerSideProps } from 'next';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 interface Props {
   publicationSummary: PublicationSummary;
-  releases: PaginatedList<PublicationReleaseSeriesItem>;
+  allReleases: PaginatedList<PublicationReleaseSeriesItem>;
 }
+
+const MIN_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 25;
 
 const PublicationReleaseListPage = ({
   publicationSummary,
-  releases,
+  allReleases,
 }: Props) => {
-  const { paging, results } = releases ?? {};
-  const { page, totalPages } = paging ?? {};
+  const { results } = allReleases ?? {};
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+  const paginatedReleasesPages = useMemo(
+    () => chunk(results, pageSize),
+    [results, pageSize],
+  );
+
+  const totalPages = paginatedReleasesPages.length;
+
+  const handlePageSizeChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const newPageSize = Number(event.target.value);
+    setPageSize(newPageSize);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  };
 
   return (
     <Page
       title={publicationSummary.title}
       metaTitle={`Releases - ${publicationSummary.title} ${
-        page ? `- page ${page}` : ''
+        currentPage > 1 ? `- page ${currentPage}` : ''
       }`}
       description={`Releases in ${publicationSummary.title.toLocaleLowerCase()}.`}
       caption="Releases in this series"
@@ -68,64 +95,104 @@ const PublicationReleaseListPage = ({
           >
             Release home (latest release)
           </Link>
-          <table data-testid="release-updates-table">
-            <caption className="govuk-table__caption--m">
-              Table showing all published releases in this series
-            </caption>
 
-            <thead>
-              <tr>
-                <th scope="col">Release period</th>
-                <th scope="col">Published date</th>
-                <th scope="col">Last update</th>
-              </tr>
-            </thead>
-            <tbody>
-              {results.map(release =>
-                'releaseId' in release ? (
-                  <tr key={release.releaseId}>
-                    <td>
-                      <Link
-                        to={`/find-statistics/${publicationSummary.slug}/${release.slug}`}
-                      >
-                        {release.title}
-                      </Link>
-                    </td>
-                    <td>
-                      <div className="dfe-flex dfe-flex-wrap dfe-gap-2">
-                        <FormattedDate>{release.published}</FormattedDate>
-                        {release.isLatestRelease === true && (
-                          <Tag>Latest release</Tag>
-                        )}
-                      </div>
-                    </td>
-                    <td>
-                      <FormattedDate>{release.lastUpdated}</FormattedDate>
-                    </td>
+          {paginatedReleasesPages.length > 0 ? (
+            <div className="table-container">
+              <table data-testid="release-updates-table">
+                <caption className="govuk-table__caption--m">
+                  Table showing all published releases in this series
+                </caption>
+
+                <thead>
+                  <tr>
+                    <th scope="col">Release period</th>
+                    <th scope="col">Published date</th>
+                    <th scope="col">Last update</th>
                   </tr>
-                ) : (
-                  <tr key={release.title}>
-                    <td>
-                      <Link to={release.url}>{release.title}</Link>
-                    </td>
-                    <td>Not available</td>
-                    <td>Not available</td>
-                  </tr>
-                ),
-              )}
-            </tbody>
-          </table>
-          {page && !!totalPages && (
+                </thead>
+                <tbody>
+                  {paginatedReleasesPages[currentPage - 1].map(release =>
+                    'releaseId' in release ? (
+                      <tr key={release.releaseId}>
+                        <td>
+                          <Link
+                            to={`/find-statistics/${publicationSummary.slug}/${release.slug}`}
+                          >
+                            {release.title}
+                          </Link>
+                        </td>
+                        <td>
+                          <div className="dfe-flex dfe-flex-wrap dfe-gap-2">
+                            <FormattedDate>{release.published}</FormattedDate>
+                            {release.isLatestRelease === true && (
+                              <Tag>Latest release</Tag>
+                            )}
+                          </div>
+                        </td>
+                        <td>
+                          <FormattedDate>{release.lastUpdated}</FormattedDate>
+                        </td>
+                      </tr>
+                    ) : (
+                      <tr key={release.title}>
+                        <td>
+                          <Link to={release.url}>{release.title}</Link>
+                        </td>
+                        <td>Not available</td>
+                        <td>Not available</td>
+                      </tr>
+                    ),
+                  )}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            'No results found.'
+          )}
+
+          {results.length > MIN_PAGE_SIZE && (
+            <FormGroup>
+              <FormSelect
+                className={styles.pageSizeSelect}
+                id="pagination-size-select"
+                label="Number of results per page"
+                name="pagination-size"
+                options={[
+                  { value: '10', label: '10' },
+                  { value: '25', label: '25' },
+                  { value: '50', label: '50' },
+                  { value: '100', label: '100' },
+                ]}
+                value={pageSize.toString()}
+                order={[]}
+                onChange={handlePageSizeChange}
+              />
+            </FormGroup>
+          )}
+
+          {totalPages > 1 && (
             <Pagination
-              currentPage={page}
+              currentPage={currentPage}
               totalPages={totalPages}
-              onClick={pageNumber => {
-                logEvent({
-                  category: 'Publication releases',
-                  action: `Pagination clicked`,
-                  label: `Page ${pageNumber}`,
-                });
-              }}
+              renderLink={({
+                'aria-current': ariaCurrent,
+                'aria-label': ariaLabel,
+                'data-testid': testId,
+                children,
+                className,
+                onClick,
+              }) => (
+                <ButtonText
+                  ariaCurrent={ariaCurrent}
+                  ariaLabel={ariaLabel}
+                  className={`govuk-link ${className}`}
+                  testId={testId}
+                  onClick={onClick}
+                >
+                  {children}
+                </ButtonText>
+              )}
+              onClick={handlePageChange}
             />
           )}
         </div>
@@ -139,31 +206,24 @@ export default PublicationReleaseListPage;
 export const getServerSideProps: GetServerSideProps<Props> = async ({
   query,
 }) => {
-  const {
-    publication: publicationSlug,
-    page,
-    pageSize,
-  } = query as Dictionary<string>;
+  const { publication: publicationSlug } = query as Dictionary<string>;
 
   const queryClient = new QueryClient();
 
   try {
-    const [publicationSummary, releases] = await Promise.all([
+    const [publicationSummary, allReleases] = await Promise.all([
       queryClient.fetchQuery(
         publicationQueries.getPublicationSummary(publicationSlug),
       ),
       queryClient.fetchQuery(
-        publicationQueries.getPublicationReleaseList(publicationSlug, {
-          page: page ? Number(page) : 1,
-          pageSize: pageSize ? Number(pageSize) : 25,
-        }),
+        publicationQueries.getPublicationReleaseList(publicationSlug),
       ),
     ]);
 
     return {
       props: {
         publicationSummary,
-        releases,
+        allReleases,
       },
     };
   } catch (error) {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
@@ -1,6 +1,7 @@
 import { PublicationReleaseSeriesItem } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
-import { render, screen, within } from '@testing-library/react';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import PublicationReleaseListPage from '../PublicationReleaseListPage';
 import { testPublicationSummary } from './__data__/testReleaseData';
@@ -36,16 +37,121 @@ describe('PublicationReleaseListPage', () => {
     ],
     paging: {
       page: 1,
-      pageSize: 10,
+      pageSize: 3,
       totalResults: 3,
       totalPages: 1,
     },
   };
+
+  const testReleasesLonger: PaginatedList<PublicationReleaseSeriesItem> = {
+    results: [
+      ...testReleases.results,
+      {
+        title: 'Legacy title 4',
+        url: 'https://example.com/legacy-title-4',
+      },
+      {
+        title: 'Legacy title 5',
+        url: 'https://example.com/legacy-title-5',
+      },
+      {
+        title: 'Legacy title 6',
+        url: 'https://example.com/legacy-title-6',
+      },
+      {
+        title: 'Legacy title 7',
+        url: 'https://example.com/legacy-title-7',
+      },
+      {
+        title: 'Legacy title 8',
+        url: 'https://example.com/legacy-title-8',
+      },
+      {
+        title: 'Legacy title 9',
+        url: 'https://example.com/legacy-title-9',
+      },
+      {
+        title: 'Legacy title 10',
+        url: 'https://example.com/legacy-title-10',
+      },
+      {
+        title: 'Legacy title 11',
+        url: 'https://example.com/legacy-title-11',
+      },
+      {
+        title: 'Legacy title 12',
+        url: 'https://example.com/legacy-title-12',
+      },
+      {
+        title: 'Legacy title 13',
+        url: 'https://example.com/legacy-title-13',
+      },
+      {
+        title: 'Legacy title 14',
+        url: 'https://example.com/legacy-title-14',
+      },
+      {
+        title: 'Legacy title 15',
+        url: 'https://example.com/legacy-title-15',
+      },
+      {
+        title: 'Legacy title 16',
+        url: 'https://example.com/legacy-title-16',
+      },
+      {
+        title: 'Legacy title 17',
+        url: 'https://example.com/legacy-title-17',
+      },
+      {
+        title: 'Legacy title 18',
+        url: 'https://example.com/legacy-title-18',
+      },
+      {
+        title: 'Legacy title 19',
+        url: 'https://example.com/legacy-title-19',
+      },
+      {
+        title: 'Legacy title 20',
+        url: 'https://example.com/legacy-title-20',
+      },
+      {
+        title: 'Legacy title 21',
+        url: 'https://example.com/legacy-title-21',
+      },
+      {
+        title: 'Legacy title 22',
+        url: 'https://example.com/legacy-title-22',
+      },
+      {
+        title: 'Legacy title 23',
+        url: 'https://example.com/legacy-title-23',
+      },
+      {
+        title: 'Legacy title 24',
+        url: 'https://example.com/legacy-title-24',
+      },
+      {
+        title: 'Legacy title 25',
+        url: 'https://example.com/legacy-title-25',
+      },
+      {
+        title: 'Legacy title 26',
+        url: 'https://example.com/legacy-title-26',
+      },
+    ],
+    paging: {
+      page: 1,
+      pageSize: 26,
+      totalResults: 26,
+      totalPages: 1,
+    },
+  };
+
   test('renders next publish date', () => {
     render(
       <PublicationReleaseListPage
         publicationSummary={testPublicationSummary}
-        releases={testReleases}
+        allReleases={testReleases}
       />,
     );
 
@@ -58,7 +164,7 @@ describe('PublicationReleaseListPage', () => {
     render(
       <PublicationReleaseListPage
         publicationSummary={testPublicationSummary}
-        releases={testReleases}
+        allReleases={testReleases}
       />,
     );
 
@@ -109,39 +215,61 @@ describe('PublicationReleaseListPage', () => {
     );
     expect(within(row3Cells[1]).getByText('Not available')).toBeInTheDocument();
     expect(within(row3Cells[2]).getByText('Not available')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('navigation', { name: 'Pagination' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Number of results per page'),
+    ).not.toBeInTheDocument();
   });
 
-  test('renders pagination when multiple pages', () => {
-    const testReleasesMultiPage: PaginatedList<PublicationReleaseSeriesItem> = {
-      ...testReleases,
-      paging: {
-        page: 2,
-        pageSize: 1,
-        totalResults: 3,
-        totalPages: 3,
-      },
-    };
-    render(
+  test('pagination', async () => {
+    const { user } = render(
       <PublicationReleaseListPage
         publicationSummary={testPublicationSummary}
-        releases={testReleasesMultiPage}
+        allReleases={testReleasesLonger}
       />,
     );
 
     expect(
       screen.getByRole('navigation', { name: 'Pagination' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Page 1' })).toHaveAttribute(
-      'href',
-      '?page=1',
+    expect(
+      screen.getByLabelText('Number of results per page'),
+    ).toBeInTheDocument();
+
+    expect(within(screen.getByRole('table')).getAllByRole('row')).toHaveLength(
+      26,
+    ); // including header row
+
+    await user.click(screen.getByRole('button', { name: 'Page 2' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('10 August 2025')).not.toBeInTheDocument(),
     );
-    expect(screen.getByRole('link', { name: 'Page 2' })).toHaveAttribute(
-      'aria-current',
-      'page',
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(row1Cells[0]).toHaveTextContent('Legacy title 26');
+
+    expect(
+      screen.getByRole('button', { name: 'Previous page' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Next page' }),
+    ).not.toBeInTheDocument();
+
+    // Check pagination window functionality
+    await user.selectOptions(
+      screen.getByLabelText('Number of results per page'),
+      '50',
     );
-    expect(screen.getByRole('link', { name: 'Page 3' })).toHaveAttribute(
-      'href',
-      '?page=3',
+    expect(within(screen.getByRole('table')).getAllByRole('row')).toHaveLength(
+      27,
     );
+    expect(
+      screen.queryByRole('navigation', { name: 'Pagination' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
@@ -1,5 +1,4 @@
 import { PublicationReleaseSeriesItem } from '@common/services/publicationService';
-import { PaginatedList } from '@common/services/types/pagination';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
@@ -7,145 +6,129 @@ import PublicationReleaseListPage from '../PublicationReleaseListPage';
 import { testPublicationSummary } from './__data__/testReleaseData';
 
 describe('PublicationReleaseListPage', () => {
-  const testReleases: PaginatedList<PublicationReleaseSeriesItem> = {
-    results: [
-      {
-        releaseId: 'test-release-id-3',
-        slug: 'test-release-slug-3',
-        title: 'Test Release Title 3 - Final',
-        yearTitle: '2021/22',
-        coverageTitle: 'Academic Year',
-        label: 'Final',
-        published: '2025-08-10T09:30:00+01:00',
-        lastUpdated: '2025-08-11T14:30:00+01:00',
-        isLatestRelease: true,
-      },
-      {
-        releaseId: 'test-release-id-2',
-        slug: 'test-release-slug-2',
-        title: 'Test Release Title 2',
-        yearTitle: '2021/22',
-        coverageTitle: 'Academic Year',
-        published: '2025-07-01T09:30:00+01:00',
-        lastUpdated: '2025-07-11T14:30:00+01:00',
-        isLatestRelease: false,
-      },
-      {
-        title: 'Legacy title',
-        url: 'https://example.com/legacy-title',
-      },
-    ],
-    paging: {
-      page: 1,
-      pageSize: 3,
-      totalResults: 3,
-      totalPages: 1,
+  const testReleases: PublicationReleaseSeriesItem[] = [
+    {
+      releaseId: 'test-release-id-3',
+      slug: 'test-release-slug-3',
+      title: 'Test Release Title 3 - Final',
+      yearTitle: '2021/22',
+      coverageTitle: 'Academic Year',
+      label: 'Final',
+      published: '2025-08-10T09:30:00+01:00',
+      lastUpdated: '2025-08-11T14:30:00+01:00',
+      isLatestRelease: true,
     },
-  };
+    {
+      releaseId: 'test-release-id-2',
+      slug: 'test-release-slug-2',
+      title: 'Test Release Title 2',
+      yearTitle: '2021/22',
+      coverageTitle: 'Academic Year',
+      published: '2025-07-01T09:30:00+01:00',
+      lastUpdated: '2025-07-11T14:30:00+01:00',
+      isLatestRelease: false,
+    },
+    {
+      title: 'Legacy title',
+      url: 'https://example.com/legacy-title',
+    },
+  ];
 
-  const testReleasesLonger: PaginatedList<PublicationReleaseSeriesItem> = {
-    results: [
-      ...testReleases.results,
-      {
-        title: 'Legacy title 4',
-        url: 'https://example.com/legacy-title-4',
-      },
-      {
-        title: 'Legacy title 5',
-        url: 'https://example.com/legacy-title-5',
-      },
-      {
-        title: 'Legacy title 6',
-        url: 'https://example.com/legacy-title-6',
-      },
-      {
-        title: 'Legacy title 7',
-        url: 'https://example.com/legacy-title-7',
-      },
-      {
-        title: 'Legacy title 8',
-        url: 'https://example.com/legacy-title-8',
-      },
-      {
-        title: 'Legacy title 9',
-        url: 'https://example.com/legacy-title-9',
-      },
-      {
-        title: 'Legacy title 10',
-        url: 'https://example.com/legacy-title-10',
-      },
-      {
-        title: 'Legacy title 11',
-        url: 'https://example.com/legacy-title-11',
-      },
-      {
-        title: 'Legacy title 12',
-        url: 'https://example.com/legacy-title-12',
-      },
-      {
-        title: 'Legacy title 13',
-        url: 'https://example.com/legacy-title-13',
-      },
-      {
-        title: 'Legacy title 14',
-        url: 'https://example.com/legacy-title-14',
-      },
-      {
-        title: 'Legacy title 15',
-        url: 'https://example.com/legacy-title-15',
-      },
-      {
-        title: 'Legacy title 16',
-        url: 'https://example.com/legacy-title-16',
-      },
-      {
-        title: 'Legacy title 17',
-        url: 'https://example.com/legacy-title-17',
-      },
-      {
-        title: 'Legacy title 18',
-        url: 'https://example.com/legacy-title-18',
-      },
-      {
-        title: 'Legacy title 19',
-        url: 'https://example.com/legacy-title-19',
-      },
-      {
-        title: 'Legacy title 20',
-        url: 'https://example.com/legacy-title-20',
-      },
-      {
-        title: 'Legacy title 21',
-        url: 'https://example.com/legacy-title-21',
-      },
-      {
-        title: 'Legacy title 22',
-        url: 'https://example.com/legacy-title-22',
-      },
-      {
-        title: 'Legacy title 23',
-        url: 'https://example.com/legacy-title-23',
-      },
-      {
-        title: 'Legacy title 24',
-        url: 'https://example.com/legacy-title-24',
-      },
-      {
-        title: 'Legacy title 25',
-        url: 'https://example.com/legacy-title-25',
-      },
-      {
-        title: 'Legacy title 26',
-        url: 'https://example.com/legacy-title-26',
-      },
-    ],
-    paging: {
-      page: 1,
-      pageSize: 26,
-      totalResults: 26,
-      totalPages: 1,
+  const testReleasesLonger: PublicationReleaseSeriesItem[] = [
+    ...testReleases,
+    {
+      title: 'Legacy title 4',
+      url: 'https://example.com/legacy-title-4',
     },
-  };
+    {
+      title: 'Legacy title 5',
+      url: 'https://example.com/legacy-title-5',
+    },
+    {
+      title: 'Legacy title 6',
+      url: 'https://example.com/legacy-title-6',
+    },
+    {
+      title: 'Legacy title 7',
+      url: 'https://example.com/legacy-title-7',
+    },
+    {
+      title: 'Legacy title 8',
+      url: 'https://example.com/legacy-title-8',
+    },
+    {
+      title: 'Legacy title 9',
+      url: 'https://example.com/legacy-title-9',
+    },
+    {
+      title: 'Legacy title 10',
+      url: 'https://example.com/legacy-title-10',
+    },
+    {
+      title: 'Legacy title 11',
+      url: 'https://example.com/legacy-title-11',
+    },
+    {
+      title: 'Legacy title 12',
+      url: 'https://example.com/legacy-title-12',
+    },
+    {
+      title: 'Legacy title 13',
+      url: 'https://example.com/legacy-title-13',
+    },
+    {
+      title: 'Legacy title 14',
+      url: 'https://example.com/legacy-title-14',
+    },
+    {
+      title: 'Legacy title 15',
+      url: 'https://example.com/legacy-title-15',
+    },
+    {
+      title: 'Legacy title 16',
+      url: 'https://example.com/legacy-title-16',
+    },
+    {
+      title: 'Legacy title 17',
+      url: 'https://example.com/legacy-title-17',
+    },
+    {
+      title: 'Legacy title 18',
+      url: 'https://example.com/legacy-title-18',
+    },
+    {
+      title: 'Legacy title 19',
+      url: 'https://example.com/legacy-title-19',
+    },
+    {
+      title: 'Legacy title 20',
+      url: 'https://example.com/legacy-title-20',
+    },
+    {
+      title: 'Legacy title 21',
+      url: 'https://example.com/legacy-title-21',
+    },
+    {
+      title: 'Legacy title 22',
+      url: 'https://example.com/legacy-title-22',
+    },
+    {
+      title: 'Legacy title 23',
+      url: 'https://example.com/legacy-title-23',
+    },
+    {
+      title: 'Legacy title 24',
+      url: 'https://example.com/legacy-title-24',
+    },
+    {
+      title: 'Legacy title 25',
+      url: 'https://example.com/legacy-title-25',
+    },
+    {
+      title: 'Legacy title 26',
+      url: 'https://example.com/legacy-title-26',
+    },
+  ];
 
   test('renders next publish date', () => {
     render(

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
@@ -272,4 +272,40 @@ describe('PublicationReleaseListPage', () => {
       screen.queryByRole('navigation', { name: 'Pagination' }),
     ).not.toBeInTheDocument();
   });
+
+  test('search', async () => {
+    const { user } = render(
+      <PublicationReleaseListPage
+        publicationSummary={testPublicationSummary}
+        allReleases={testReleasesLonger}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Pagination' }),
+    ).toBeInTheDocument();
+
+    const searchInput = screen.getByLabelText(/Search release periods/);
+    expect(searchInput).toBeInTheDocument();
+
+    expect(within(screen.getByRole('table')).getAllByRole('row')).toHaveLength(
+      26,
+    );
+
+    await user.type(searchInput, 'title 2');
+
+    await waitFor(() => {
+      const rows = within(screen.getByRole('table')).getAllByRole('row');
+      // Should match: header + Test Release Title 2 + Legacy title 20-26 (8 data rows)
+      expect(rows).toHaveLength(9);
+      const row1Cells = within(rows[1]).getAllByRole('cell');
+      expect(row1Cells[0]).toHaveTextContent('Test Release Title 2');
+    });
+
+    expect(screen.queryByText('Test Release Title 3')).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('navigation', { name: 'Pagination' }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR adds search functionality to the 'releases in this series' page.

This search is client side. To accomplish this, we have to fetch **all** releases and create the pagination client side, instead of requesting paginated results from the server.

- Pagination size can be controlled via a select, with default being 25
- I found similar functionality we had already implemented for an in page search and built pagination in `admin\src\pages\release\data\components\ApiDataSetAutoMappedTable.tsx` so I have reused some of the patterns from here

---

<img width="1024" height="1106" alt="daadbe24-b478-4426-b14e-60a2e4736a17" src="https://github.com/user-attachments/assets/faf21cc8-e272-4286-8da1-69fcfabc3128" />

---

<img width="646" height="544" alt="image" src="https://github.com/user-attachments/assets/43fc9af5-ff9f-443f-ae58-d30eb7c9656f" />
