### PR TITLE
EES-6963 - separating weekday and weekend data factory runs for rebuilding indexes

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -81,7 +81,7 @@
             "type": "SqlServerStoredProcedure",
             "dependsOn": [],
             "policy": {
-              "timeout": "0.06:00:00",
+              "timeout": "@pipeline().parameters.ActivityTimeout",
               "retry": 0,
               "retryIntervalInSeconds": 30,
               "secureOutput": false,
@@ -857,6 +857,10 @@
           "Tables": {
             "type": "string",
             "defaultValue": "[variables('fragmentationTables')]"
+          },
+          "ActivityTimeout": {
+            "type": "string",
+            "defaultValue": "0.06:00:00"
           }
         },
         "variables": {
@@ -1250,14 +1254,15 @@
               "type": "PipelineReference"
             },
             "parameters": {
-              "Tables": "[variables('fragmentationTables')]"
+              "Tables": "[variables('fragmentationTables')]",
+              "ActivityTimeout": "0.06:00:00"
             }
           }
         ],
         "type": "ScheduleTrigger",
         "typeProperties": {
           "recurrence": {
-            "frequency": "Day",
+            "frequency": "Week",
             "interval": 1,
             "startTime": "2023-03-03T02:00:00",
             "timeZone": "GMT Standard Time",
@@ -1267,6 +1272,56 @@
               ],
               "minutes": [
                 0
+              ],
+              "weekDays": [
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday"
+              ]
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[concat(variables('factoryId'), '/pipelines/pl_rebuild_statistics_indexes')]"
+      ]
+    },
+    {
+      "name": "[concat(parameters('factoryName'), '/rebuild_indexes_weekend_trigger')]",
+      "type": "Microsoft.DataFactory/factories/triggers",
+      "apiVersion": "2018-06-01",
+      "properties": {
+        "annotations": [],
+        "runtimeState": "Stopped",
+        "pipelines": [
+          {
+            "pipelineReference": {
+              "referenceName": "pl_rebuild_statistics_indexes",
+              "type": "PipelineReference"
+            },
+            "parameters": {
+              "Tables": "[variables('fragmentationTables')]",
+              "ActivityTimeout": "2.06:00:00"
+            }
+          }
+        ],
+        "type": "ScheduleTrigger",
+        "typeProperties": {
+          "recurrence": {
+            "frequency": "Week",
+            "interval": 1,
+            "startTime": "2023-03-03T02:00:00",
+            "timeZone": "GMT Standard Time",
+            "schedule": {
+              "hours": [
+                2
+              ],
+              "minutes": [
+                0
+              ],
+              "weekDays": [
+                "Saturday"
               ]
             }
           }


### PR DESCRIPTION
This PR amends the rebuild indexes schedule to:
- run its standard out-of-office-hours rebuilds from 2am to 8am Tuesday to Friday
- run a long-running activity over the weekend from 2am Saturday morning to 8am Monday morning.

:warning: As part of this work, a new trigger has been defined.  As such, a faffy task will accompany this ticket to manually add "stop" and "start" jobs to the Inf Release pipeline to ensure the triggers are stopped during deployments, as out other 2 currently are.

## The work

1. A new "ActivityTimeout" parameter has been added to the "Rebuild indexes" pipeline.  It uses this to control the maximum run time for the main indexing activity.
2. The existing trigger has been updated to supply "6 hours" for the "ActivityTimeout".
3. The existing trigger has been updated to run on Tuesday, Wednesday, Thursday and Friday only at 2am for 6 hours.
4. A new trigger has been added which only runs on Saturday at 2am, but runs for 2 days and 6 hours, thus finishing at 8am on Monday, ready for office hours.

## The new trigger

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/c0fa3c78-111c-468c-b84c-18c87f6e582b" />

A "Start" task in our Inf Release pipeline will get this to start.

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/757a7ba3-aa1c-45dd-aafb-239c26968d68" />

Note that "2:04" is actually "2:06" - just an old screenshot!

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/a6e8b2ce-122f-4f6c-a309-2791a456f1d5" />

## The existing trigger

Note these screenshots are slightly out of date, as the trigger doesn't fire on Mondays now.

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/971e7771-d441-4160-a3a3-6a6759a3ba6a" />

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/a15b59dd-4b6b-4f8e-9a17-c030ce551bb9" />


