### PR TITLE
EES-7172 Ensure migration runs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -33,21 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             migrationBuilder.Sql(
                 """
-                UPDATE DSM
-                SET DSM.OriginalDataFileId = F.Id
-                FROM DataSetMappings AS DSM
-                INNER JOIN Files AS F
-                    ON DSM.OriginalDataSetId = F.SubjectId AND F.Type = 'Data';
-                """
-            );
-
-            migrationBuilder.Sql(
-                """
-                UPDATE DSM
-                SET DSM.ReplacementDataFileId = F.Id
-                FROM DataSetMappings AS DSM
-                INNER JOIN Files AS F
-                    ON DSM.ReplacementDataSetId = F.SubjectId AND F.Type = 'Data';
+                DELETE FROM DataSetMappings;
                 """
             );
 


### PR DESCRIPTION
So unfortunately Ben's comment ended up being correct (https://github.com/dfe-analytical-services/explore-education-statistics/pull/7019#discussion_r3341341671) and the migration failed to complete on the Dev environment. I managed to make the migration run on Dev by removing all entries from the DataSetMappings table.

I think we hit this problem because DataSetMappings aren't being cleaned up correctly - I'll create a separate ticket to investigate that.

This PR prevents it failing on other environments by removing all DataSetMappings entry as part of the migration. This does mean that if someone has manually updated mappings, they will lose those changes, but I think the risk of this is fairly low and easy for users to fix if it does happen, hence why I'm going for this approach.