### PR TITLE
EES-7209 Enable API key access to Azure AI Search to support local development

### DIFF
--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -9,7 +9,7 @@ param name string
 @description('Location for all resources.')
 param location string
 
-@description('A list IP network rules to allow access to the Search Service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccessEnabled\' is \'true\'.')
+@description('A list IP network rules to allow access to the Event Grid topic from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccessEnabled\' is \'true\'.')
 param ipRules IpRange[] = []
 
 @description('Specifies whether to enable local authentication. Microsoft Entra access authentication is always enabled.')

--- a/infrastructure/templates/common/components/search/searchServiceRoleAssignment.bicep
+++ b/infrastructure/templates/common/components/search/searchServiceRoleAssignment.bicep
@@ -3,7 +3,7 @@ import { builtInRoleDefinitionIds } from '../../builtInRoles.bicep'
 @export()
 type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Reader' | 'Search Service Contributor'
 
-@description('Specifies the name of the Search Service.')
+@description('Specifies the name of the Azure AI Search service.')
 param searchServiceName string
 
 @description('Specifies the ids of the service principals that are being assigned the role')
@@ -27,7 +27,7 @@ resource searchService 'Microsoft.Search/searchServices@2025-05-01' existing = {
 }
 
 // Create the role assignment. Note that this is dependent on the deploying service principal having
-// "Microsoft.Authorization/roleAssignments/write" permissions on the Search Service via an appropriate
+// "Microsoft.Authorization/roleAssignments/write" permissions on the Azure AI Search service via an appropriate
 // role.
 resource searchServiceRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
   scope: searchService

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -33,7 +33,7 @@ param appInsightsConnectionString string
 @description('Resource limits and scaling configuration.')
 param resourceAndScalingConfig ContainerAppResourceConfig
 
-@description('Configuration settings for the Search service used to search publications.')
+@description('Configuration settings for the Azure AI Search service used to search publications.')
 param searchServiceConfig SearchServiceConfig
 
 @description('Whether to create or update Azure Monitor alerts during this deploy')

--- a/infrastructure/templates/public-api/application/shared/searchService.bicep
+++ b/infrastructure/templates/public-api/application/shared/searchService.bicep
@@ -1,4 +1,4 @@
-@description('The name of the existing Search service.')
+@description('The name of the existing Azure AI Search service.')
 param name string
 
 resource searchService 'Microsoft.Search/searchServices@2025-05-01' existing = {

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -156,7 +156,7 @@ param publicApiContainerAppConfig ContainerAppResourceConfig = {
   workloadProfileName: 'Consumption'
 }
 
-@description('Name of the Search service index used to search publications.')
+@description('Name of the Azure AI Search service index used to search publications.')
 param searchServiceIndexName string = ''
 
 @description('Enable the Swagger UI for public API.')

--- a/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
+++ b/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
@@ -8,7 +8,7 @@ param functionAppFirewallRules FirewallRule[]
 @description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
 param logAnalyticsWorkspaceId string
 
-@description('Specifies the Search Service name.')
+@description('Specifies the Azure AI Search service name.')
 param searchServiceName string
 
 @description('Name of the \'Natural language search filter\' index in Azure AI Search.')

--- a/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
@@ -14,7 +14,7 @@ param logAnalyticsWorkspaceId string
 @description('Name of the indexer associated with the \'Search\' index in Azure AI Search.')
 param searchServiceSearchIndexerName string
 
-@description('Specifies the Search Service name.')
+@description('Specifies the Azure AI Search service name.')
 param searchServiceName string
 
 @description('Name of the Search storage account.')

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -19,7 +19,7 @@ param searchStorageDocumentContainers object = {
   nlSearchLocationsDictionary: 'nl-search-locations-dictionary'
 }
 
-@description('A list of IP network rules to allow access to the Search Service from specific public internet IP address ranges.')
+@description('A list of IP network rules to allow access to the Azure AI Search service from specific public internet IP address ranges.')
 param searchServiceIpRules IpRange[]
 
 @description('Controls the availability of semantic ranking for all indexes. Set to \'free\' for limited query volume on the free plan, \'standard\' for unlimited volume on the standard pricing plan, or \'disabled\' to turn it off.')

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -19,6 +19,9 @@ param searchStorageDocumentContainers object = {
   nlSearchLocationsDictionary: 'nl-search-locations-dictionary'
 }
 
+@description('Indicates whether API keys are permitted for authentication to the Azure AI Search service in addition to role-based access control (RBAC). Disabling API keys forces all clients to use RBAC only.')
+param searchServiceLocalAuthEnabled bool = false
+
 @description('A list of IP network rules to allow access to the Azure AI Search service from specific public internet IP address ranges.')
 param searchServiceIpRules IpRange[]
 
@@ -60,6 +63,7 @@ module searchServiceModule '../components/searchService.bicep' = {
   params: {
     name: searchServiceName
     location: location
+    searchServiceLocalAuthEnabled: searchServiceLocalAuthEnabled
     ipRules: searchServiceIpRules
     publicNetworkAccess: 'Enabled'
     semanticRankerAvailability: semanticRankerAvailability

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -8,7 +8,7 @@ import { dynamicAverageGreaterThan, dynamicTotalGreaterThan } from '../../common
 @maxLength(60)
 param name string
 
-@description('A list IP network rules to allow access to the Search Service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccess\' is \'Enabled\'.')
+@description('A list of IP network rules to allow access to the Azure AI Search service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccess\' is \'Enabled\'.')
 param ipRules IpRange[] = []
 
 @allowed([
@@ -20,7 +20,7 @@ param ipRules IpRange[] = []
   'storage_optimized_l1'
   'storage_optimized_l2'
 ])
-@description('The pricing tier of the Search Service you want to create (for example, basic or standard).')
+@description('The pricing tier of the Azure AI Search service you want to create (for example, basic or standard).')
 param sku string = 'standard'
 
 @description('Replicas distribute search workloads across the service. You need at least two replicas to support high availability of query workloads (not applicable to the free tier).')

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -8,6 +8,9 @@ import { dynamicAverageGreaterThan, dynamicTotalGreaterThan } from '../../common
 @maxLength(60)
 param name string
 
+@description('Indicates whether API keys are permitted for authentication to the Azure AI Search service in addition to role-based access control (RBAC). Disabling API keys forces all clients to use RBAC only.')
+param searchServiceLocalAuthEnabled bool = false
+
 @description('A list of IP network rules to allow access to the Azure AI Search service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccess\' is \'Enabled\'.')
 param ipRules IpRange[] = []
 
@@ -103,7 +106,14 @@ resource searchService 'Microsoft.Search/searchServices@2025-05-01' = {
     userAssignedIdentities: !empty(userAssignedIdentityName) ? { '${userAssignedIdentity.id}': {} } : null
   }
   properties: {
-    disableLocalAuth: true
+    disableLocalAuth: !searchServiceLocalAuthEnabled
+    authOptions: searchServiceLocalAuthEnabled
+      ? {
+          aadOrApiKey: {
+            aadAuthFailureMode: 'http401WithBearerChallenge'
+          }
+        }
+      : null
     replicaCount: replicaCount
     networkRuleSet: {
       bypass: length(ipRules) > 0 ? 'AzureServices' : 'None'

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -41,6 +41,9 @@ param searchServiceNLSearchDatasetIndexName string = ''
 @description('Name of the indexer associated with the \'Search\' index in Azure AI Search.')
 param searchServiceSearchIndexerName string = ''
 
+@description('Indicates whether API keys are permitted for authentication to Azure AI Search in addition to role-based access control (RBAC). Disabling API keys forces all clients to use RBAC only.')
+param searchServiceLocalAuthEnabled bool = false
+
 @description('Controls the availability of semantic ranking for all indexes. Set to \'free\' for limited query volume on the free plan, \'standard\' for unlimited volume on the standard pricing plan, or \'disabled\' to turn it off.')
 @allowed([
   'disabled'
@@ -203,6 +206,7 @@ module searchServiceModule 'application/searchService.bicep' = {
     location: location
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
+    searchServiceLocalAuthEnabled: searchServiceLocalAuthEnabled
     searchServiceIpRules: [] // No restrictions applied as the resource is intended to be publicly accessible.
     semanticRankerAvailability: searchServiceSemanticRankerAvailability
     storageIpRules: maintenanceIpRanges

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -6,4 +6,7 @@ param environmentName = 'Development'
 param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
 param searchServiceSemanticRankerAvailability = 'free'
 
+// Allow API key authentication for the Azure AI Search service to support local development.
+param searchServiceLocalAuthEnabled = true
+
 param deployNaturalLanguageSearchFunctionApp = true

--- a/infrastructure/templates/search/scripts/SetupSearchService.ps1
+++ b/infrastructure/templates/search/scripts/SetupSearchService.ps1
@@ -4,7 +4,7 @@ Configures Azure AI Search index, indexer and data source resources using the Az
 
 .DESCRIPTION
 Reads the JSON definition of an index from file, injects CORS settings into it, builds indexer and data source definitions 
-based on the provided parameters, and sends REST API requests to create or update the Search service resources.
+based on the provided parameters, and sends REST API requests to create or update the Azure AI Search service resources.
 #>
 param(
     [string[]] [Parameter(Mandatory=$true)] $indexCorsAllowedOrigins,


### PR DESCRIPTION
Currently developers working on natural language querying of data are having to manually change Azure AI Search settings to enable API key access after every deploy, as the default setting is to deny API key access.

Each deploy is reverting the setting and disabling API key access.

This PR enables API key authentication for the Azure AI Search service in the Dev environment to support local development.

### Other changes

- Corrects the `ipRules` param description in `eventGridCustomTopic.bicep`.
- Renames occurrences of 'Search service' with 'Azure AI Search service' in param descriptions and comments for clarity.