### PR TITLE
EES-6212 - Removing all OLD permissions system roles from the DB and improving the unique index restrictions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
@@ -688,8 +688,7 @@ public abstract class UserPublicationRoleRepositoryTests
 
                 var result = await repository.GetByCompositeKey(
                     userId: userPublicationRole.UserId,
-                    publicationId: userPublicationRole.PublicationId,
-                    role: userPublicationRole.Role
+                    publicationId: userPublicationRole.PublicationId
                 );
 
                 Assert.NotNull(result);
@@ -708,11 +707,7 @@ public abstract class UserPublicationRoleRepositoryTests
         {
             var repository = CreateRepository();
 
-            var result = await repository.GetByCompositeKey(
-                userId: Guid.NewGuid(),
-                publicationId: Guid.NewGuid(),
-                role: PublicationRole.Drafter
-            );
+            var result = await repository.GetByCompositeKey(userId: Guid.NewGuid(), publicationId: Guid.NewGuid());
 
             Assert.Null(result);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610135016_Ees6212RemovingOldPermissionsSystemRoles")]
+    partial class Ees6212RemovingOldPermissionsSystemRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -430,6 +433,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("ScreeningStatus")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
 
                     b.Property<string>("UploadedBy")
                         .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.cs
@@ -1,0 +1,76 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees6212RemovingOldPermissionsSystemRoles : Migration
+    {
+        private const string MigrationId = "20260610135016";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Remove all OLD permissions system roles:
+            // - Publication `Allower`
+            // - Publication `Owner`
+            // - Release `Approver`
+            // - Release `Contributor`
+            migrationBuilder.SqlFromFile(
+                MigrationConstants.ContentMigrationsPath,
+                $"{MigrationId}_{nameof(Ees6212RemovingOldPermissionsSystemRoles)}.sql"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserReleaseRoles_UserId_ReleaseVersionId_Role",
+                table: "UserReleaseRoles"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserPublicationRoles_UserId_PublicationId_Role",
+                table: "UserPublicationRoles"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserReleaseRoles_UserId_ReleaseVersionId",
+                table: "UserReleaseRoles",
+                columns: new[] { "UserId", "ReleaseVersionId" },
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationRoles_UserId_PublicationId",
+                table: "UserPublicationRoles",
+                columns: new[] { "UserId", "PublicationId" },
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(name: "IX_UserReleaseRoles_UserId_ReleaseVersionId", table: "UserReleaseRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserPublicationRoles_UserId_PublicationId",
+                table: "UserPublicationRoles"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserReleaseRoles_UserId_ReleaseVersionId_Role",
+                table: "UserReleaseRoles",
+                columns: new[] { "UserId", "ReleaseVersionId", "Role" },
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationRoles_UserId_PublicationId_Role",
+                table: "UserPublicationRoles",
+                columns: new[] { "UserId", "PublicationId", "Role" },
+                unique: true
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260610135016_Ees6212RemovingOldPermissionsSystemRoles.sql
@@ -1,0 +1,10 @@
+﻿-- Remove all OLD permissions system roles:
+-- - Publication `Allower`
+-- - Publication `Owner`
+-- - Release `Approver`
+-- - Release `Contributor`
+DELETE FROM UserPublicationRoles
+WHERE Role IN ('Allower', 'Owner');
+
+DELETE FROM UserReleaseRoles
+WHERE Role IN ('Approver', 'Contributor');

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationRoleRepository.cs
@@ -26,7 +26,6 @@ public interface IUserPublicationRoleRepository
     Task<UserPublicationRole?> GetByCompositeKey(
         Guid userId,
         Guid publicationId,
-        PublicationRole role,
         CancellationToken cancellationToken = default
     );
 
@@ -41,12 +40,7 @@ public interface IUserPublicationRoleRepository
 
     Task<bool> RemoveById(Guid userPublicationRoleId, CancellationToken cancellationToken = default);
 
-    Task<bool> RemoveByCompositeKey(
-        Guid userId,
-        Guid publicationId,
-        PublicationRole role,
-        CancellationToken cancellationToken = default
-    );
+    Task<bool> RemoveByCompositeKey(Guid userId, Guid publicationId, CancellationToken cancellationToken = default);
 
     Task RemoveMany(
         IEnumerable<UserPublicationRole> userPublicationRoles,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
@@ -134,14 +134,12 @@ public class UserPublicationRoleRepository(
     public async Task<UserPublicationRole?> GetByCompositeKey(
         Guid userId,
         Guid publicationId,
-        PublicationRole role,
         CancellationToken cancellationToken = default
     )
     {
         return await Query(ResourceRoleFilter.All)
             .WhereForUser(userId)
             .WhereForPublication(publicationId)
-            .WhereRolesIn(role)
             .SingleOrDefaultAsync(cancellationToken);
     }
 
@@ -179,14 +177,12 @@ public class UserPublicationRoleRepository(
     public async Task<bool> RemoveByCompositeKey(
         Guid userId,
         Guid publicationId,
-        PublicationRole role,
         CancellationToken cancellationToken = default
     )
     {
         var userPublicationRole = await GetByCompositeKey(
             userId: userId,
             publicationId: publicationId,
-            role: role,
             cancellationToken: cancellationToken
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -640,15 +640,7 @@ public class ContentDbContext : DbContext
 
     private static void ConfigureUserPublicationRole(ModelBuilder modelBuilder)
     {
-        modelBuilder
-            .Entity<UserPublicationRole>()
-            .HasIndex(upr => new
-            {
-                upr.UserId,
-                upr.PublicationId,
-                upr.Role,
-            })
-            .IsUnique();
+        modelBuilder.Entity<UserPublicationRole>().HasIndex(upr => new { upr.UserId, upr.PublicationId }).IsUnique();
 
         modelBuilder
             .Entity<UserPublicationRole>()
@@ -674,15 +666,7 @@ public class ContentDbContext : DbContext
 
     private static void ConfigureUserPreReleaseRole(ModelBuilder modelBuilder)
     {
-        modelBuilder
-            .Entity<UserReleaseRole>()
-            .HasIndex(urr => new
-            {
-                urr.UserId,
-                urr.ReleaseVersionId,
-                urr.Role,
-            })
-            .IsUnique();
+        modelBuilder.Entity<UserReleaseRole>().HasIndex(urr => new { urr.UserId, urr.ReleaseVersionId }).IsUnique();
 
         modelBuilder
             .Entity<UserReleaseRole>()


### PR DESCRIPTION
Following the work in https://github.com/dfe-analytical-services/explore-education-statistics/pull/7022, we now need to take a backup of the `UserPublicationRoles` & `UserReleaseRoles` tables, and remove all of the OLD release roles (except for pre-release roles) and all of the OLD publication roles from the database. 

These roles are no longer being used, and can therefore be removed safely.

We have removed them as part of a migration.

In addition to this, we have also changed the unique indexes on these tables to `(UserId, PublicationId)` on the `UserPublicationRoles` table, and `(UserId, ReleaseVersionId)` on the `UserReleaseRoles` table.

The previous indexes were:
- `(UserId, PublicationId, Role)`
- `(UserId, ReleaseVersionId, Role)`

and they were necessary because historically we could have multiple publication roles for the same user/publication combination, and multiple release roles for the same user/release version combination. 

However, now that the OLD roles are being removed, we should only ever have 1 publication role per user/publication combination, and 1 pre-release role per user/release version combination.

Changing these indexes as per the above will ensure that it is impossible to end up in a state where we have multiple roles for the same user/entity combination.