### PR TITLE
EES-7259 Prevent DataSetMapping generation if replacement inds/locs c…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -175,6 +175,19 @@ public class DataSetMappingServiceTests
             Indicators = [replacementIndicatorA4],
         };
 
+        var replacementLocation = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Country,
+            Country = new Country("E0200000", "England"),
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementSubjectId,
+            Location = replacementLocation,
+        };
+
         var statisticsDbContextId = Guid.NewGuid().ToString();
         await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
         {
@@ -183,6 +196,7 @@ public class DataSetMappingServiceTests
                 replacementIndicatorGroupA,
                 replacementIndicatorGroupB
             );
+            statisticsDbContext.Observation.Add(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -272,7 +286,15 @@ public class DataSetMappingServiceTests
                 ],
             };
 
-            result.AssertDeepEqualTo(expectedMapping, ignoreProperties: [mapping => mapping.Id]);
+            result.AssertDeepEqualTo(
+                expectedMapping,
+                ignoreProperties:
+                [
+                    mapping => mapping.Id,
+                    mapping => mapping.LocationMappings,
+                    mapping => mapping.UnmappedReplacementLocations,
+                ]
+            );
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -172,10 +172,28 @@ public class ReplacementPlanServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Indicators = [new Indicator()],
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
+            statisticsDbContext.IndicatorGroup.Add(replacementIndicatorGroup);
+            statisticsDbContext.Observation.Add(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -307,6 +325,12 @@ public class ReplacementPlanServiceTests
             Location = originalLocation,
         };
 
+        var replacementObservationForLocation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location { GeographicLevel = GeographicLevel.LocalAuthority, LocalAuthority = _derby },
+        };
+
         var timePeriod = new TimePeriodQuery
         {
             StartYear = 2019,
@@ -395,7 +419,7 @@ public class ReplacementPlanServiceTests
                 footnoteForSubject
             );
             statisticsDbContext.Location.AddRange(originalLocation);
-            statisticsDbContext.Observation.AddRange(observationForOriginalLocation);
+            statisticsDbContext.Observation.AddRange(observationForOriginalLocation, replacementObservationForLocation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -710,6 +734,13 @@ public class ReplacementPlanServiceTests
             Location = location,
         };
 
+        var replacementObservationForLocation = new Observation
+        {
+            Id = Guid.NewGuid(),
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = location,
+        };
+
         var timePeriod = new TimePeriodQuery
         {
             StartYear = 2019,
@@ -763,7 +794,7 @@ public class ReplacementPlanServiceTests
             statisticsDbContext.Filter.AddRange(originalDefaultFilter, replacementDefaultFilter);
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
             statisticsDbContext.Location.AddRange(location);
-            statisticsDbContext.Observation.AddRange(observationForLocation);
+            statisticsDbContext.Observation.AddRange(observationForLocation, replacementObservationForLocation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -898,6 +929,13 @@ public class ReplacementPlanServiceTests
             Location = location,
         };
 
+        var replacementLocationObservation = new Observation
+        {
+            Id = Guid.NewGuid(),
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = location,
+        };
+
         var timePeriod = new TimePeriodQuery
         {
             StartYear = 2019,
@@ -951,7 +989,7 @@ public class ReplacementPlanServiceTests
             statisticsDbContext.Filter.AddRange(originalDefaultFilter, replacementDefaultFilter);
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
             statisticsDbContext.Location.AddRange(location);
-            statisticsDbContext.Observation.AddRange(observationForLocation);
+            statisticsDbContext.Observation.AddRange(observationForLocation, replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -1105,6 +1143,13 @@ public class ReplacementPlanServiceTests
             Location = location,
         };
 
+        var replacementObservationForLocation = new Observation
+        {
+            Id = Guid.NewGuid(),
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = location,
+        };
+
         var timePeriod = new TimePeriodQuery
         {
             StartYear = 2019,
@@ -1162,7 +1207,7 @@ public class ReplacementPlanServiceTests
             );
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
             statisticsDbContext.Location.AddRange(location);
-            statisticsDbContext.Observation.AddRange(observationForLocation);
+            statisticsDbContext.Observation.AddRange(observationForLocation, replacementObservationForLocation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -1537,6 +1582,29 @@ public class ReplacementPlanServiceTests
             contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
             // because we're not adding a contentDbContext.DataSetMapping entry, one will be automatically generated
             await contentDbContext.SaveChangesAsync();
+        }
+
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            Subject = replacementReleaseSubject.Subject,
+            Indicators = [new Indicator()],
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            Subject = replacementReleaseSubject.Subject,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.IndicatorGroup.Add(replacementIndicatorGroup);
+            statisticsDbContext.Observation.Add(replacementLocationObservation);
+            await statisticsDbContext.SaveChangesAsync();
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -153,11 +153,29 @@ public class ReplacementServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Indicators = [new Indicator()],
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.Location.AddRange(originalLocation);
+            statisticsDbContext.IndicatorGroup.AddRange(replacementIndicatorGroup);
+            statisticsDbContext.Observation.AddRange(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -693,6 +711,29 @@ public class ReplacementServiceTests
             contentDbContext.DataImports.Add(replacementDataImport);
             // because we're not adding a contentDbContext.DataSetMapping entry, one will be automatically generated
             await contentDbContext.SaveChangesAsync();
+        }
+
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Indicators = [new Indicator()],
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.IndicatorGroup.AddRange(replacementIndicatorGroup);
+            statisticsDbContext.Observation.AddRange(replacementLocationObservation);
+            await statisticsDbContext.SaveChangesAsync();
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2121,6 +2162,16 @@ public class ReplacementServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
@@ -2128,6 +2179,7 @@ public class ReplacementServiceTests
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.Filter.AddRange(originalFilter1, replacementFilter1);
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
+            statisticsDbContext.Observation.AddRange(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -2325,12 +2377,30 @@ public class ReplacementServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Indicators = [new Indicator()],
+        };
+
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.Filter.AddRange(originalFilters);
             statisticsDbContext.Filter.AddRange(replacementFilters);
+            statisticsDbContext.IndicatorGroup.AddRange(replacementIndicatorGroup);
+            statisticsDbContext.Observation.AddRange(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -2522,6 +2592,16 @@ public class ReplacementServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
+        var replacementLocationObservation = new Observation
+        {
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Location = new Location
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Country = new Country("E0200000", "England"),
+            },
+        };
+
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
@@ -2529,6 +2609,7 @@ public class ReplacementServiceTests
             statisticsDbContext.IndicatorGroup.AddRange(originalGroups);
             statisticsDbContext.IndicatorGroup.AddRange(replacementGroups);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
+            statisticsDbContext.Observation.AddRange(replacementLocationObservation);
             await statisticsDbContext.SaveChangesAsync();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -44,20 +44,6 @@ public class DataSetMappingService(
                 cancellationToken
             );
 
-        // TODO EES-7126 Remove this code - it was only needed when first introducing LocationMappings to ensure they were set
-        if (mapping.LocationMappings.IsNullOrEmpty() && mapping.UnmappedReplacementLocations.IsNullOrEmpty())
-        {
-            var (initialLocationMappingDictionary, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
-                originalSubjectId,
-                replacementSubjectId,
-                cancellationToken
-            );
-
-            mapping.LocationMappings = initialLocationMappingDictionary;
-            mapping.UnmappedReplacementLocations = unmappedReplacementLocations;
-            await contentDbContext.SaveChangesAsync(cancellationToken);
-        }
-
         return mapping;
     }
 
@@ -112,6 +98,11 @@ public class DataSetMappingService(
             .Indicator.Include(i => i.IndicatorGroup)
             .Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
             .ToDictionaryAsync(i => i.Name, i => i, cancellationToken);
+
+        if (replacementIndicatorNameToIndicatorMap.IsNullOrEmpty())
+        {
+            throw new Exception($"Replacement data set should have indicators. SubjectId: {replacementSubjectId}");
+        }
 
         var initialMappingDictionary = originalIndicators.ToDictionary(
             originalIndicator => originalIndicator.Id,
@@ -187,6 +178,11 @@ public class DataSetMappingService(
             .Select(observation => observation.Location)
             .Distinct()
             .ToDictionaryAsync(location => location.Id, location => location, cancellationToken);
+
+        if (replacementLocationMap.IsNullOrEmpty())
+        {
+            throw new Exception($"Replacement data set should have locations. SubjectId: {replacementSubjectId}");
+        }
 
         var initialMappingDictionary = originalLocations.ToDictionary(
             originalLocation => originalLocation.Id,


### PR DESCRIPTION
…annot be found

This is a semi-speculative fix attempt as we saw an issue where a DataSetMapping entry was created that didn't contain any indicators/locations for the replacement data set. We haven't managed to recreate this, so we're not certain why this happened, but our working theory is that the DataSetMapping entry was generated before the replacement data set had finished importing.

EES-7150 will fix this issue more completely, but until then this PR aims to prevent users getting into an unrecoverable situation by preventing the DataSetMappings entries from being generated if no indicators/locations are found.

Rather than spend further time investigating something that would be quick to fix if it happened and delay the next deploy, I decided it's better to save time and deploy this semi-speculative fix.

### Other changes

- I've removed the code that checks that all DataSetMappings have locations set correctly - this code was included for when those columns were originally introduced, but given how we delete all mappings in the next migration, this is no longer necessary.