### PR TITLE
EES-7115 - Work around character limit for Data factory pipeline name…

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -526,7 +526,7 @@
                       }
                     },
                     {
-                      "name": "Report error when pausing resumable index rebuilds 2",
+                      "name": "Report error when pausing resumable index rebuilds Teams",
                       "type": "WebActivity",
                       "dependsOn": [
                         {

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -526,7 +526,7 @@
                       }
                     },
                     {
-                      "name": "Report error when pausing resumable index rebuilds to Teams",
+                      "name": "Report error when pausing resumable index rebuilds 2",
                       "type": "WebActivity",
                       "dependsOn": [
                         {


### PR DESCRIPTION
This PR adds a quick work around a for a character limit (80) which is imposed on the name of data factory pipeline 'Report error when pausing resumable index rebuilds to Teams' by renaming it to 'Report error when pausing resumable index rebuilds Teams' which falls under the 80 characters limit. 

This is the error Azure Data Factory trigger runs has thrown:
"Triggering Pipeline pl_rebuild_statistics_indexes failed with Error ErrorCode=InvalidWorkflowRunActionName, ErrorMessage=Activity 'Report error when pausing resumable index rebuilds to TeamsComposeRuntimeVariables' has a length of '82' which exceeds the maximum limit of '80'.." 