### PR TITLE
EES-6710 EES-7252 Add more NuGet config

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -109,6 +109,10 @@ jobs:
     workspace:
       clean: all
     steps:
+      - task: NuGetAuthenticate@1
+        inputs:
+          nuGetServiceConnections: $(NuGetServiceConnectionName)
+
       - task: UseDotNet@2
         displayName: Install .NET $(DotNetVersion)
         inputs:
@@ -130,6 +134,10 @@ jobs:
     pool:
       vmImage: ubuntu-22.04
     steps:
+      - task: NuGetAuthenticate@1
+        inputs:
+          nuGetServiceConnections: $(NuGetServiceConnectionName)
+
       - task: UseDotNet@2
         displayName: Install .NET $(DotNetVersion)
         inputs:
@@ -303,6 +311,10 @@ jobs:
           workingDir: .
           targetType: inline
           script: corepack enable
+
+      - task: NuGetAuthenticate@1
+        inputs:
+          nuGetServiceConnections: $(NuGetServiceConnectionName)
 
       - task: UseDotNet@2
         displayName: Install .NET $(DotNetVersion)

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="dfe-analytical-services-github" value="https://nuget.pkg.github.com/dfe-analytical-services/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This PR builds on the change already made by @tomjonesdev in #7085, in an attempt to get the #7060 PR building in the Azure DevOps pipeline.

- It adds the dfe-analytical-services GitHub Packages as a source to `nuget.config`.
- It adds additional `NuGetAuthenticate` build tasks before each `UseDotNet` task.

I also checked that I can build the solution with the changes in #7060 locally ✅ .