### PR TITLE
EES-7256 Ensure associated DataSetMapping is deleted before deleting …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -90,12 +90,18 @@ public class ReleaseDataFileService(
                         await privateBlobStorageService.DeleteBlob(PrivateReleaseFiles, file.Path());
                         await privateBlobStorageService.DeleteBlob(PrivateReleaseFiles, metaFile.Path());
 
-                        // If this is a replacement then unlink it from the original
+                        // If this is a replacement then unlink it from the original and delete any mapping
                         if (file.ReplacingId.HasValue)
                         {
                             var originalFile = await fileRepository.Get(file.ReplacingId.Value);
                             originalFile.ReplacedById = null;
                             contentDbContext.Update(originalFile);
+
+                            var mappings = await contentDbContext
+                                .DataSetMappings.Where(map => map.ReplacementDataFileId == file.Id)
+                                .ToListAsync();
+                            contentDbContext.DataSetMappings.RemoveRange(mappings);
+
                             await contentDbContext.SaveChangesAsync();
                         }
 


### PR DESCRIPTION
…File

This PR fixes an issue where we were seeing the UI test teardown / theme deletion failing at the ends of runs due to the new DataSetMappings table entries preventing File entry deletions if it has a row associated with that File entry.

This PR adds the code to ensure any associated DataSetMappings entries are deleted before we remove a File entry.