### PR TITLE
EES-7211 Create new route and base page build for table tool search

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/SearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchForm.tsx
@@ -9,12 +9,14 @@ import React from 'react';
 const min = 3;
 
 interface Props {
+  hint?: string;
   label?: string;
   value?: string;
   onSubmit: (value: string) => void;
 }
 
 export default function SearchForm({
+  hint,
   label = 'Search',
   value: initialValue = '',
   onSubmit,
@@ -43,6 +45,7 @@ export default function SearchForm({
             </button>
           }
           announceError
+          hint={hint}
           id="search"
           label={label}
           labelSize="m"

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
@@ -1,0 +1,103 @@
+import Details from '@common/components/Details';
+import publicationService, {
+  PublicationSummary,
+  ReleaseVersionSummary,
+} from '@common/services/publicationService';
+import { Dictionary } from '@common/types';
+import Page from '@frontend/components/Page';
+import SearchForm from '@frontend/components/SearchForm';
+import ReleasePageTitle from '@frontend/modules/find-statistics/components/ReleasePageTitle';
+import { GetServerSideProps, NextPage } from 'next';
+import React from 'react';
+
+export interface TableToolSearchPageProps {
+  latestReleaseVersion: ReleaseVersionSummary;
+  publicationSummary: PublicationSummary;
+}
+
+const TableToolSearchPage: NextPage<TableToolSearchPageProps> = ({
+  latestReleaseVersion,
+  publicationSummary,
+}) => {
+  return (
+    <Page
+      title={`Search statistics - ${publicationSummary.title}`}
+      description={`Search statistics in ${publicationSummary.title.toLocaleLowerCase()} using natural language`}
+      breadcrumbs={[
+        { name: 'Table tool', link: `/data-tables/${publicationSummary.slug}` },
+      ]}
+      pageTitleComponent={
+        <ReleasePageTitle
+          publicationSummary={publicationSummary}
+          releaseTitle={latestReleaseVersion.title}
+          publishingOrganisations={latestReleaseVersion.publishingOrganisations}
+        />
+      }
+      width="wide"
+    >
+      <div className="govuk-grid-row govuk-!-margin-bottom-4">
+        <div className="govuk-grid-column-two-thirds">
+          <SearchForm
+            label="Search these statistics"
+            hint={`Use natural language to search for statistics relating to ${publicationSummary.title}.`}
+            onSubmit={() => {}}
+          />
+          <Details
+            className="govuk-!-margin-top-3 govuk-!-margin-bottom-4"
+            summary="Help and example searches"
+          >
+            <p>
+              Use phrases to find the statistics you are looking for such as:
+            </p>
+            <ul>
+              <li>Show results for science</li>
+              <li>Compare subjects</li>
+              <li>Filter by North West</li>
+              <li>Show me English results from 2024</li>
+            </ul>
+            <p>
+              You can preview results and also filter results further to help
+              you find something specific
+            </p>
+          </Details>
+        </div>
+      </div>
+    </Page>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<
+  TableToolSearchPageProps
+> = async ({ query }) => {
+  if (process.env.APP_ENV === 'Production') {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { publicationSlug = '' } = query as Dictionary<string>;
+
+  if (!publicationSlug) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const publicationSummary = await publicationService.getPublicationSummary(
+    publicationSlug,
+  );
+
+  const latestReleaseVersion =
+    await publicationService.getReleaseVersionSummary(
+      publicationSlug,
+      publicationSummary.latestRelease.slug,
+    );
+  return {
+    props: {
+      publicationSummary,
+      latestReleaseVersion,
+    },
+  };
+};
+
+export default TableToolSearchPage;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolSearchPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolSearchPage.test.tsx
@@ -1,0 +1,35 @@
+import render from '@common-test/render';
+import {
+  testPublicationSummary,
+  testReleaseVersionSummary,
+} from '@frontend/modules/find-statistics/__tests__/__data__/testReleaseData';
+import TableToolSearchPage from '@frontend/modules/table-tool/TableToolSearchPage';
+import { screen } from '@testing-library/react';
+
+describe('TableToolSearchPage', () => {
+  test('renders the page correctly with search form', async () => {
+    render(
+      <TableToolSearchPage
+        publicationSummary={testPublicationSummary}
+        latestReleaseVersion={testReleaseVersionSummary}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Pupil attendance in schools',
+        level: 1,
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText('Search these statistics'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: /Help and example searches/,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/[publicationSlug]/search.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/[publicationSlug]/search.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/table-tool/TableToolSearchPage';


### PR DESCRIPTION
First step in implementing the table tool natural search frontend - just creating a new route and scaffolding the base view for the page.

The search doesn't do anything yet - this will be wired up in future tickets.