### PR TITLE
EES-6971 - fixing duplication issue in locations

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
@@ -120,6 +120,8 @@ export default function DataFileReplacementDifferences({
       Object.values(block.locations || {}),
     );
 
+    const uniqueLocationGroups = uniqueByLabel(allLocations);
+
     // second determine the locations
     const locationsToShow = getNonAutoSetMappings(
       plan.mapping.locations.mappings,
@@ -127,7 +129,7 @@ export default function DataFileReplacementDifferences({
 
     const groupedLocationMappings = createTableMappingsAndGroups(
       locationsToShow,
-      allLocations,
+      uniqueLocationGroups,
       'locationAttributes',
     );
 


### PR DESCRIPTION
PR to fix locations showing multiple times when added to multiple data blocks.

Location groups were not being de-duplicated and therefore if added to multiple blocks
they would be added to the list and shown multiple times.