### PR TITLE
EES-7264 - fix azure rewriting of empty delete requests

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -145,9 +145,6 @@
     "datasetsSearchIndexName": {
       "value": "nl-search-dataset-index"
     },
-    "enhancedScreenerJourney": {
-      "value": true
-    },
     "sqlServerPublicNetworkAccess": {
       "value": "Enabled"
     }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -754,7 +754,7 @@
     },
     "enhancedScreenerJourney": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
         "description": "Whether or not Admin supports the background screening process"
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
@@ -228,6 +228,7 @@ public class DataSetScreenerClientTests
             _mockHttp
                 .Expect(HttpMethod.Delete, $"{BaseUri.AbsoluteUri}/progress-and-completion-files")
                 .WithQueryString($"data_set_id={dataSetIds[0]}&data_set_id={dataSetIds[1]}")
+                .WithContent("{}")
                 .Respond(HttpStatusCode.NoContent);
 
             var dataSetScreenerClient = BuildService();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
@@ -98,7 +98,15 @@ public class DataSetScreenerClient(
         dataSetIds.ForEach(dataSetId => query.Add("data_set_id", dataSetId.ToString()));
 
         var url = $"{httpClient.BaseAddress}/progress-and-completion-files?{query}";
-        var response = await httpClient.DeleteAsync(url, cancellationToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+
+        // Add a dummy empty body to prevent Azure from rewriting the empty DELETE request into a
+        // request with the "Transfer-Encoding: chunked" header set, which the Azure Functions Host
+        // can't handle.
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {


### PR DESCRIPTION
This PR:
- fixes an issue with Admin sending DELETE requests to Screener API, where Azure was rewriting the request headers into an incompatible configuration for the Azure Function Host to handle.
- enables background screening in all environments.

## The problem

App Insights was complaining of regular 500 errors from the Screener API.  The cause was:

```
2026-06-22T06:36:01.3097261Z info: Function.function_delete_progress_and_completion_files[1]
2026-06-22T06:36:01.3097456Z       Executing 'Functions.function_delete_progress_and_completion_files' (Reason='This function was programmatically called via the host APIs.', Id=bd1cca0d-098e-4070-ac7d-792508861a71)
2026-06-22T06:36:01.3122957Z fail: Function.function_delete_progress_and_completion_files[3]
2026-06-22T06:36:01.3123114Z       Executed 'Functions.function_delete_progress_and_completion_files' (Failed, Id=bd1cca0d-098e-4070-ac7d-792508861a71, Duration=2ms)
2026-06-22T06:36:01.3127483Z       Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Functions.function_delete_progress_and_completion_files
2026-06-22T06:36:01.3127565Z        ---> System.Net.Http.HttpRequestException: An error occurred while sending the request.
2026-06-22T06:36:01.3127599Z        ---> System.InvalidOperationException: 'Transfer-Encoding: chunked' header can not be used when content object is not specified.
2026-06-22T06:36:01.3127627Z          --- End of inner exception stack trace ---
2026-06-22T06:36:01.3127665Z          at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
2026-06-22T06:36:01.3127703Z
```

The cause of this (and the reason we didn't see it locally) was that Azure's request proxying infrastructure was normalising these requests, and adding "Transfer-Encoding: chunked" headers to empty DELETE requests.

To prevent it from doing this, we make our DELETE request non-empty with a little dummy body that is ignored. 