### PR TITLE
EES-7067 - adding private endpoints to core and public SQL servers

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1240,6 +1240,8 @@
     "searchDocsFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs')]",
     "searchDocsFunctionAppPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs-pep')]",
     "searchStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-search-pep')]",
+    "sqlServerPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sqlsvr-pep')]",
+    "sqlServerPrivateEndpointsSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('sqlServerPrivateEndpointsSubnetName'))]",
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
     "eventGridCustomTopicPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-evgt-pep')]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
@@ -2980,6 +2982,107 @@
       }
     },
     {
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2024-06-01",
+      "name": "privatelink.database.windows.net",
+      "location": "global"
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2024-06-01",
+      "name": "[concat('privatelink.database.windows.net/', variables('vNetName'), '-database-vnetlink')]",
+      "location": "global",
+      "properties": {
+        "registrationEnabled": true,
+        "virtualNetwork": {
+          "id": "[variables('vNetRef')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.database.windows.net')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2025-07-01",
+      "name": "[concat(variables('coreSqlServerName'), '-pep')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "subnet": {
+          "id": "[variables('sqlServerPrivateEndpointsSubnetRef')]"
+        },
+        "privateLinkServiceConnections": [
+          {
+            "name": "[concat(variables('coreSqlServerName'), '-pep-conn')]",
+            "properties": {
+              "privateLinkServiceId": "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+              "groupIds": [
+                "sqlServer"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2025-07-01",
+      "name": "[concat(variables('coreSqlServerName'), '-pep', '/default')]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "privatelink-database-windows-net",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.database.windows.net')]"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateEndpoints', concat(variables('coreSqlServerName'), '-pep'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2025-07-01",
+      "name": "[concat(variables('publicSqlServerName'), '-pep')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "subnet": {
+          "id": "[variables('sqlServerPrivateEndpointsSubnetRef')]"
+        },
+        "privateLinkServiceConnections": [
+          {
+            "name": "[concat(variables('publicSqlServerName'), '-pep-conn')]",
+            "properties": {
+              "privateLinkServiceId": "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
+              "groupIds": [
+                "sqlServer"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2025-07-01",
+      "name": "[concat(variables('publicSqlServerName'), '-pep', '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateEndpoints', concat(variables('publicSqlServerName'), '-pep'))]"
+      ],
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "privatelink-database-windows-net",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.database.windows.net')]"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('notificationsStorageAccountName')]",
       "apiVersion": "2023-05-01",
@@ -4085,6 +4188,12 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "[variables('sqlServerPrivateEndpointsSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.23.0/24"
             }
           }
         ]


### PR DESCRIPTION
This PR:
- adds code to the ARM template to add private endpoints to both of our Azure SQL database servers, ahead of a follow-up PR to remove public access.

In order to do this, we:

1. Add a new subnet to allow our new private endpoints to be connected to our VNet.
2. Add a private DNS zone for Azure SQL so that DNS records of our SQL Servers can be added there (privateDnsZones).
3. Link the private DNS zone to our VNet so that our resources on the VNet can make use of its DNS records before going to other DNS resolution providers (privateDnsZones/virtualNetworkLinks).
4.  Add 2 private endpoints, one for each server, linked to the new subnet (privateEndpoints).
5. Link the 2 private endpoints to 2 private DNS zone groups so that their DNS records are added and updated automatically (privateEndpoints/privateDnsZoneGroups).

This creates the private endpoint links to the servers:

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/412725a0-cc9c-4d9c-9cb2-e9ea83f54c30" />

and

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/b6fc9c04-4382-4625-806c-0bf0c34d7178" />
