### PR TITLE
EES-7224 - Making the `UserPublicationRoles.CreatedById` & `UserPreReleaseRoles.CreatedById` fields non-nullable

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPreReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPreReleaseRoleRepositoryTests.cs
@@ -192,7 +192,7 @@ public abstract class UserPreReleaseRoleRepositoryTests
                 .Select(uprr => new UserPreReleaseRoleCreateDto(
                     UserId: uprr.UserId,
                     ReleaseVersionId: uprr.ReleaseVersionId,
-                    CreatedById: uprr.CreatedById!.Value,
+                    CreatedById: uprr.CreatedById,
                     CreatedDate: uprr.Created
                 ))
                 .ToHashSet();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
@@ -242,7 +242,7 @@ public abstract class UserPublicationRoleRepositoryTests
                     UserId: upr.UserId,
                     PublicationId: upr.PublicationId,
                     Role: upr.Role,
-                    CreatedById: upr.CreatedById!.Value,
+                    CreatedById: upr.CreatedById,
                     CreatedDate: upr.Created
                 ))
                 .ToHashSet();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable")]
+    partial class Ees7224MakingResourceRoleCreatedByIdNonNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -430,6 +433,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("ScreeningStatus")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
 
                     b.Property<string>("UploadedBy")
                         .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.cs
@@ -1,0 +1,68 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7224MakingResourceRoleCreatedByIdNonNullable : Migration
+    {
+        private const string MigrationId = "20260617160136";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Migrate any cases where the CreatedById is null to point to the deleted user placeholder user
+            // so that we can make the column non-nullable.
+            migrationBuilder.SqlFromFile(
+                MigrationConstants.ContentMigrationsPath,
+                $"{MigrationId}_{nameof(Ees7224MakingResourceRoleCreatedByIdNonNullable)}.sql"
+            );
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CreatedById",
+                table: "UserPublicationRoles",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CreatedById",
+                table: "UserPreReleaseRoles",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CreatedById",
+                table: "UserPublicationRoles",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier"
+            );
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "CreatedById",
+                table: "UserPreReleaseRoles",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier"
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617160136_Ees7224MakingResourceRoleCreatedByIdNonNullable.sql
@@ -1,0 +1,16 @@
+﻿-- Get the ID of the placeholder deleted user
+DECLARE @DeletedUserId UNIQUEIDENTIFIER;
+
+SELECT @DeletedUserId = Id
+FROM Users
+WHERE Email = 'deleted.user@doesnotexist.com';
+
+-- Migrate any cases where the CreatedById is null to point to the deleted user placeholder user
+-- so that we can make the column non-nullable.
+UPDATE UserPublicationRoles
+SET CreatedById = @DeletedUserId
+WHERE CreatedById IS NULL;
+
+UPDATE UserPreReleaseRoles
+SET CreatedById = @DeletedUserId
+WHERE CreatedById IS NULL;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -671,6 +671,12 @@ public class ContentDbContext : DbContext
             .Entity<UserPreReleaseRole>()
             .Property(userReleaseRole => userReleaseRole.Created)
             .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+        modelBuilder
+            .Entity<UserPreReleaseRole>()
+            .HasOne(upr => upr.CreatedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
     }
 
     private static void ConfigureGlossaryEntry(ModelBuilder modelBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ResourceRole.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ResourceRole.cs
@@ -20,9 +20,9 @@ public abstract class ResourceRole<TResource>
 
     public DateTimeOffset? EmailSent { get; set; }
 
-    public Guid? CreatedById { get; set; }
+    public required Guid CreatedById { get; set; }
 
-    public User? CreatedBy { get; set; }
+    public User CreatedBy { get; set; } = null!;
 
     public required DateTime Created { get; set; }
 }


### PR DESCRIPTION
Currently, the `UserPublicationRoles.CreatedById` & `UserPreReleaseRoles.CreatedById` fields are nullable, and there are many entries in the database which have it set to `NULL`. 

In reality, we should always have a value to set it to, and we now have a 'deleted user placeholder' in the DB that we can use to migrate those historic `NULL` entries to point to that (since we will never know which user was responsible for creating them).

So, this PR forces the `CreatedById` to always be set in code, and forces it to be non-nullable. Historic `NULL` entries are migrated to point to the 'deleted user placeholder'