### PR TITLE
EES-7165 Add metadata fields to natural language search indexes

### DIFF
--- a/infrastructure/templates/search/application/indexes/nl-search/nl-search-dataset-index.json
+++ b/infrastructure/templates/search/application/indexes/nl-search/nl-search-dataset-index.json
@@ -368,6 +368,54 @@
       "key": false,
       "analyzer": "standard.lucene",
       "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_encoding",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_type",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_name",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_path",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
     }
   ],
   "scoringProfiles": [],
@@ -378,11 +426,7 @@
     {
       "name": "nl-search-dataset-suggester",
       "searchMode": "analyzingInfixMatching",
-      "sourceFields": [
-        "dataSetFileId",
-        "title",
-        "content"
-      ]
+      "sourceFields": ["dataSetFileId", "title", "content"]
     }
   ],
   "tokenFilters": [],

--- a/infrastructure/templates/search/application/indexes/nl-search/nl-search-filter-index.json
+++ b/infrastructure/templates/search/application/indexes/nl-search/nl-search-filter-index.json
@@ -164,6 +164,54 @@
       "dimensions": 1536,
       "vectorSearchProfile": "nl-search-filter-index-vector-profile",
       "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_encoding",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_type",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_name",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_path",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
     }
   ],
   "scoringProfiles": [],


### PR DESCRIPTION
This PR adds missing metadata fields to the two natural language search indexes `nl-search-dataset-index` and `nl-search-filter-index`:

- metadata_content_encoding
- metadata_content_type
- metadata_storage_name
- metadata_storage_path