### PR TITLE
EES-6963 - removed unsupported dynamic activity timeout and replaced with IfCondition

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -149,7 +149,7 @@
       "value": true
     },
     "sqlServerPublicNetworkAccess": {
-      "value": "Disabled"
+      "value": "Enabled"
     }
   }
 }

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -78,35 +78,207 @@
         "activities": [
           {
             "name": "Rebuild indexes",
-            "type": "SqlServerStoredProcedure",
+            "type": "IfCondition",
             "dependsOn": [],
-            "policy": {
-              "timeout": "@pipeline().parameters.ActivityTimeout",
-              "retry": 0,
-              "retryIntervalInSeconds": 30,
-              "secureOutput": false,
-              "secureInput": false
-            },
-            "userProperties": [],
             "typeProperties": {
-              "storedProcedureName": "[[dbo].[RebuildIndexes]",
-              "storedProcedureParameters": {
-                "Tables": {
-                  "value": {
-                    "value": "@pipeline().parameters.Tables",
-                    "type": "Expression"
+              "expression": {
+                "value": "@equals(pipeline().parameters.RunMode, 'Weekend')",
+                "type": "Expression"
+              },
+              "ifTrueActivities": [
+                {
+                  "name": "Rebuild indexes - weekend",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.23:45:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
                   },
-                  "type": "String"
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[[dbo].[RebuildIndexes]",
+                    "storedProcedureParameters": {
+                      "Tables": {
+                        "value": {
+                          "value": "@pipeline().parameters.Tables",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "ls_sql_statistics",
+                    "type": "LinkedServiceReference"
+                  }
+                },
+                {
+                  "name": "Get reason for index rebuild failure - weekend",
+                  "type": "SetVariable",
+                  "dependsOn": [
+                    {
+                      "activity": "Rebuild indexes - weekend",
+                      "dependencyConditions": [
+                        "Failed"
+                      ]
+                    }
+                  ],
+                  "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "variableName": "storedProcedureActivityFailure",
+                    "value": {
+                      "value": "@coalesce(\n  activity('Rebuild indexes - weekend').error.errorCode,\n  activity('Rebuild indexes - weekend').error.message,\n  'Unknown'\n)",
+                      "type": "Expression"
+                    }
+                  }
+                },
+                {
+                  "name": "Get index rebuild failure message - weekend",
+                  "type": "SetVariable",
+                  "dependsOn": [
+                    {
+                      "activity": "Get reason for index rebuild failure - weekend",
+                      "dependencyConditions": [
+                        "Succeeded"
+                      ]
+                    }
+                  ],
+                  "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "variableName": "storedProcedureActivityFailureMessage",
+                    "value": {
+                      "value": "@activity('Rebuild indexes - weekend').error.message",
+                      "type": "Expression"
+                    }
+                  }
+                },
+                {
+                  "name": "Fail Rebuild indexes - weekend",
+                  "type": "Fail",
+                  "dependsOn": [
+                    {
+                      "activity": "Get index rebuild failure message - weekend",
+                      "dependencyConditions": [
+                        "Succeeded"
+                      ]
+                    }
+                  ],
+                  "typeProperties": {
+                    "message": "Weekend Index Rebuild failed",
+                    "errorCode": "500"
+                  }
                 }
-              }
-            },
-            "linkedServiceName": {
-              "referenceName": "ls_sql_statistics",
-              "type": "LinkedServiceReference"
+              ],
+              "ifFalseActivities": [
+                {
+                  "name": "Rebuild indexes - weekday",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.09:30:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[[dbo].[RebuildIndexes]",
+                    "storedProcedureParameters": {
+                      "Tables": {
+                        "value": {
+                          "value": "@pipeline().parameters.Tables",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "ls_sql_statistics",
+                    "type": "LinkedServiceReference"
+                  }
+                },
+                {
+                  "name": "Get reason for index rebuild failure - weekday",
+                  "type": "SetVariable",
+                  "dependsOn": [
+                    {
+                      "activity": "Rebuild indexes - weekday",
+                      "dependencyConditions": [
+                        "Failed"
+                      ]
+                    }
+                  ],
+                  "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "variableName": "storedProcedureActivityFailure",
+                    "value": {
+                      "value": "@coalesce(\n  activity('Rebuild indexes - weekday').error.errorCode,\n  activity('Rebuild indexes - weekday').error.message,\n  'Unknown'\n)",
+                      "type": "Expression"
+                    }
+                  }
+                },
+                {
+                  "name": "Get index rebuild failure message - weekday",
+                  "type": "SetVariable",
+                  "dependsOn": [
+                    {
+                      "activity": "Get reason for index rebuild failure - weekday",
+                      "dependencyConditions": [
+                        "Succeeded"
+                      ]
+                    }
+                  ],
+                  "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "variableName": "storedProcedureActivityFailureMessage",
+                    "value": {
+                      "value": "@activity('Rebuild indexes - weekday').error.message",
+                      "type": "Expression"
+                    }
+                  }
+                },
+                {
+                  "name": "Fail Rebuild indexes - weekday",
+                  "type": "Fail",
+                  "dependsOn": [
+                    {
+                      "activity": "Get index rebuild failure message - weekday",
+                      "dependencyConditions": [
+                        "Succeeded"
+                      ]
+                    }
+                  ],
+                  "typeProperties": {
+                    "message": "Weekday Index Rebuild failed",
+                    "errorCode": "500"
+                  }
+                }
+              ]
             }
           },
           {
-            "name": "Report indexes rebuilt successfully",
+            "name": "Report reindex success",
             "type": "WebActivity",
             "dependsOn": [
               {
@@ -160,7 +332,7 @@
             }
           },
           {
-            "name": "Report indexes rebuilt successfully to Teams",
+            "name": "Report reindex success to Teams",
             "type": "WebActivity",
             "dependsOn": [
               {
@@ -228,38 +400,14 @@
             }
           },
           {
-            "name": "Get reason for index rebuild failure",
-            "type": "SetVariable",
-            "dependsOn": [
-              {
-                "activity": "Rebuild indexes",
-                "dependencyConditions": [
-                  "Failed"
-                ]
-              }
-            ],
-            "policy": {
-              "secureOutput": false,
-              "secureInput": false
-            },
-            "userProperties": [],
-            "typeProperties": {
-              "variableName": "storedProcedureActivityFailure",
-              "value": {
-                "value": "@coalesce(\n  activity('Rebuild indexes').error.errorCode,\n  activity('Rebuild indexes').error.message,\n  'Unknown'\n)",
-                "type": "Expression"
-              }
-            }
-          },
-          {
             "name": "Choose how to handle rebuild indexes failure",
             "description": "This activity routes to the appropriate error handler based on the reason for the 'Rebuild indexes' activity's reason for failure",
             "type": "Switch",
             "dependsOn": [
               {
-                "activity": "Get reason for index rebuild failure",
+                "activity": "Rebuild indexes",
                 "dependencyConditions": [
-                  "Succeeded"
+                  "Failed"
                 ]
               }
             ],
@@ -335,7 +483,7 @@
                       }
                     },
                     {
-                      "name": "Report timeout handled successfully",
+                      "name": "Report successful timeout",
                       "description": "Messages Slack to inform that the timeout has been handled successfully",
                       "type": "WebActivity",
                       "dependsOn": [
@@ -395,7 +543,7 @@
                       }
                     },
                     {
-                      "name": "Report timeout handled successfully to Teams",
+                      "name": "Report successful timeout to Teams",
                       "type": "WebActivity",
                       "dependsOn": [
                         {
@@ -467,7 +615,7 @@
                       }
                     },
                     {
-                      "name": "Report error when pausing resumable index rebuilds",
+                      "name": "Report rebuild pause error",
                       "type": "WebActivity",
                       "dependsOn": [
                         {
@@ -526,7 +674,7 @@
                       }
                     },
                     {
-                      "name": "Report error when pausing resumable index rebuilds Teams",
+                      "name": "Report rebuild pause error to Teams",
                       "type": "WebActivity",
                       "dependsOn": [
                         {
@@ -598,7 +746,7 @@
                       }
                     },
                     {
-                      "name": "Report error when killing index reorganizations",
+                      "name": "Report index reorganization kill error",
                       "type": "WebActivity",
                       "dependsOn": [
                         {
@@ -657,7 +805,7 @@
                       }
                     },
                     {
-                      "name": "Report error when killing index reorganizations to Teams",
+                      "name": "Report index reorganization kill error to Teams",
                       "type": "WebActivity",
                       "dependsOn": [
                         {
@@ -770,7 +918,7 @@
                             },
                             {
                               "title": "Error",
-                              "value": "@{activity('Rebuild indexes').Error.message}",
+                              "value": "@variables('storedProcedureActivityFailureMessage')",
                               "short": true
                             },
                             {
@@ -834,7 +982,7 @@
                                   },
                                   {
                                     "title": "Error",
-                                    "value": "@{activity('Rebuild indexes').Error.message}"
+                                    "value": "@variables('storedProcedureActivityFailureMessage')"
                                   },
                                   {
                                     "title": "Duration",
@@ -858,14 +1006,17 @@
             "type": "string",
             "defaultValue": "[variables('fragmentationTables')]"
           },
-          "ActivityTimeout": {
+          "RunMode": {
             "type": "string",
-            "defaultValue": "0.06:00:00"
+            "defaultValue": "Weekday"
           }
         },
         "variables": {
           "storedProcedureActivityFailure": {
-            "type": "String"
+            "type": "string"
+          },
+          "storedProcedureActivityFailureMessage": {
+            "type": "string"
           }
         },
         "annotations": [],
@@ -1255,7 +1406,7 @@
             },
             "parameters": {
               "Tables": "[variables('fragmentationTables')]",
-              "ActivityTimeout": "0.06:00:00"
+              "RunMode": "Weekday"
             }
           }
         ],
@@ -1268,16 +1419,17 @@
             "timeZone": "GMT Standard Time",
             "schedule": {
               "hours": [
-                2
+                22
               ],
               "minutes": [
-                0
+                30
               ],
               "weekDays": [
+                "Sunday",
+                "Monday",
                 "Tuesday",
                 "Wednesday",
-                "Thursday",
-                "Friday"
+                "Thursday"
               ]
             }
           }
@@ -1302,7 +1454,7 @@
             },
             "parameters": {
               "Tables": "[variables('fragmentationTables')]",
-              "ActivityTimeout": "2.06:00:00"
+              "RunMode": "Weekend"
             }
           }
         ],
@@ -1315,12 +1467,13 @@
             "timeZone": "GMT Standard Time",
             "schedule": {
               "hours": [
-                2
+                22
               ],
               "minutes": [
-                0
+                30
               ],
               "weekDays": [
+                "Friday",
                 "Saturday"
               ]
             }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2772,30 +2772,6 @@
       }
     },
     {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2023-07-01",
-      "name": "conditionalFirewallDeployment",
-      "condition": "[and(equals(parameters('sqlServerPublicNetworkAccess'), 'Enabled'), parameters('useSubnets'))]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
-      ],
-      "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[uri(deployment().properties.templateLink.uri, 'db-firewall-template.json')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "sqlServerName": {
-            "value": "[variables('coreSqlServerName')]"
-          },
-          "firewallRules": {
-            "value": "[parameters('sqlFirewallRules')]"
-          }
-        }
-      }
-    },
-    {
       "type": "Microsoft.Sql/servers/firewallRules",
       "name": "[concat(variables('coreSqlServerName'), '/', parameters('sqlFirewallRules')[copyIndex()].IPRangeName)]",
       "condition": "[and(equals(parameters('sqlServerPublicNetworkAccess'), 'Enabled'), parameters('useSubnets'))]",


### PR DESCRIPTION
This PR:
- replaces unsupported parameterised Data Factory Activity timeout with IfCondition.
- shortens some activity names that were too long to be valid.
- re-enables public access to the Azure SQL databases for now, as Data Factory is not using its private endpoints successsfully currently.

## Swapping parameter for IfCondition

Previously I'd tried to support 2 schedules for the Rebuild Indexes pipeline by parameterising the Activity timeout and passing in 2 different values for a weekday and a weekend trigger.  This turned out not to be possible unfortunately upon testing.

Instead, we now have a `RunType` parameter that is passed either "Weekend" or "Weekday" and this is evaluated within an IfCondition Activity to determine the correct Activity timeout, and run the "Rebuild Indexes - weekend" or "Rebuild Indexes - weekday" activities as inner activities of the IfCondition.

If the "Rebuild Indexes - xxx" inner activity fails, we need to get the reason and the message out of the IfCondition activity so that subsequent outer activities can use those values, and so we capture the failure reason in variables and then fail the overall IfCondition activity so the outer ones can determine what to do with the failure (e.g. real failure, or just activity timeout).

## Altering schedule to get even more run time

This PR also alters the schedule of the pipeline to get even more time out of it.  We now run it on the following schedule:

* Monday 1030pm to Tuesday 8am
* Tuesday 1030pm to Wednesday 8am
* Wednesday 1030pm to Thursday 8am
* Thursday 1030pm to Friday 8am
* Friday 1030pm to *Saturday 1015pm*
* Saturday 1030pm to *Sunday 1015pm*
* Sunday 1030pm to Monday 8am

This provides more than 60 additional hours of run time per week to help towards clearing our indexes.

Originally I had the activity running solidly from 1030pm Friday to 8am Monday, but chose to break it down into 3 stages instead so that if any transient failure occurred during any of the 3 stages, it would get a chance to run some of the other stages over the weekend instead.

  