### PR TITLE
EES-7112: Make public site data set pages more resilient to public API unavailability

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -40,6 +40,8 @@ import { GetServerSideProps } from 'next';
 import isPatchVersion from '@common/utils/isPatchVersion';
 import React, { useEffect, useMemo, useState } from 'react';
 import omit from 'lodash/omit';
+import WarningMessage from '@common/components/WarningMessage';
+import logger from '@common/services/logger';
 
 export const pageBaseSections = {
   dataSetDetails: 'Data set details',
@@ -275,28 +277,30 @@ export default function DataSetFilePage({
                 onDownload={handleDownload}
               />
 
-              {apiDataSet && apiDataSetVersion && (
-                <>
-                  <DataSetFileApiQuickStart
-                    id={apiDataSet.id}
-                    name={apiDataSet.title}
-                    version={apiDataSetVersion.version}
-                  />
+              <DataSetFileApiQuickStart
+                id={apiDataSet?.id}
+                name={apiDataSet?.title}
+                version={apiDataSetVersion?.version}
+              />
 
+              {apiDataSet && apiDataSetVersion ? (
+                <>
                   <DataSetFileApiVersionHistory
                     apiDataSetId={apiDataSet.id}
                     currentVersion={apiDataSetVersion.version}
                   />
 
-                  {apiDataSetVersionChanges && (
-                    <DataSetFileApiChangelog
-                      changes={apiDataSetVersionChanges}
-                      guidanceNotes={apiDataSetVersion.notes}
-                      version={apiDataSetVersion.version}
-                      patchHistory={apiDataSetVersionChanges.patchHistory || []}
-                    />
-                  )}
+                  <DataSetFileApiChangelog
+                    changes={apiDataSetVersionChanges}
+                    guidanceNotes={apiDataSetVersion.notes}
+                    version={apiDataSetVersion.version}
+                    patchHistory={apiDataSetVersionChanges?.patchHistory || []}
+                  />
                 </>
+              ) : (
+                <WarningMessage>
+                  API data set version history is not currently available
+                </WarningMessage>
               )}
 
               <DataSetFileContact
@@ -332,44 +336,53 @@ export const getServerSideProps: GetServerSideProps<Props> = withAxiosHandler(
       publicationSummary,
     };
 
+    let apiDataSet: ApiDataSet | undefined;
+    let apiDataSetVersion: ApiDataSetVersion | undefined;
+    let apiDataSetVersionChanges: ApiDataSetVersionChanges | null | undefined;
+
     if (dataSetFile.api) {
-      await queryClient.prefetchQuery({
-        ...apiDataSetQueries.listDataSetVersions(dataSetFile.api.id, {
-          page: versionPage ? Number(versionPage) : 1,
-        }),
-        staleTime: Infinity,
-      });
+      try {
+        await queryClient.prefetchQuery({
+          ...apiDataSetQueries.listDataSetVersions(dataSetFile.api.id, {
+            page: versionPage ? Number(versionPage) : 1,
+          }),
+          staleTime: Infinity,
+        });
 
-      const [apiDataSet, apiDataSetVersion, apiDataSetVersionChanges] =
-        await Promise.all([
-          queryClient.fetchQuery(
-            apiDataSetQueries.getDataSet(dataSetFile.api.id),
-          ),
-          queryClient.fetchQuery(
-            apiDataSetQueries.getDataSetVersion(
-              dataSetFile.api.id,
-              dataSetFile.api.version,
+        [apiDataSet, apiDataSetVersion, apiDataSetVersionChanges] =
+          await Promise.all([
+            queryClient.fetchQuery(
+              apiDataSetQueries.getDataSet(dataSetFile.api.id),
             ),
-          ),
-          dataSetFile.api.version !== '1.0'
-            ? queryClient.fetchQuery(
-                apiDataSetQueries.getDataSetVersionChanges(
-                  dataSetFile.api.id,
-                  dataSetFile.api.version,
-                  isPatchVersion(dataSetFile.api.version),
-                ),
-              )
-            : null,
-        ]);
-
-      props.apiDataSet = apiDataSet;
-      props.apiDataSetVersion = apiDataSetVersion;
-      props.apiDataSetVersionChanges = apiDataSetVersionChanges;
+            queryClient.fetchQuery(
+              apiDataSetQueries.getDataSetVersion(
+                dataSetFile.api.id,
+                dataSetFile.api.version,
+              ),
+            ),
+            dataSetFile.api.version !== '1.0'
+              ? queryClient.fetchQuery(
+                  apiDataSetQueries.getDataSetVersionChanges(
+                    dataSetFile.api.id,
+                    dataSetFile.api.version,
+                    isPatchVersion(dataSetFile.api.version),
+                  ),
+                )
+              : null,
+          ]);
+      } catch (error) {
+        logger.error(error);
+      }
     }
 
     return {
       props: {
         ...props,
+        ...(apiDataSet !== undefined ? { apiDataSet } : {}),
+        ...(apiDataSetVersion !== undefined ? { apiDataSetVersion } : {}),
+        ...(apiDataSetVersionChanges !== undefined
+          ? { apiDataSetVersionChanges }
+          : {}),
         dehydratedState: dehydrate(queryClient),
       },
     };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -277,30 +277,36 @@ export default function DataSetFilePage({
                 onDownload={handleDownload}
               />
 
-              <DataSetFileApiQuickStart
-                id={apiDataSet?.id}
-                name={apiDataSet?.title}
-                version={apiDataSetVersion?.version}
-              />
-
-              {apiDataSet && apiDataSetVersion ? (
+              {dataSetFile.api && (
                 <>
-                  <DataSetFileApiVersionHistory
-                    apiDataSetId={apiDataSet.id}
-                    currentVersion={apiDataSetVersion.version}
+                  <DataSetFileApiQuickStart
+                    id={apiDataSet?.id}
+                    name={apiDataSet?.title}
+                    version={apiDataSetVersion?.version}
                   />
 
-                  <DataSetFileApiChangelog
-                    changes={apiDataSetVersionChanges}
-                    guidanceNotes={apiDataSetVersion.notes}
-                    version={apiDataSetVersion.version}
-                    patchHistory={apiDataSetVersionChanges?.patchHistory || []}
-                  />
+                  {apiDataSet && apiDataSetVersion ? (
+                    <>
+                      <DataSetFileApiVersionHistory
+                        apiDataSetId={apiDataSet.id}
+                        currentVersion={apiDataSetVersion.version}
+                      />
+
+                      <DataSetFileApiChangelog
+                        changes={apiDataSetVersionChanges}
+                        guidanceNotes={apiDataSetVersion.notes}
+                        version={apiDataSetVersion.version}
+                        patchHistory={
+                          apiDataSetVersionChanges?.patchHistory || []
+                        }
+                      />
+                    </>
+                  ) : (
+                    <WarningMessage>
+                      API data set version history is not currently available
+                    </WarningMessage>
+                  )}
                 </>
-              ) : (
-                <WarningMessage>
-                  API data set version history is not currently available
-                </WarningMessage>
               )}
 
               <DataSetFileContact
@@ -342,34 +348,34 @@ export const getServerSideProps: GetServerSideProps<Props> = withAxiosHandler(
 
     if (dataSetFile.api) {
       try {
-        await queryClient.prefetchQuery({
+        await queryClient.fetchQuery({
           ...apiDataSetQueries.listDataSetVersions(dataSetFile.api.id, {
             page: versionPage ? Number(versionPage) : 1,
           }),
           staleTime: Infinity,
         });
 
-        [apiDataSet, apiDataSetVersion, apiDataSetVersionChanges] =
-          await Promise.all([
-            queryClient.fetchQuery(
-              apiDataSetQueries.getDataSet(dataSetFile.api.id),
-            ),
-            queryClient.fetchQuery(
-              apiDataSetQueries.getDataSetVersion(
-                dataSetFile.api.id,
-                dataSetFile.api.version,
-              ),
-            ),
-            dataSetFile.api.version !== '1.0'
-              ? queryClient.fetchQuery(
-                  apiDataSetQueries.getDataSetVersionChanges(
-                    dataSetFile.api.id,
-                    dataSetFile.api.version,
-                    isPatchVersion(dataSetFile.api.version),
-                  ),
-                )
-              : null,
-          ]);
+        apiDataSet = await queryClient.fetchQuery(
+          apiDataSetQueries.getDataSet(dataSetFile.api.id),
+        );
+
+        apiDataSetVersion = await queryClient.fetchQuery(
+          apiDataSetQueries.getDataSetVersion(
+            dataSetFile.api.id,
+            dataSetFile.api.version,
+          ),
+        );
+
+        apiDataSetVersionChanges =
+          dataSetFile.api.version !== '1.0'
+            ? await queryClient.fetchQuery(
+                apiDataSetQueries.getDataSetVersionChanges(
+                  dataSetFile.api.id,
+                  dataSetFile.api.version,
+                  isPatchVersion(dataSetFile.api.version),
+                ),
+              )
+            : null;
       } catch (error) {
         logger.error(error);
       }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
@@ -5,6 +5,7 @@ import {
   testApiDataSet,
   testApiDataSetVersion,
   testDataSetFile,
+  testDataSetWithApi,
 } from '@frontend/modules/data-catalogue/__data__/testDataSets';
 import { testPublicationSummary } from '@frontend/modules/find-statistics/__tests__/__data__/testReleaseData';
 import DataSetFilePage from '@frontend/modules/data-catalogue/DataSetFilePage';
@@ -507,7 +508,7 @@ describe('DataSetFilePage', () => {
           apiDataSet={testApiDataSet}
           apiDataSetVersion={testApiDataSetVersion}
           apiDataSetVersionChanges={testApiDataSetVersionChanges}
-          dataSetFile={{ ...testDataSetFile, footnotes: [] }}
+          dataSetFile={{ ...testDataSetWithApi, footnotes: [] }}
           publicationSummary={testPublicationSummary}
         />,
       );
@@ -530,7 +531,7 @@ describe('DataSetFilePage', () => {
         <DataSetFilePage
           apiDataSet={testApiDataSet}
           apiDataSetVersion={testApiDataSetVersion}
-          dataSetFile={testDataSetFile}
+          dataSetFile={testDataSetWithApi}
           publicationSummary={testPublicationSummary}
         />,
       );
@@ -547,7 +548,7 @@ describe('DataSetFilePage', () => {
         <DataSetFilePage
           apiDataSet={testApiDataSet}
           apiDataSetVersion={testApiDataSetVersion}
-          dataSetFile={testDataSetFile}
+          dataSetFile={testDataSetWithApi}
           publicationSummary={testPublicationSummary}
         />,
       );
@@ -587,7 +588,7 @@ describe('DataSetFilePage', () => {
             version: '2.0',
           }}
           apiDataSetVersionChanges={testApiDataSetVersionChanges}
-          dataSetFile={testDataSetFile}
+          dataSetFile={testDataSetWithApi}
           publicationSummary={testPublicationSummary}
         />,
       );
@@ -632,7 +633,7 @@ describe('DataSetFilePage', () => {
           apiDataSet={testApiDataSet}
           apiDataSetVersion={testApiDataSetVersion}
           apiDataSetVersionChanges={testApiDataSetVersionChanges}
-          dataSetFile={{ ...testDataSetFile, footnotes: [] }}
+          dataSetFile={{ ...testDataSetWithApi, footnotes: [] }}
           publicationSummary={testPublicationSummary}
         />,
       );

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
@@ -19,7 +19,7 @@ export default function DataSetFileApiChangelog({
   version,
   patchHistory,
 }: Props) {
-  if (!changes || !guidanceNotes || !version || !patchHistory) return null;
+  if (!changes || !version || !patchHistory) return null;
 
   const { majorChanges, minorChanges } = changes;
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import sortVersionChanges from '../utils/sortVersionChanges';
 
 interface Props {
-  changes: ApiDataSetVersionChanges;
-  guidanceNotes?: string;
+  changes: ApiDataSetVersionChanges | null | undefined;
+  guidanceNotes?: string | undefined;
   version: string;
   patchHistory: ApiDataSetVersionChanges[];
 }
@@ -19,6 +19,8 @@ export default function DataSetFileApiChangelog({
   version,
   patchHistory,
 }: Props) {
+  if (!changes || !guidanceNotes || !version || !patchHistory) return null;
+
   const { majorChanges, minorChanges } = changes;
 
   if (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiQuickStart.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiQuickStart.tsx
@@ -5,14 +5,21 @@ import ApiDataSetQuickStart from '@common/modules/data-catalogue/components/ApiD
 import DataSetFilePageSection from '@frontend/modules/data-catalogue/components/DataSetFilePageSection';
 import { pageSections } from '@frontend/modules/data-catalogue/DataSetFilePage';
 import React from 'react';
+import WarningMessage from '@common/components/WarningMessage';
 
 interface Props {
-  id: string;
-  name: string;
-  version: string;
+  id: string | undefined;
+  name: string | undefined;
+  version: string | undefined;
 }
 
 export default function DataSetFileApiQuickStart({ id, name, version }: Props) {
+  if (!id || !name || !version) {
+    return (
+      <WarningMessage>API data set is not currently available</WarningMessage>
+    );
+  }
+
   return (
     <DataSetFilePageSection heading={pageSections.api} id="api">
       <ChevronGrid>


### PR DESCRIPTION
This PR adds a try/catch block inc. logging around API data set file queries, and displays a warning message in UI on failure. This prevents displaying of the generic "sorry" server error page when a connection could not be established with the external service (FaUAPI).