### PR TITLE
EES-7009 wait for cache to expire for tests such as prerelease and prerelease_and_amend

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -1024,5 +1024,6 @@ user checks pre-release access list on help and related information tab
     [Arguments]    @{access_list_content}
     user clicks link    Help and related information
     user waits until h2 is visible    Pre-release access list
+    user waits for caches to expire
     user checks section with ID contains elements and back to top link    pre-release-access-list-section
     ...    @{access_list_content}


### PR DESCRIPTION
UI tests reported as failing even though when visually verified, they appear as expected. For example the failure reports 'Updated test public access list' is expected but its text was 'Pre-release access list', when visually verifying, the value is actually 'Updated test public access list'. This change overcomes this problem by adding a wait in the relevant section.