### PR TITLE
EES-7237 Trim whitespace when searching releases page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -68,7 +68,7 @@ const PublicationReleaseListPage = ({
   };
 
   const [handleSearch] = useDebouncedCallback((term: string) => {
-    setSearchTerm(term);
+    setSearchTerm(term.trim());
     setCurrentPage(1);
   }, 800);
 
@@ -126,7 +126,7 @@ const PublicationReleaseListPage = ({
                   id={`${formId}-search`}
                   label="Search release periods"
                   labelSize="s"
-                  min={0}
+                  min={1}
                   name="search"
                   onChange={handleSearch}
                   onReset={() => handleSearch('')}


### PR DESCRIPTION
This prevents users accidentally not getting matches if they add in spaces by mistake.

Also set min 1 char before allowing form submission

Before:
<img width="426" height="427" alt="image" src="https://github.com/user-attachments/assets/51445c7b-efc6-4267-a756-568e74be4e76" />


After:

<img width="759" height="414" alt="file-303de1bb404a6f92200cb0c29645add2" src="https://github.com/user-attachments/assets/3fd56608-6e1c-46ba-8a4d-19b44078636b" />
