### PR TITLE
EES-7115 - Add Microsoft Teams alert notifications alongside the existing Slack alerting

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -22,6 +22,9 @@
     },
     "slackAppToken": {
       "type": "securestring"
+    },
+    "teamsPowerAutomateWebhookUrl": {
+      "type": "securestring"
     }
   },
   "variables": {
@@ -151,6 +154,74 @@
                         "short": true
                       }
                     ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Report indexes rebuilt successfully to Teams",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "Rebuild indexes",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.00:10:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": true
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+              "method": "POST",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": {
+                "type": "message",
+                "attachments": [
+                  {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "contentUrl": null,
+                    "content": {
+                      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                      "type": "AdaptiveCard",
+                      "version": "1.2",
+                      "body": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Data Factory Success! All fragmented indexes rebuilt.",
+                          "weight": "Bolder",
+                          "size": "Medium",
+                          "color": "good",
+                          "wrap": true
+                        },
+                        {
+                          "type": "FactSet",
+                          "facts": [
+                            {
+                              "title": "Data Factory",
+                              "value": "@{pipeline().DataFactory}"
+                            },
+                            {
+                              "title": "Pipeline",
+                              "value": "@{pipeline().Pipeline}"
+                            },
+                            {
+                              "title": "Duration",
+                              "value": "@{activity('Rebuild indexes').Duration}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
                   }
                 ]
               }
@@ -324,6 +395,78 @@
                       }
                     },
                     {
+                      "name": "Report timeout handled successfully to Teams",
+                      "type": "WebActivity",
+                      "dependsOn": [
+                        {
+                          "activity": "Kill index reorganizes after timeout",
+                          "dependencyConditions": [
+                            "Succeeded"
+                          ]
+                        }
+                      ],
+                      "policy": {
+                        "timeout": "0.00:10:00",
+                        "retry": 0,
+                        "retryIntervalInSeconds": 30,
+                        "secureOutput": false,
+                        "secureInput": true
+                      },
+                      "userProperties": [],
+                      "typeProperties": {
+                        "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+                        "method": "POST",
+                        "headers": {
+                          "Content-Type": "application/json"
+                        },
+                        "body": {
+                          "type": "message",
+                          "attachments": [
+                            {
+                              "contentType": "application/vnd.microsoft.card.adaptive",
+                              "contentUrl": null,
+                              "content": {
+                                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                                "type": "AdaptiveCard",
+                                "version": "1.2",
+                                "body": [
+                                  {
+                                    "type": "TextBlock",
+                                    "text": "Data Factory timeout handled successfully.",
+                                    "weight": "Bolder",
+                                    "size": "Medium",
+                                    "color": "good",
+                                    "wrap": true
+                                  },
+                                  {
+                                    "type": "FactSet",
+                                    "facts": [
+                                      {
+                                        "title": "Data Factory",
+                                        "value": "@{pipeline().DataFactory}"
+                                      },
+                                      {
+                                        "title": "Pipeline",
+                                        "value": "@{pipeline().Pipeline}"
+                                      },
+                                      {
+                                        "title": "Details",
+                                        "value": "Any resumable index rebuilds have been paused.\nAny reorganizations have been killed."
+                                      },
+                                      {
+                                        "title": "Duration",
+                                        "value": "@{activity('Rebuild indexes').Duration}"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
                       "name": "Report error when pausing resumable index rebuilds",
                       "type": "WebActivity",
                       "dependsOn": [
@@ -377,6 +520,78 @@
                                   "short": true
                                 }
                               ]
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "name": "Report error when pausing resumable index rebuilds to Teams",
+                      "type": "WebActivity",
+                      "dependsOn": [
+                        {
+                          "activity": "Pause resumable index rebuilds after timeout",
+                          "dependencyConditions": [
+                            "Failed"
+                          ]
+                        }
+                      ],
+                      "policy": {
+                        "timeout": "0.00:10:00",
+                        "retry": 0,
+                        "retryIntervalInSeconds": 30,
+                        "secureOutput": false,
+                        "secureInput": true
+                      },
+                      "userProperties": [],
+                      "typeProperties": {
+                        "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+                        "method": "POST",
+                        "headers": {
+                          "Content-Type": "application/json"
+                        },
+                        "body": {
+                          "type": "message",
+                          "attachments": [
+                            {
+                              "contentType": "application/vnd.microsoft.card.adaptive",
+                              "contentUrl": null,
+                              "content": {
+                                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                                "type": "AdaptiveCard",
+                                "version": "1.2",
+                                "body": [
+                                  {
+                                    "type": "TextBlock",
+                                    "text": "Data Factory failure! Problem encountered when pausing resumable index rebuilds.",
+                                    "weight": "Bolder",
+                                    "size": "Medium",
+                                    "color": "warning",
+                                    "wrap": true
+                                  },
+                                  {
+                                    "type": "FactSet",
+                                    "facts": [
+                                      {
+                                        "title": "Data Factory",
+                                        "value": "@{pipeline().DataFactory}"
+                                      },
+                                      {
+                                        "title": "Pipeline",
+                                        "value": "@{pipeline().Pipeline}"
+                                      },
+                                      {
+                                        "title": "Activity",
+                                        "value": "@{activity('Pause resumable index rebuilds after timeout').Error.message}"
+                                      },
+                                      {
+                                        "title": "Duration",
+                                        "value": "@{activity('Rebuild indexes').Duration}"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -440,6 +655,78 @@
                           ]
                         }
                       }
+                    },
+                    {
+                      "name": "Report error when killing index reorganizations to Teams",
+                      "type": "WebActivity",
+                      "dependsOn": [
+                        {
+                          "activity": "Kill index reorganizes after timeout",
+                          "dependencyConditions": [
+                            "Failed"
+                          ]
+                        }
+                      ],
+                      "policy": {
+                        "timeout": "0.00:10:00",
+                        "retry": 0,
+                        "retryIntervalInSeconds": 30,
+                        "secureOutput": false,
+                        "secureInput": true
+                      },
+                      "userProperties": [],
+                      "typeProperties": {
+                        "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+                        "method": "POST",
+                        "headers": {
+                          "Content-Type": "application/json"
+                        },
+                        "body": {
+                          "type": "message",
+                          "attachments": [
+                            {
+                              "contentType": "application/vnd.microsoft.card.adaptive",
+                              "contentUrl": null,
+                              "content": {
+                                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                                "type": "AdaptiveCard",
+                                "version": "1.2",
+                                "body": [
+                                  {
+                                    "type": "TextBlock",
+                                    "text": "Data Factory failure! Problem encountered when killing index reorganizations.",
+                                    "weight": "Bolder",
+                                    "size": "Medium",
+                                    "color": "warning",
+                                    "wrap": true
+                                  },
+                                  {
+                                    "type": "FactSet",
+                                    "facts": [
+                                      {
+                                        "title": "Data Factory",
+                                        "value": "@{pipeline().DataFactory}"
+                                      },
+                                      {
+                                        "title": "Pipeline",
+                                        "value": "@{pipeline().Pipeline}"
+                                      },
+                                      {
+                                        "title": "Activity",
+                                        "value": "@{activity('Kill index reorganizes after timeout').Error.message}"
+                                      },
+                                      {
+                                        "title": "Duration",
+                                        "value": "@{activity('Rebuild indexes').Duration}"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
                   ]
                 }
@@ -492,6 +779,71 @@
                               "short": true
                             }
                           ]
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "name": "Report failure to Teams",
+                  "type": "WebActivity",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": true
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+                    "method": "POST",
+                    "headers": {
+                      "Content-Type": "application/json"
+                    },
+                    "body": {
+                      "type": "message",
+                      "attachments": [
+                        {
+                          "contentType": "application/vnd.microsoft.card.adaptive",
+                          "contentUrl": null,
+                          "content": {
+                            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                            "type": "AdaptiveCard",
+                            "version": "1.2",
+                            "body": [
+                              {
+                                "type": "TextBlock",
+                                "text": "Data Factory Failure!",
+                                "weight": "Bolder",
+                                "size": "Medium",
+                                "color": "warning",
+                                "wrap": true
+                              },
+                              {
+                                "type": "FactSet",
+                                "facts": [
+                                  {
+                                    "title": "Data Factory",
+                                    "value": "@{pipeline().DataFactory}"
+                                  },
+                                  {
+                                    "title": "Pipeline",
+                                    "value": "@{pipeline().Pipeline}"
+                                  },
+                                  {
+                                    "title": "Error",
+                                    "value": "@{activity('Rebuild indexes').Error.message}"
+                                  },
+                                  {
+                                    "title": "Duration",
+                                    "value": "@{activity('Rebuild indexes').Duration}"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -597,24 +949,96 @@
               "body": {
                 "channel": "[parameters('slackAlertsChannel')]",
                 "text": "Data Factory Success!",
-                "attachments": [{
-                  "color": "good",
-                  "fields": [{
-                    "title": "Data Factory",
-                    "value": "@{pipeline().DataFactory}",
-                    "short": true
-                  },
-                    {
-                      "title": "Pipeline",
-                      "value": "@{pipeline().Pipeline}",
-                      "short": true
-                    },
-                    {
-                      "title": "Duration",
-                      "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}",
-                      "short": true
-                    }]
-                }]
+                "attachments": [
+                  {
+                    "color": "good",
+                    "fields": [
+                      {
+                        "title": "Data Factory",
+                        "value": "@{pipeline().DataFactory}",
+                        "short": true
+                      },
+                      {
+                        "title": "Pipeline",
+                        "value": "@{pipeline().Pipeline}",
+                        "short": true
+                      },
+                      {
+                        "title": "Duration",
+                        "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}",
+                        "short": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Report success to Teams",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_remove_soft_deleted_subjects",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.00:10:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": true
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+              "method": "POST",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": {
+                "type": "message",
+                "attachments": [
+                  {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "contentUrl": null,
+                    "content": {
+                      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                      "type": "AdaptiveCard",
+                      "version": "1.2",
+                      "body": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Data Factory Success!",
+                          "weight": "Bolder",
+                          "size": "Medium",
+                          "color": "good",
+                          "wrap": true
+                        },
+                        {
+                          "type": "FactSet",
+                          "facts": [
+                            {
+                              "title": "Data Factory",
+                              "value": "@{pipeline().DataFactory}"
+                            },
+                            {
+                              "title": "Pipeline",
+                              "value": "@{pipeline().Pipeline}"
+                            },
+                            {
+                              "title": "Duration",
+                              "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
           },
@@ -676,6 +1100,78 @@
                 ]
               }
             }
+          },
+          {
+            "name": "Report failure to Teams",
+            "type": "WebActivity",
+            "dependsOn": [
+              {
+                "activity": "sp_remove_soft_deleted_subjects",
+                "dependencyConditions": [
+                  "Failed"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.00:10:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": true
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+              "method": "POST",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": {
+                "type": "message",
+                "attachments": [
+                  {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "contentUrl": null,
+                    "content": {
+                      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                      "type": "AdaptiveCard",
+                      "version": "1.2",
+                      "body": [
+                        {
+                          "type": "TextBlock",
+                          "text": "Data Factory Failure!",
+                          "weight": "Bolder",
+                          "size": "Medium",
+                          "color": "warning",
+                          "wrap": true
+                        },
+                        {
+                          "type": "FactSet",
+                          "facts": [
+                            {
+                              "title": "Data Factory",
+                              "value": "@{pipeline().DataFactory}"
+                            },
+                            {
+                              "title": "Pipeline",
+                              "value": "@{pipeline().Pipeline}"
+                            },
+                            {
+                              "title": "Error",
+                              "value": "@{activity('sp_remove_soft_deleted_subjects').Error.message}"
+                            },
+                            {
+                              "title": "Duration",
+                              "value": "@{activity('sp_remove_soft_deleted_subjects').Duration}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
           }
         ],
         "parameters": {
@@ -726,8 +1222,12 @@
             "startTime": "2020-11-23T19:00:00",
             "timeZone": "GMT Standard Time",
             "schedule": {
-              "hours": [19],
-              "minutes": [0]
+              "hours": [
+                19
+              ],
+              "minutes": [
+                0
+              ]
             }
           }
         }
@@ -762,8 +1262,12 @@
             "startTime": "2023-03-03T02:00:00",
             "timeZone": "GMT Standard Time",
             "schedule": {
-              "hours": [2],
-              "minutes": [0]
+              "hours": [
+                2
+              ],
+              "minutes": [
+                0
+              ]
             }
           }
         }

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters":{
+  "parameters": {
     "subscription": {
       "type": "string",
       "metadata": {
@@ -55,17 +55,17 @@
       }
     }
   },
-  "variables":{
+  "variables": {
     "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]"
   },
-  "resources":[
+  "resources": [
     {
-      "name":"[parameters('dataFactoryName')]",
-      "apiVersion":"2018-06-01",
-      "type":"Microsoft.DataFactory/factories",
-      "location":"[resourceGroup().location]",
-      "identity":{
-        "type":"SystemAssigned"
+      "name": "[parameters('dataFactoryName')]",
+      "apiVersion": "2018-06-01",
+      "type": "Microsoft.DataFactory/factories",
+      "location": "[resourceGroup().location]",
+      "identity": {
+        "type": "SystemAssigned"
       },
       "properties": {},
       "dependsOn": []
@@ -96,6 +96,14 @@
                 "id": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
               },
               "secretName": "ees-alerts-slackapptoken"
+            }
+          },
+          "teamsPowerAutomateWebhookUrl": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+              },
+              "secretName": "ees-alerts-teamswebhookurl"
             }
           }
         }

--- a/infrastructure/templates/logic-app-template.json
+++ b/infrastructure/templates/logic-app-template.json
@@ -19,6 +19,9 @@
     },
     "workspaceResourceId": {
       "type": "string"
+    },
+    "teamsPowerAutomateWebhookUrl": {
+      "type": "securestring"
     }
   },
   "resources": [
@@ -31,12 +34,16 @@
         "state": "Enabled",
         "parameters": {
           "subscription": {
-              "type": "String",
-              "value": "[parameters('subscription')]"
+            "type": "String",
+            "value": "[parameters('subscription')]"
           },
           "resourceGroup": {
-              "type": "String",
-              "value": "[parameters('resourceGroup')]"
+            "type": "String",
+            "value": "[parameters('resourceGroup')]"
+          },
+          "teamsPowerAutomateWebhookUrl": {
+            "type": "SecureString",
+            "value": "[parameters('teamsPowerAutomateWebhookUrl')]"
           }
         },
         "definition": {
@@ -44,8 +51,8 @@
           "contentVersion": "1.0.0.0",
           "parameters": {
             "$connections": {
-                 "type": "Object",
-                "defaultValue": {}
+              "type": "Object",
+              "defaultValue": {}
             },
             "subscription": {
               "type": "string",
@@ -54,6 +61,9 @@
             "resourceGroup": {
               "type": "string",
               "defaultValue": ""
+            },
+            "teamsPowerAutomateWebhookUrl": {
+              "type": "securestring"
             }
           },
           "triggers": {
@@ -121,7 +131,7 @@
                             "alertTargetIDs": {
                               "type": "array",
                               "items": {
-                                  "type": "string"
+                                "type": "string"
                               }
                             },
                             "originAlertId": {
@@ -392,9 +402,9 @@
                             "short": true
                           },
                           {
-                              "title": "Window end",
-                              "value": "@{if(equals(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], null), '', formatDateTime(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], 'dd/MM/yyyy h:mm:sstt'))}",
-                              "short": true
+                            "title": "Window end",
+                            "value": "@{if(equals(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], null), '', formatDateTime(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], 'dd/MM/yyyy h:mm:sstt'))}",
+                            "short": true
                           }
                         ]
                       }
@@ -406,6 +416,108 @@
                   }
                 },
                 "unsubscribe": {}
+              }
+            },
+            "Initialize alertRuleUrl variable": {
+              "type": "InitializeVariable",
+              "inputs": {
+                "variables": [
+                  {
+                    "name": "alertRuleUrl",
+                    "type": "string",
+                    "value": "@{concat('https://portal.azure.com.mcas.ms/#@platform.education.gov.uk/resource', first(split(triggerBody()?['data']?['essentials']?['alertTargetIDs'][0], '/providers/')), '/providers/microsoft.insights/metricAlerts/', triggerBody()?['data']?['essentials']?['alertRule'], '/overview')}"
+                  }
+                ]
+              },
+              "runAfter": {
+                "Initialize severity variable": [
+                  "Succeeded"
+                ]
+              }
+            },
+            "HTTP_Teams": {
+              "type": "Http",
+              "inputs": {
+                "uri": "@parameters('teamsPowerAutomateWebhookUrl')",
+                "method": "POST",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "body": {
+                  "type": "message",
+                  "attachments": [
+                    {
+                      "contentType": "application/vnd.microsoft.card.adaptive",
+                      "contentUrl": null,
+                      "content": {
+                        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                        "type": "AdaptiveCard",
+                        "version": "1.2",
+                        "body": [
+                          {
+                            "type": "TextBlock",
+                            "text": "@{concat('Alert ', triggerBody()?['data']?['essentials']?['alertRule'], ' ', toLower(variables('monitorCondition')), if(equals(variables('monitorCondition'), 'Resolved'), '', '!'))}",
+                            "weight": "Bolder",
+                            "size": "Medium",
+                            "color": "@{if(equals(variables('monitorCondition'), 'Resolved'), 'good', if(or(equals(variables('severity'), 'Sev0'), equals(variables('severity'), 'Sev1')), 'attention', if(equals(variables('severity'), 'Sev2'), 'warning', 'good')))}"
+                          },
+                          {
+                            "type": "TextBlock",
+                            "text": "@{if(equals(variables('monitorCondition'), 'Resolved'), '', concat(triggerBody()?['data']?['essentials']?['description'], '\n'))}\n@{if(equals(variables('monitorCondition'), 'Resolved'), variables('withinThresholdMessage'), variables('outsideThresholdMessage'))}\n[Link to alert](@{variables('alertRuleUrl')})\n[Link to resource](https://portal.azure.com/#@platform.education.gov.uk/resource@{triggerBody()?['data']?['essentials']?['alertTargetIDs'][0]})",
+                            "wrap": true
+                          },
+                          {
+                            "type": "FactSet",
+                            "facts": [
+                              {
+                                "title": "Alert",
+                                "value": "@{triggerBody()?['data']?['essentials']?['alertRule']}"
+                              },
+                              {
+                                "title": "Severity",
+                                "value": "@{if(equals(variables('monitorCondition'), 'Resolved'), 'Resolved', variables('severityDisplay'))}"
+                              },
+                              {
+                                "title": "@{variables('monitorCondition')} at",
+                                "value": "@{if(equals(variables('monitorCondition'), 'Resolved'), formatDateTime(triggerBody()?['data']?['essentials']?['resolvedDateTime'], 'dd/MM/yyyy h:mm:sstt'), formatDateTime(triggerBody()?['data']?['essentials']?['firedDateTime'], 'dd/MM/yyyy h:mm:sstt'))}"
+                              },
+                              {
+                                "title": "Window Start",
+                                "value": "@{if(equals(triggerBody()?['data']?['alertContext']?['condition']?['windowStartTime'], null), '', formatDateTime(triggerBody()?['data']?['alertContext']?['condition']?['windowStartTime'], 'dd/MM/yyyy h:mm:sstt'))}"
+                              },
+                              {
+                                "title": "Window End",
+                                "value": "@{if(equals(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], null), '', formatDateTime(triggerBody()?['data']?['alertContext']?['condition']?['windowEndTime'], 'dd/MM/yyyy h:mm:sstt'))}"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              "runAfter": {
+                "Initialize monitorCondition variable": [
+                  "Succeeded"
+                ],
+                "Initialize severityDisplay variable": [
+                  "Succeeded"
+                ],
+                "Initialize withinThresholdMessage variable": [
+                  "Succeeded"
+                ],
+                "Initialize outsideThresholdMessage variable": [
+                  "Succeeded"
+                ],
+                "Initialize alertRuleUrl variable": [
+                  "Succeeded"
+                ]
+              },
+              "runtimeConfiguration": {
+                "contentTransfer": {
+                  "transferMode": "Chunked"
+                }
               }
             }
           },
@@ -424,14 +536,14 @@
       "properties": {
         "logs": [
           {
-              "category": "WorkflowRuntime",
-              "enabled": true
+            "category": "WorkflowRuntime",
+            "enabled": true
           }
         ],
         "metrics": [
           {
-              "category": "AllMetrics",
-              "enabled": true
+            "category": "AllMetrics",
+            "enabled": true
           }
         ],
         "workspaceId": "[parameters('workspaceResourceId')]",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -4566,6 +4566,14 @@
           },
           "workspaceResourceId": {
             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+          },
+          "teamsPowerAutomateWebhookUrl": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+              },
+              "secretName": "ees-alerts-teamswebhookurl"
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

This PR adds [Microsoft Teams alert notifications channels](https://teams.microsoft.com/l/channel/19%3Af4de4d84b9244c2894c420c27ff48cdb%40thread.tacv2/Alerts%20TEST?groupId=a8d697a0-c0a7-40c0-9020-07e7bd157e91&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9) alongside the existing Slack alerting channels. Azure Monitor metric alerts currently notify Slack via an action group and Logic App. This change adds a separate Teams action group and Logic App so the same metric alerts are also posted to a Teams channel. 

## Changes

- Adds a new Teams Logic App ARM template for Azure Monitor common alert schema payloads.
  - We can just delete the slack services when we are ready to turn them off without having to make any untangling or editing. 
  - The Teams webhook URL is stored in Key Vault and is used by the Logic App to call the Teams Power Automate workflow.
- ~~Adds a new Teams Azure Monitor action group with a Logic App receiver.~~
- ~~Updates existing metric alerts to notify both Slack and Teams.~~ 
- ~~Updates the Data Factory activity failure metric alert to notify both Slack and Teams.~~
- Reuse existing logic app and action group and extend it to send Teams message as well as Slack message.
- Fix the 'link to alert' hyperlink so it points to the correct link (currently it is a broken link in slack)
- Adds Teams notifications for the direct Data Factory housekeeping pipeline messages that currently post to Slack.
- Reuses Key Vault secret `ees-alerts-teamswebhookurl` for the Teams Power Automate webhook URL.

## Screenshots
<img width="1908" height="11331" alt="image" src="https://github.com/user-attachments/assets/5da87466-07e4-4ff3-9b20-71c9d644e195" />
