### PR TITLE
EES-XXXX - upping stats db sizes on environments where capacity is low

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -114,7 +114,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 644245094400
+      "value": 1099511627776
     },
     "dataFactoryConcurrency": {
       "value": 10

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -93,7 +93,7 @@
       "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
-      "value": 805306368000
+      "value": 1099511627776
     },
     "publisherFunctionPrepareScheduledReleaseVersionsNowEnabled": {
       "value": true

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -99,7 +99,7 @@
       "value": 4294967296
     },
     "maxStatsDbSizeBytes": {
-      "value": 2748779069440
+      "value": 3298534883328
     }
   }
 }


### PR DESCRIPTION
This PR:
- ups Dev's stats db to 1024Gi
- ups Pre-Prod's stats db to 1024Gi
- ups Prod's stats db to 3052Gi