### PR TITLE
EES-7164 Update health check URL and enable the health check status alert metric

### DIFF
--- a/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
+++ b/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
@@ -143,7 +143,7 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
       tier: 'ElasticPremium'
       family: 'EP'
     }
-    healthCheckPath: '/api/HealthCheck'
+    healthCheckPath: '/api/health_check'
     operatingSystem: 'Linux'
     functionAppRuntime: 'python'
     linuxFxVersion: 'Python|3.14'
@@ -161,8 +161,7 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
     outboundSubnetId: outboundVnetSubnet.id
     alerts: {
       cpuPercentage: true
-      // TODO EES-7164 - Enable function app health alert once the health check endpoint is deployed
-      functionAppHealth: false
+      functionAppHealth: true
       httpErrors: true
       memoryPercentage: true
       storageAccountAvailability: true


### PR DESCRIPTION
This PR makes an infrastructure change altering the health check URL of the Natural Language Search function app to use snake case. This corresponds with an application change being made in https://github.com/dfe-analytical-services/ees-natural-language-search/pull/13.

It also enables the `HealthCheckStatus` metric alert which was previously omitted until the Azure function app was proven to be working which is now the case.