### PR TITLE
EES-7252: Add package source command to build pipeline

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -69,6 +69,13 @@ jobs:
           version: $(DotNetVersion)
           performMultiLevelLookup: true
 
+      - task: DotNetCoreCLI@2
+        displayName: Add GitHub package source
+        inputs:
+          command: nuget
+          nuget: add source
+          arguments: --name $(GitHubPackageSourceName) --source $(GitHubPackageSourceUrl) --username $(GitHubPackageSourceUsername) --password $(GitHubPackageSourcePassword)
+
       # Check code formatting
       - task: DotNetCoreCLI@2
         displayName: Restore .NET tools


### PR DESCRIPTION
The pipeline is failing to build due to the new GitHub source being inaccessible, this PR adds the source via the dotnet CLI.