### PR TITLE
EES-7255 - Automatically set the Resource Roles `Created` field if not explicitly overridden + Convert it to a `DateTimeOffset`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -598,7 +598,9 @@ public abstract class PreReleaseUserServiceTests
 
                 var userId = existingUser?.Id ?? newUserIdsByEmail[email];
                 userPreReleaseRoleRepository
-                    .Setup(mock => mock.Create(userId, releaseVersion.Id, _userId, null, It.IsAny<CancellationToken>()))
+                    .Setup(mock =>
+                        mock.Create(userId, releaseVersion.Id, _userId, default, It.IsAny<CancellationToken>())
+                    )
                     .ReturnsAsync(createdUserPreReleaseRole);
             }
 
@@ -856,7 +858,9 @@ public abstract class PreReleaseUserServiceTests
 
                 var userId = existingUser?.Id ?? newUserIdsByEmail[email];
                 userPreReleaseRoleRepository
-                    .Setup(mock => mock.Create(userId, releaseVersion.Id, _userId, null, It.IsAny<CancellationToken>()))
+                    .Setup(mock =>
+                        mock.Create(userId, releaseVersion.Id, _userId, default, It.IsAny<CancellationToken>())
+                    )
                     .ReturnsAsync(
                         _dataFixture
                             .DefaultUserPreReleaseRole()
@@ -976,7 +980,7 @@ public abstract class PreReleaseUserServiceTests
                 )
                 .ReturnsAsync(false);
             userPreReleaseRoleRepository
-                .Setup(s => s.Create(user.Id, latestReleaseVersion.Id, _userId, null, It.IsAny<CancellationToken>()))
+                .Setup(s => s.Create(user.Id, latestReleaseVersion.Id, _userId, default, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(createdUserPreReleaseRole);
 
             var globalRoleService = new Mock<IGlobalRoleService>(MockBehavior.Strict);
@@ -1068,7 +1072,7 @@ public abstract class PreReleaseUserServiceTests
                 )
                 .ReturnsAsync(false);
             userPreReleaseRoleRepository
-                .Setup(s => s.Create(user.Id, latestReleaseVersion.Id, _userId, null, It.IsAny<CancellationToken>()))
+                .Setup(s => s.Create(user.Id, latestReleaseVersion.Id, _userId, default, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(createdUserPreReleaseRole);
 
             var globalRoleService = new Mock<IGlobalRoleService>(MockBehavior.Strict);
@@ -1153,7 +1157,7 @@ public abstract class PreReleaseUserServiceTests
                 .ReturnsAsync(false);
             userPreReleaseRoleRepository
                 .Setup(s =>
-                    s.Create(updatedUser.Id, latestReleaseVersion.Id, _userId, null, It.IsAny<CancellationToken>())
+                    s.Create(updatedUser.Id, latestReleaseVersion.Id, _userId, default, It.IsAny<CancellationToken>())
                 )
                 .ReturnsAsync(createdUserPreReleaseRole);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -33,7 +33,11 @@ public abstract class UserManagementServiceTests
 
     private static readonly Guid CreatedById = Guid.NewGuid();
 
-    public static readonly TheoryData<DateTime?> InviteUserOptionalCreatedDates = [null, DateTime.UtcNow.AddDays(-5)];
+    public static readonly TheoryData<DateTimeOffset?> InviteUserOptionalCreatedDates =
+    [
+        null,
+        DateTime.UtcNow.AddDays(-5),
+    ];
 
     public class GetUserTests : UserManagementServiceTests
     {
@@ -364,7 +368,7 @@ public abstract class UserManagementServiceTests
     {
         [Theory]
         [MemberData(nameof(InviteUserOptionalCreatedDates))]
-        public async Task Success(DateTime? createdDate)
+        public async Task Success(DateTimeOffset? createdDate)
         {
             var email = "test@test.com";
 
@@ -428,7 +432,7 @@ public abstract class UserManagementServiceTests
                         userToCreate.Id,
                         releaseVersion.Id,
                         CreatedById,
-                        createdDate,
+                        createdDate ?? default,
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -449,7 +453,7 @@ public abstract class UserManagementServiceTests
                                 && upr.Role == publicationRole
                                 && createdDate.HasValue
                                     ? upr.CreatedDate == createdDate
-                                    : Math.Abs((upr.CreatedDate!.Value - DateTime.UtcNow).Milliseconds)
+                                    : Math.Abs((upr.CreatedDate - DateTime.UtcNow).Milliseconds)
                                         <= AssertExtensions.TimeWithinMillis
                                         && upr.CreatedById == CreatedById
                             )
@@ -594,12 +598,24 @@ public abstract class UserManagementServiceTests
                 .Returns(Task.CompletedTask);
             userPreReleaseRoleRepository
                 .Setup(mock =>
-                    mock.Create(userToCreate.Id, releaseVersion1.Id, CreatedById, null, It.IsAny<CancellationToken>())
+                    mock.Create(
+                        userToCreate.Id,
+                        releaseVersion1.Id,
+                        CreatedById,
+                        default,
+                        It.IsAny<CancellationToken>()
+                    )
                 )
                 .ReturnsAsync(It.IsAny<UserPreReleaseRole>());
             userPreReleaseRoleRepository
                 .Setup(mock =>
-                    mock.Create(userToCreate.Id, releaseVersion2.Id, CreatedById, null, It.IsAny<CancellationToken>())
+                    mock.Create(
+                        userToCreate.Id,
+                        releaseVersion2.Id,
+                        CreatedById,
+                        default,
+                        It.IsAny<CancellationToken>()
+                    )
                 )
                 .ReturnsAsync(It.IsAny<UserPreReleaseRole>());
 
@@ -616,13 +632,13 @@ public abstract class UserManagementServiceTests
                             && l.Any(upr =>
                                 upr.PublicationId == publications[2].Id
                                 && upr.Role == publicationRole1
-                                && Math.Abs((upr.CreatedDate!.Value - DateTime.UtcNow).Milliseconds)
+                                && Math.Abs((upr.CreatedDate - DateTime.UtcNow).Milliseconds)
                                     <= AssertExtensions.TimeWithinMillis
                             )
                             && l.Any(upr =>
                                 upr.PublicationId == publications[3].Id
                                 && upr.Role == publicationRole2
-                                && Math.Abs((upr.CreatedDate!.Value - DateTime.UtcNow).Milliseconds)
+                                && Math.Abs((upr.CreatedDate - DateTime.UtcNow).Milliseconds)
                                     <= AssertExtensions.TimeWithinMillis
                             )
                         ),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPreReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPreReleaseRoleRepositoryTests.cs
@@ -145,8 +145,8 @@ public abstract class UserPreReleaseRoleRepositoryTests
         [Fact]
         public async Task ManyRoles_IgnoresRolesThatAlreadyExist()
         {
-            var existingRoleCreatedDate = DateTime.UtcNow.AddDays(-2);
-            var newRolesCreatedDate = DateTime.UtcNow;
+            var existingRoleCreatedDate = DateTimeOffset.UtcNow.AddDays(-2);
+            var newRolesCreatedDate = DateTimeOffset.UtcNow;
             User createdBy = _fixture.DefaultUser();
 
             // Test across multiple User/Publication combinations
@@ -264,7 +264,7 @@ public abstract class UserPreReleaseRoleRepositoryTests
                     .Select(uprr => (uprr.UserId, uprr.ReleaseVersionId, uprr.Created))
                     .ToHashSet();
 
-                var expectedPreReleaseRoles = new HashSet<(Guid UserId, Guid PublicationId, DateTime Created)>
+                var expectedPreReleaseRoles = new HashSet<(Guid UserId, Guid PublicationId, DateTimeOffset Created)>
                 {
                     // Existing roles
                     (user1.Id, releaseVersion1.Id, existingRoleCreatedDate),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationRoleRepositoryTests.cs
@@ -195,8 +195,8 @@ public abstract class UserPublicationRoleRepositoryTests
         [Fact]
         public async Task ManyRoles_IgnoresRolesThatAlreadyExist()
         {
-            var existingRoleCreatedDate = DateTime.UtcNow.AddDays(-2);
-            var newRolesCreatedDate = DateTime.UtcNow;
+            var existingRoleCreatedDate = DateTimeOffset.UtcNow.AddDays(-2);
+            var newRolesCreatedDate = DateTimeOffset.UtcNow;
             User createdBy = _fixture.DefaultUser();
 
             // Test across multiple User/Publication combinations
@@ -313,7 +313,12 @@ public abstract class UserPublicationRoleRepositoryTests
                     .Select(upr => (upr.UserId, upr.PublicationId, upr.Role, upr.Created))
                     .ToHashSet();
 
-                var expected = new HashSet<(Guid UserId, Guid PublicationId, PublicationRole Role, DateTime Created)>
+                var expected = new HashSet<(
+                    Guid UserId,
+                    Guid PublicationId,
+                    PublicationRole Role,
+                    DateTimeOffset Created
+                )>
                 {
                     // New roles
                     (user1.Id, publication3.Id, PublicationRole.Drafter, newRolesCreatedDate),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServiceTests.cs
@@ -106,7 +106,7 @@ public abstract class UserRoleServiceTests
                         publication.Id,
                         PublicationRole.Approver,
                         _user.Id,
-                        null,
+                        default,
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -196,7 +196,7 @@ public abstract class UserRoleServiceTests
                         It.IsAny<Guid>(),
                         It.IsAny<PublicationRole>(),
                         It.IsAny<Guid>(),
-                        It.IsAny<DateTime?>(),
+                        It.IsAny<DateTimeOffset>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Never
@@ -261,7 +261,7 @@ public abstract class UserRoleServiceTests
                         It.IsAny<Guid>(),
                         It.IsAny<PublicationRole>(),
                         It.IsAny<Guid>(),
-                        It.IsAny<DateTime?>(),
+                        It.IsAny<DateTimeOffset>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Never
@@ -326,7 +326,7 @@ public abstract class UserRoleServiceTests
                         It.IsAny<Guid>(),
                         It.IsAny<PublicationRole>(),
                         It.IsAny<Guid>(),
-                        It.IsAny<DateTime?>(),
+                        It.IsAny<DateTimeOffset>(),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Never
@@ -458,7 +458,7 @@ public abstract class UserRoleServiceTests
                         publication.Id,
                         PublicationRole.Drafter,
                         _user.Id,
-                        null,
+                        default,
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -628,7 +628,7 @@ public abstract class UserRoleServiceTests
                         publication.Id,
                         PublicationRole.Drafter,
                         _user.Id,
-                        null,
+                        default,
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -701,7 +701,7 @@ public abstract class UserRoleServiceTests
                         publication.Id,
                         PublicationRole.Drafter,
                         _user.Id,
-                        null,
+                        default,
                         It.IsAny<CancellationToken>()
                     )
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617180440_Ees7255ChangingResourceRoleCreatedToDateTimeOffset.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617180440_Ees7255ChangingResourceRoleCreatedToDateTimeOffset.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617180440_Ees7255ChangingResourceRoleCreatedToDateTimeOffset")]
+    partial class Ees7255ChangingResourceRoleCreatedToDateTimeOffset
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -430,6 +433,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("ScreeningStatus")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
 
                     b.Property<string>("UploadedBy")
                         .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617180440_Ees7255ChangingResourceRoleCreatedToDateTimeOffset.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260617180440_Ees7255ChangingResourceRoleCreatedToDateTimeOffset.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7255ChangingResourceRoleCreatedToDateTimeOffset : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "Created",
+                table: "UserPublicationRoles",
+                type: "datetimeoffset",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2"
+            );
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "Created",
+                table: "UserPreReleaseRoles",
+                type: "datetimeoffset",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "UserPublicationRoles",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "datetimeoffset"
+            );
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "UserPreReleaseRoles",
+                type: "datetime2",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "datetimeoffset"
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPreReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPreReleaseRoleRepository.cs
@@ -11,7 +11,7 @@ public interface IUserPreReleaseRoleRepository
         Guid userId,
         Guid releaseVersionId,
         Guid createdById,
-        DateTime? createdDate = null,
+        DateTimeOffset createdDate = default,
         CancellationToken cancellationToken = default
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserPublicationRoleRepository.cs
@@ -12,7 +12,7 @@ public interface IUserPublicationRoleRepository
         Guid publicationId,
         PublicationRole role,
         Guid createdById,
-        DateTime? createdDate = null,
+        DateTimeOffset createdDate = default,
         CancellationToken cancellationToken = default
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -231,7 +231,7 @@ public class UserManagementService(
                         userId: user.Id,
                         releaseVersionId: latestReleaseVersion!.Id,
                         createdById: userService.GetUserId(),
-                        createdDate: request.CreatedDate?.UtcDateTime
+                        createdDate: request.CreatedDate ?? default
                     );
                 }
 
@@ -240,7 +240,7 @@ public class UserManagementService(
                         UserId: user.Id,
                         PublicationId: userPublicationRole.PublicationId,
                         Role: userPublicationRole.PublicationRole,
-                        CreatedDate: request.CreatedDate?.UtcDateTime ?? DateTime.UtcNow,
+                        CreatedDate: request.CreatedDate ?? default,
                         CreatedById: userService.GetUserId()
                     ))
                     .ToHashSet();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPreReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPreReleaseRoleRepository.cs
@@ -14,17 +14,15 @@ public class UserPreReleaseRoleRepository(ContentDbContext contentDbContext) : I
         Guid userId,
         Guid releaseVersionId,
         Guid createdById,
-        DateTime? createdDate = null,
+        DateTimeOffset createdDate = default,
         CancellationToken cancellationToken = default
     )
     {
-        createdDate ??= createdDate?.ToUniversalTime() ?? DateTime.UtcNow;
-
         var newUserPreReleaseRole = new UserPreReleaseRole
         {
             UserId = userId,
             ReleaseVersionId = releaseVersionId,
-            Created = createdDate!.Value,
+            Created = createdDate,
             CreatedById = createdById,
         };
 
@@ -215,6 +213,6 @@ public class UserPreReleaseRoleRepository(ContentDbContext contentDbContext) : I
         Guid UserId,
         Guid ReleaseVersionId,
         Guid CreatedById,
-        DateTime? CreatedDate = null
+        DateTimeOffset CreatedDate = default
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
@@ -20,12 +20,10 @@ public class UserPublicationRoleRepository(
         Guid publicationId,
         PublicationRole role,
         Guid createdById,
-        DateTime? createdDate = null,
+        DateTimeOffset createdDate = default,
         CancellationToken cancellationToken = default
     )
     {
-        createdDate ??= createdDate?.ToUniversalTime() ?? DateTime.UtcNow;
-
         var existingUserPublicationRole = await Query(ResourceRoleFilter.All)
             .WhereForUser(userId)
             .WhereForPublication(publicationId)
@@ -65,7 +63,7 @@ public class UserPublicationRoleRepository(
             UserId = userId,
             PublicationId = publicationId,
             Role = publicationRoleToCreate.Value,
-            Created = createdDate!.Value,
+            Created = createdDate,
             CreatedById = createdById,
         };
 
@@ -271,6 +269,6 @@ public class UserPublicationRoleRepository(
         Guid PublicationId,
         PublicationRole Role,
         Guid CreatedById,
-        DateTime? CreatedDate = null
+        DateTimeOffset CreatedDate = default
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPreReleaseRoleGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPreReleaseRoleGeneratorExtensions.cs
@@ -41,7 +41,7 @@ public static class UserPreReleaseRoleGeneratorExtensions
 
     public static Generator<UserPreReleaseRole> WithCreated(
         this Generator<UserPreReleaseRole> generator,
-        DateTime created
+        DateTimeOffset created
     ) => generator.ForInstance(s => s.SetCreated(created));
 
     public static Generator<UserPreReleaseRole> WithCreatedBy(
@@ -60,11 +60,7 @@ public static class UserPreReleaseRoleGeneratorExtensions
     ) => generator.ForInstance(s => s.SetEmailSent(emailSent));
 
     public static InstanceSetters<UserPreReleaseRole> SetDefaults(this InstanceSetters<UserPreReleaseRole> setters) =>
-        setters
-            .SetDefault(uprr => uprr.Id)
-            .SetDefault(uprr => uprr.ReleaseVersionId)
-            .SetDefault(uprr => uprr.UserId)
-            .SetDefault(uprr => uprr.Created);
+        setters.SetDefault(uprr => uprr.Id).SetDefault(uprr => uprr.ReleaseVersionId).SetDefault(uprr => uprr.UserId);
 
     public static InstanceSetters<UserPreReleaseRole> SetReleaseVersion(
         this InstanceSetters<UserPreReleaseRole> setters,
@@ -88,7 +84,7 @@ public static class UserPreReleaseRoleGeneratorExtensions
 
     public static InstanceSetters<UserPreReleaseRole> SetCreated(
         this InstanceSetters<UserPreReleaseRole> setters,
-        DateTime created
+        DateTimeOffset created
     ) => setters.Set(uprr => uprr.Created, created);
 
     public static InstanceSetters<UserPreReleaseRole> SetCreatedBy(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPublicationRoleGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserPublicationRoleGeneratorExtensions.cs
@@ -56,7 +56,7 @@ public static class UserPublicationRoleGeneratorExtensions
 
     public static Generator<UserPublicationRole> WithCreated(
         this Generator<UserPublicationRole> generator,
-        DateTime created
+        DateTimeOffset created
     ) => generator.ForInstance(s => s.SetCreated(created));
 
     public static Generator<UserPublicationRole> WithCreatedBy(
@@ -79,7 +79,6 @@ public static class UserPublicationRoleGeneratorExtensions
             .SetDefault(upr => upr.Id)
             .SetDefault(upr => upr.PublicationId)
             .SetDefault(upr => upr.UserId)
-            .SetDefault(upr => upr.Created)
             .Set(upr => upr.Role, PublicationRole.Drafter);
 
     public static InstanceSetters<UserPublicationRole> SetPublication(
@@ -109,7 +108,7 @@ public static class UserPublicationRoleGeneratorExtensions
 
     public static InstanceSetters<UserPublicationRole> SetCreated(
         this InstanceSetters<UserPublicationRole> setters,
-        DateTime created
+        DateTimeOffset created
     ) => setters.Set(upr => upr.Created, created);
 
     public static InstanceSetters<UserPublicationRole> SetCreatedBy(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -644,11 +644,6 @@ public class ContentDbContext : DbContext
 
         modelBuilder
             .Entity<UserPublicationRole>()
-            .Property(upr => upr.Created)
-            .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
-
-        modelBuilder
-            .Entity<UserPublicationRole>()
             .HasOne(upr => upr.CreatedBy)
             .WithMany()
             .OnDelete(DeleteBehavior.NoAction);
@@ -666,11 +661,6 @@ public class ContentDbContext : DbContext
             .Entity<UserPreReleaseRole>()
             .HasIndex(uprr => new { uprr.UserId, uprr.ReleaseVersionId })
             .IsUnique();
-
-        modelBuilder
-            .Entity<UserPreReleaseRole>()
-            .Property(userReleaseRole => userReleaseRole.Created)
-            .HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
 
         modelBuilder
             .Entity<UserPreReleaseRole>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ResourceRole.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ResourceRole.cs
@@ -1,9 +1,10 @@
 #nullable enable
 using System.ComponentModel.DataAnnotations.Schema;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
-public abstract class ResourceRole<TResource>
+public abstract class ResourceRole<TResource> : ICreatedTimestamp<DateTimeOffset>
     where TResource : class
 {
     public Guid Id { get; set; }
@@ -24,5 +25,5 @@ public abstract class ResourceRole<TResource>
 
     public User CreatedBy { get; set; } = null!;
 
-    public required DateTime Created { get; set; }
+    public DateTimeOffset Created { get; set; }
 }


### PR DESCRIPTION
In the backend, the `UserReleaseRole` & `UserPublicationRole` entities both inherit from `ResourceRole`.

`ResourceRole` has a field `public required DateTime Created { get; set; }`.

Currently, you must remember to set this yourself. We want to investigate if we can instead force `ResourceRole` to implement `ICreatedTimestamp<DateTimeOffset>` so that the field starts being automatically set, and is also migrated to be a `DateTimeOffset` to be more consistent with how we’ve started storing date-times in the DB.

At the moment, there are one or more robot tests which need to set this field. This is the reason why we have not thus-far enforced the `ResourceRole` to implement `ICreatedTimestamp<DateTimeOffset>`, and, instead, the code sets the field manually depending on whether or not a override value was provided. The only thing which would provide a specific override value for this is the robot tests.



**After the investigation, we found that it would be ideal to still allow the robot tests to set this value. However, we can still refactor the model/code so that it automatically sets it in the case where we don’t explicitly set it to something non-default - and that is the purpose of this work. We have also taken the opportunity to migrate the field type to `DateTimeOffset`**