### PR TITLE
Update .NET SDK version to 8.0.422 and change rollForward policy

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.407",
-    "rollForward": "latestMajor"
+    "version": "8.0.422",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
This PR:

* Updates the minimum SDK version from `8.0.407` to `8.0.422` to use a newer patch release which includes .NET Runtime 8.0.28.
* Changes the `rollForward` setting from `latestMajor` to `latestMinor` so that we use the highest installed SDK in the **same .NET 8 major version**.

Previously, `latestMajor` would allow jumping to the highest installed SDK that's at least the requested version, regardless of major version, (e.g. it would jump to .NET 10 if installed). For predictability, this change forces using .NET 8.