### PR TITLE
EES-7258 Enable public access to the Natural language search function app and update Health check URL

### DIFF
--- a/infrastructure/templates/common/components/function-app/functionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/functionApp.bicep
@@ -90,6 +90,13 @@ param privateEndpoints {
 @description('Specifies whether this Function App is accessible from the public internet.')
 param publicNetworkAccessEnabled bool = false
 
+@description('Specifies the \'Unmatched rule action\' for access restrictions if no rules are matched.')
+@allowed([
+  'Allow'
+  'Deny'
+])
+param ipSecurityRestrictionsDefaultAction string?
+
 @description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
 param functionAppFirewallRules FirewallRule[] = []
 
@@ -291,7 +298,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
       linuxFxVersion: operatingSystem == 'Linux' ? linuxFxVersion : null
       publicNetworkAccess: publicNetworkAccessEnabled ? 'Enabled' : 'Disabled'
       ipSecurityRestrictions: publicNetworkAccessEnabled && length(firewallRules) > 0 ? firewallRules : null
-      ipSecurityRestrictionsDefaultAction: 'Deny'
+      ipSecurityRestrictionsDefaultAction: ipSecurityRestrictionsDefaultAction
       scmIpSecurityRestrictions: [
         {
           ipAddress: 'Any'

--- a/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
+++ b/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
@@ -143,7 +143,7 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
       tier: 'ElasticPremium'
       family: 'EP'
     }
-    healthCheckPath: '/api/health_check'
+    healthCheckPath: '/health_check'
     operatingSystem: 'Linux'
     functionAppRuntime: 'python'
     linuxFxVersion: 'Python|3.14'

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -107,17 +107,7 @@ module nlSearchFunctionAppModule 'application/nlSearchFunctionApp.bicep' = if (d
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
     functionAppExists: naturalLanguageSearchFunctionAppExists
-    functionAppFirewallRules: union(
-      [
-        {
-          cidr: 'AzureCloud'
-          tag: 'ServiceTag'
-          priority: 101
-          name: 'AzureCloud'
-        }
-      ],
-      maintenanceFirewallRules
-    )
+    functionAppFirewallRules: []
     logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId
     searchServiceName: searchServiceModule.outputs.searchServiceName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName


### PR DESCRIPTION
This PR:

* Enables public access to the Natural language search function app deployed to the Dev environment to support local development.
* Updates the Health check URL from `/api/health_check` to `/health_check` to correspond with a change being made by https://github.com/dfe-analytical-services/ees-natural-language-search/pull/18.