### PR TITLE
EES-7253 Relocate event messaging infrastructure from Search into Core infrastructure

### DIFF
--- a/infrastructure/templates/core/application/eventMessaging/eventMessaging.bicep
+++ b/infrastructure/templates/core/application/eventMessaging/eventMessaging.bicep
@@ -3,10 +3,10 @@ Sets up event messaging infrastructure using Azure Event Grid and ensures that b
 Publisher Function App have the necessary permissions to send events to the Event Grid topics.
 '''
 
-import { builtInRoleDefinitionIds } from '../builtInRoles.bicep'
-import { eventTopics } from '../eventTopics.bicep'
-import { buildFullyQualifiedTopicName } from '../functions.bicep'
-import { IpRange } from '../types.bicep'
+import { builtInRoleDefinitionIds } from '../../../common/builtInRoles.bicep'
+import { eventTopics } from '../../../common/eventTopics.bicep'
+import { buildFullyQualifiedTopicName } from '../../../common/functions.bicep'
+import { IpRange } from '../../../common/types.bicep'
 
 @description('Location for all resources.')
 param location string
@@ -54,7 +54,7 @@ resource eventGridCustomTopicPrivateEndpointsSubnet 'Microsoft.Network/virtualNe
   parent: vNet
 }
 
-module eventGridMessagingModule '../components/event-grid/eventGridMessaging.bicep' = {
+module eventGridMessagingModule '../../../common/components/event-grid/eventGridMessaging.bicep' = {
   name: 'eventGridMessagingModuleDeploy'
   params: {
     location: location
@@ -78,7 +78,7 @@ module eventGridMessagingModule '../components/event-grid/eventGridMessaging.bic
 }
 
 // Allow the Admin App Service to send events to Event Grid topics
-module adminTopicRoleAssignmentModuleDeploy '../components/event-grid/eventGridTopicRoleAssignment.bicep' = [
+module adminTopicRoleAssignmentModuleDeploy '../../../common/components/event-grid/eventGridTopicRoleAssignment.bicep' = [
   for (topicName, index) in topicNames: {
     name: 'adminTopicRoleAssignmentModuleDeploy-${index}'
     params: {
@@ -93,7 +93,7 @@ module adminTopicRoleAssignmentModuleDeploy '../components/event-grid/eventGridT
 ]
 
 // Allow the Publisher Function App to send events to Event Grid topics
-module publisherTopicRoleAssignmentModuleDeploy '../components/event-grid/eventGridTopicRoleAssignment.bicep' = [
+module publisherTopicRoleAssignmentModuleDeploy '../../../common/components/event-grid/eventGridTopicRoleAssignment.bicep' = [
   for (topicName, index) in topicNames: {
     name: 'publisherTopicRoleAssignmentModuleDeploy-${index}'
     params: {

--- a/infrastructure/templates/core/application/eventMessaging/eventMessaging.bicep
+++ b/infrastructure/templates/core/application/eventMessaging/eventMessaging.bicep
@@ -32,6 +32,9 @@ param resourceNames {
 @description('Resource prefix for all resources.')
 param resourcePrefix string
 
+@description('Whether to create or update Azure Monitor alerts during this deploy.')
+param deployAlerts bool
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -64,14 +67,14 @@ module eventGridMessagingModule '../../../common/components/event-grid/eventGrid
     customTopics: {
       names: topicNames
       privateEndpointSubnetId: eventGridCustomTopicPrivateEndpointsSubnet.id
-      alerts: {
+      alerts: deployAlerts ? {
         deadLetteredCount: true
         deliveryAttemptFailCount: true
         droppedEventCount: true
         publishFailCount: true
         unmatchedEventCount: true
         alertsGroupName: resourceNames.alertsGroup
-      }
+      } : null
     }
     tagValues: tagValues
   }

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -87,6 +87,7 @@ module eventMessagingModule 'application/eventMessaging/eventMessaging.bicep' = 
         eventGridCustomTopicPrivateEndpoints: resourceNames.existingResources.subnets.eventGridCustomTopicPrivateEndpoints
       }
     }
+    deployAlerts: deployAlerts
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -1,3 +1,4 @@
+import { abbreviations } from '../common/abbreviations.bicep'
 import { FrontDoorCertificateType } from '../common/components/front-door/types.bicep'
 
 @description('Environment : Subscription name. Used as a prefix for created resources.')
@@ -45,6 +46,18 @@ var tagValues = union(resourceTags ?? {}, {
 var resourcePrefix = '${subscription}-ees'
 var legacyResourcePrefix = '${subscription}-'
 
+var resourceNames = {
+  existingResources: {
+    adminApp: '${subscription}-as-ees-admin'
+    publisherFunction: '${subscription}-${abbreviations.webSitesFunctions}-ees-publisher'
+    vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
+    alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
+    subnets: {
+      eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
+    }
+  }
+}
+
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: '${resourcePrefix}-log'
   scope: resourceGroup()
@@ -56,6 +69,24 @@ module backupsModule 'application/backups/backups.bicep' = {
     location: location
     resourcePrefix: resourcePrefix
     deployBackupVaultReaderRoleAssignment: deployBackupVaultReaderRoleAssignment
+    tagValues: tagValues
+  }
+}
+
+module eventMessagingModule 'application/eventMessaging/eventMessaging.bicep' = {
+  name: 'eventMessagingModuleDeploy'
+  params: {
+    location: location
+    resourcePrefix: resourcePrefix
+    resourceNames: {
+      adminApp: resourceNames.existingResources.adminApp
+      alertsGroup: resourceNames.existingResources.alertsGroup
+      publisherFunction: resourceNames.existingResources.publisherFunction
+      vNet: resourceNames.existingResources.vNet
+      subnets: {
+        eventGridCustomTopicPrivateEndpoints: resourceNames.existingResources.subnets.eventGridCustomTopicPrivateEndpoints
+      }
+    }
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -1,3 +1,8 @@
+metadata description = '''
+Creates Event Grid subscriptions for the Search Docs Function App, for a defined set of topics provisioned by the Core infrastructure.
+ Each subscription delivers events to a storage queue within the Search Docs Function App storage account.
+'''
+
 import { abbreviations } from '../../common/abbreviations.bicep'
 import { eventTopics } from '../../common/eventTopics.bicep'
 import { buildFullyQualifiedTopicName } from '../../common/functions.bicep'

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -76,14 +76,11 @@ var resourcePrefix = '${subscription}-ees'
 
 var resourceNames = {
   existingResources: {
-    adminApp: '${subscription}-as-ees-admin'
     logAnalyticsWorkspace: '${resourcePrefix}-${abbreviations.operationalInsightsWorkspaces}'
-    publisherFunction: '${subscription}-${abbreviations.webSitesFunctions}-ees-publisher'
     keyVault: '${subscription}-${abbreviations.keyVaultVaults}-ees-01'
     vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
     alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
     subnets: {
-      eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
       nlSearchFunctionApp: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.webSitesFunctions}-nlsearch'
       nlSearchFunctionAppPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.webSitesFunctions}-nlsearch-pep'
       searchDocsFunctionApp: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.webSitesFunctions}-searchdocs'
@@ -99,29 +96,6 @@ module monitoringModule 'application/monitoring.bicep' = {
     location: location
     resourcePrefix: resourcePrefix
     resourceNames: resourceNames
-    tagValues: tagValues
-  }
-}
-
-// Provision the event messaging infrastructure utilised by EES for communication between services.
-// While not exclusively part of the Search service infrastructure, it is included here to support
-// other services that publish events but are not yet defined in Bicep such as the Admin App Service
-// and the Publisher Function App.
-// The Search Service relies on this infrastructure to subscribe to events.
-module eventMessagingModule '../common/application/eventMessaging.bicep' = {
-  name: 'eventMessagingModuleDeploy'
-  params: {
-    location: location
-    resourcePrefix: resourcePrefix
-    resourceNames: {
-      adminApp: resourceNames.existingResources.adminApp
-      alertsGroup: resourceNames.existingResources.alertsGroup
-      publisherFunction: resourceNames.existingResources.publisherFunction
-      vNet: resourceNames.existingResources.vNet
-      subnets: {
-        eventGridCustomTopicPrivateEndpoints: resourceNames.existingResources.subnets.eventGridCustomTopicPrivateEndpoints
-      }
-    }
     tagValues: tagValues
   }
 }
@@ -195,9 +169,6 @@ module searchDocsFunctionEventSubscriptionsModule 'application/searchDocsFunctio
     searchDocsFunctionAppStorageAccountName: searchDocsFunctionAppModule.outputs.functionAppStorageAccountName
     storageQueueNames: searchDocsFunctionAppModule.outputs.storageQueueNames
   }
-  dependsOn: [
-    eventMessagingModule
-  ]
 }
 
 module searchServiceModule 'application/searchService.bicep' = {

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -1,14 +1,11 @@
 @export()
 type ResourceNames = {
   existingResources: {
-    adminApp: string
     logAnalyticsWorkspace: string
-    publisherFunction: string
     keyVault: string
     vNet: string
     alertsGroup: string
     subnets: {
-      eventGridCustomTopicPrivateEndpoints: string
       nlSearchFunctionApp: string
       nlSearchFunctionAppPrivateEndpoints: string
       searchDocsFunctionApp: string


### PR DESCRIPTION
The event messaging infrastructure was originally created before the Core infrastructure existed.

It is currently provisioned through the Search infrastructure that was its first consumer, however it is not the only consumer of it.

It is intended to be provided for any EES services to use it for communication, and is used by the Admin and Publisher apps to publish events (e.g. when publications and releases are updated/published), which can then be consumed by other services such as Search.

This PR moves the definition and provisioning of the event messaging infrastructure from the Search pipeline into the Core infrastructure pipeline. It decouples it from Search and makes its availability as a shared feature more explicit.