### PR TITLE
EES-7076 - removing ARM template section left in error

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2772,30 +2772,6 @@
       }
     },
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2023-07-01",
-      "name": "conditionalFirewallDeployment",
-      "condition": "[and(equals(parameters('sqlServerPublicNetworkAccess'), 'Enabled'), parameters('useSubnets'))]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
-      ],
-      "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[uri(deployment().properties.templateLink.uri, 'db-firewall-template.json')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "sqlServerName": {
-            "value": "[variables('coreSqlServerName')]"
-          },
-          "firewallRules": {
-            "value": "[parameters('sqlFirewallRules')]"
-          }
-        }
-      }
-    },
-    {
       "type": "Microsoft.Sql/servers/firewallRules",
       "name": "[concat(variables('coreSqlServerName'), '/', parameters('sqlFirewallRules')[copyIndex()].IPRangeName)]",
       "condition": "[and(equals(parameters('sqlServerPublicNetworkAccess'), 'Enabled'), parameters('useSubnets'))]",


### PR DESCRIPTION
This PR:
- removes a bit of ARM template change that was left behind in error whilst doing the work to allow Azure SQL databases to be made private.