### PR TITLE
EES-6963 - stop data factory failure activities from reporting in slack

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -840,14 +840,7 @@
                     {
                       "name": "Report reindex success",
                       "type": "WebActivity",
-                      "dependsOn": [
-                        {
-                          "activity": "Rebuild indexes",
-                          "dependencyConditions": [
-                            "Succeeded"
-                          ]
-                        }
-                      ],
+                      "dependsOn": [],
                       "policy": {
                         "timeout": "0.00:10:00",
                         "retry": 0,
@@ -894,14 +887,7 @@
                     {
                       "name": "Report reindex success to Teams",
                       "type": "WebActivity",
-                      "dependsOn": [
-                        {
-                          "activity": "Rebuild indexes",
-                          "dependencyConditions": [
-                            "Succeeded"
-                          ]
-                        }
-                      ],
+                      "dependsOn": [],
                       "policy": {
                         "timeout": "0.00:10:00",
                         "retry": 0,

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -77,9 +77,77 @@
       "properties": {
         "activities": [
           {
+            "name": "Pause resumable index rebuilds first",
+            "description": "This activity pauses any ongoing RESUMABLE index REBUILDs before starting the main pipeline.",
+            "type": "SqlServerStoredProcedure",
+            "dependsOn": [],
+            "policy": {
+              "timeout": "0.00:10:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "storedProcedureName": "[[dbo].[PauseResumableIndexRebuilds]",
+              "storedProcedureParameters": {
+                "Tables": {
+                  "value": "@pipeline().parameters.Tables",
+                  "type": "String"
+                }
+              }
+            },
+            "linkedServiceName": {
+              "referenceName": "ls_sql_statistics",
+              "type": "LinkedServiceReference"
+            }
+          },
+          {
+            "name": "Kill index reorganizes first",
+            "description": "This activity kills any ongoing index REORGANIZEs before starting the main pipeline.",
+            "type": "SqlServerStoredProcedure",
+            "dependsOn": [
+              {
+                "activity": "Pause resumable index rebuilds first",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
+            "policy": {
+              "timeout": "0.00:10:00",
+              "retry": 0,
+              "retryIntervalInSeconds": 30,
+              "secureOutput": false,
+              "secureInput": false
+            },
+            "userProperties": [],
+            "typeProperties": {
+              "storedProcedureName": "[[dbo].[KillIndexReorganizations]",
+              "storedProcedureParameters": {
+                "Tables": {
+                  "value": "@pipeline().parameters.Tables",
+                  "type": "String"
+                }
+              }
+            },
+            "linkedServiceName": {
+              "referenceName": "ls_sql_statistics",
+              "type": "LinkedServiceReference"
+            }
+          },
+          {
             "name": "Rebuild indexes",
             "type": "IfCondition",
-            "dependsOn": [],
+            "dependsOn": [
+              {
+                "activity": "Kill index reorganizes first",
+                "dependencyConditions": [
+                  "Succeeded"
+                ]
+              }
+            ],
             "typeProperties": {
               "expression": {
                 "value": "@equals(pipeline().parameters.RunMode, 'Weekend')",

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -107,6 +107,27 @@
                           "type": "Expression"
                         },
                         "type": "String"
+                      },
+                      "StopInMinutes": {
+                        "value": {
+                          "value": "@pipeline().parameters.StoredProcedureStopInMinutes",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "FragmentationThresholdReorganize": {
+                        "value": {
+                          "value": "@pipeline().parameters.FragmentationThresholdReorganize",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "FragmentationThresholdRebuild": {
+                        "value": {
+                          "value": "@pipeline().parameters.FragmentationThresholdRebuild",
+                          "type": "Expression"
+                        },
+                        "type": "String"
                       }
                     }
                   },
@@ -162,22 +183,6 @@
                       "type": "Expression"
                     }
                   }
-                },
-                {
-                  "name": "Fail Rebuild indexes - weekend",
-                  "type": "Fail",
-                  "dependsOn": [
-                    {
-                      "activity": "Get index rebuild failure message - weekend",
-                      "dependencyConditions": [
-                        "Succeeded"
-                      ]
-                    }
-                  ],
-                  "typeProperties": {
-                    "message": "Weekend Index Rebuild failed",
-                    "errorCode": "500"
-                  }
                 }
               ],
               "ifFalseActivities": [
@@ -199,6 +204,27 @@
                       "Tables": {
                         "value": {
                           "value": "@pipeline().parameters.Tables",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "StopInMinutes": {
+                        "value": {
+                          "value": "@pipeline().parameters.StoredProcedureStopInMinutes",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "FragmentationThresholdReorganize": {
+                        "value": {
+                          "value": "@pipeline().parameters.FragmentationThresholdReorganize",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "FragmentationThresholdRebuild": {
+                        "value": {
+                          "value": "@pipeline().parameters.FragmentationThresholdRebuild",
                           "type": "Expression"
                         },
                         "type": "String"
@@ -257,157 +283,19 @@
                       "type": "Expression"
                     }
                   }
-                },
-                {
-                  "name": "Fail Rebuild indexes - weekday",
-                  "type": "Fail",
-                  "dependsOn": [
-                    {
-                      "activity": "Get index rebuild failure message - weekday",
-                      "dependencyConditions": [
-                        "Succeeded"
-                      ]
-                    }
-                  ],
-                  "typeProperties": {
-                    "message": "Weekday Index Rebuild failed",
-                    "errorCode": "500"
-                  }
                 }
               ]
             }
           },
           {
-            "name": "Report reindex success",
-            "type": "WebActivity",
-            "dependsOn": [
-              {
-                "activity": "Rebuild indexes",
-                "dependencyConditions": [
-                  "Succeeded"
-                ]
-              }
-            ],
-            "policy": {
-              "timeout": "0.00:10:00",
-              "retry": 0,
-              "retryIntervalInSeconds": 30,
-              "secureOutput": false,
-              "secureInput": false
-            },
-            "userProperties": [],
-            "typeProperties": {
-              "url": "https://slack.com/api/chat.postMessage",
-              "method": "POST",
-              "headers": {
-                "Content-Type": "application/json",
-                "Authorization": "[concat('Bearer ', parameters('slackAppToken'))]"
-              },
-              "body": {
-                "channel": "[parameters('slackAlertsChannel')]",
-                "text": "Data Factory Success! All fragmented indexes rebuilt.",
-                "attachments": [
-                  {
-                    "color": "good",
-                    "fields": [
-                      {
-                        "title": "Data Factory",
-                        "value": "@{pipeline().DataFactory}",
-                        "short": true
-                      },
-                      {
-                        "title": "Pipeline",
-                        "value": "@{pipeline().Pipeline}",
-                        "short": true
-                      },
-                      {
-                        "title": "Duration",
-                        "value": "@{activity('Rebuild indexes').Duration}",
-                        "short": true
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "name": "Report reindex success to Teams",
-            "type": "WebActivity",
-            "dependsOn": [
-              {
-                "activity": "Rebuild indexes",
-                "dependencyConditions": [
-                  "Succeeded"
-                ]
-              }
-            ],
-            "policy": {
-              "timeout": "0.00:10:00",
-              "retry": 0,
-              "retryIntervalInSeconds": 30,
-              "secureOutput": false,
-              "secureInput": true
-            },
-            "userProperties": [],
-            "typeProperties": {
-              "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
-              "method": "POST",
-              "headers": {
-                "Content-Type": "application/json"
-              },
-              "body": {
-                "type": "message",
-                "attachments": [
-                  {
-                    "contentType": "application/vnd.microsoft.card.adaptive",
-                    "contentUrl": null,
-                    "content": {
-                      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-                      "type": "AdaptiveCard",
-                      "version": "1.2",
-                      "body": [
-                        {
-                          "type": "TextBlock",
-                          "text": "Data Factory Success! All fragmented indexes rebuilt.",
-                          "weight": "Bolder",
-                          "size": "Medium",
-                          "color": "good",
-                          "wrap": true
-                        },
-                        {
-                          "type": "FactSet",
-                          "facts": [
-                            {
-                              "title": "Data Factory",
-                              "value": "@{pipeline().DataFactory}"
-                            },
-                            {
-                              "title": "Pipeline",
-                              "value": "@{pipeline().Pipeline}"
-                            },
-                            {
-                              "title": "Duration",
-                              "value": "@{activity('Rebuild indexes').Duration}"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "name": "Choose how to handle rebuild indexes failure",
+            "name": "Check for rebuild indexes failure",
             "description": "This activity routes to the appropriate error handler based on the reason for the 'Rebuild indexes' activity's reason for failure",
             "type": "Switch",
             "dependsOn": [
               {
                 "activity": "Rebuild indexes",
                 "dependencyConditions": [
-                  "Failed"
+                  "Succeeded"
                 ]
               }
             ],
@@ -877,6 +765,133 @@
                       }
                     }
                   ]
+                },
+                {
+                  "value": "No failures",
+                  "activities": [
+                    {
+                      "name": "Report reindex success",
+                      "type": "WebActivity",
+                      "dependsOn": [
+                        {
+                          "activity": "Rebuild indexes",
+                          "dependencyConditions": [
+                            "Succeeded"
+                          ]
+                        }
+                      ],
+                      "policy": {
+                        "timeout": "0.00:10:00",
+                        "retry": 0,
+                        "retryIntervalInSeconds": 30,
+                        "secureOutput": false,
+                        "secureInput": false
+                      },
+                      "userProperties": [],
+                      "typeProperties": {
+                        "url": "https://slack.com/api/chat.postMessage",
+                        "method": "POST",
+                        "headers": {
+                          "Content-Type": "application/json",
+                          "Authorization": "[concat('Bearer ', parameters('slackAppToken'))]"
+                        },
+                        "body": {
+                          "channel": "[parameters('slackAlertsChannel')]",
+                          "text": "Data Factory Success! All fragmented indexes rebuilt.",
+                          "attachments": [
+                            {
+                              "color": "good",
+                              "fields": [
+                                {
+                                  "title": "Data Factory",
+                                  "value": "@{pipeline().DataFactory}",
+                                  "short": true
+                                },
+                                {
+                                  "title": "Pipeline",
+                                  "value": "@{pipeline().Pipeline}",
+                                  "short": true
+                                },
+                                {
+                                  "title": "Duration",
+                                  "value": "@{activity('Rebuild indexes').Duration}",
+                                  "short": true
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "name": "Report reindex success to Teams",
+                      "type": "WebActivity",
+                      "dependsOn": [
+                        {
+                          "activity": "Rebuild indexes",
+                          "dependencyConditions": [
+                            "Succeeded"
+                          ]
+                        }
+                      ],
+                      "policy": {
+                        "timeout": "0.00:10:00",
+                        "retry": 0,
+                        "retryIntervalInSeconds": 30,
+                        "secureOutput": false,
+                        "secureInput": true
+                      },
+                      "userProperties": [],
+                      "typeProperties": {
+                        "url": "[parameters('teamsPowerAutomateWebhookUrl')]",
+                        "method": "POST",
+                        "headers": {
+                          "Content-Type": "application/json"
+                        },
+                        "body": {
+                          "type": "message",
+                          "attachments": [
+                            {
+                              "contentType": "application/vnd.microsoft.card.adaptive",
+                              "contentUrl": null,
+                              "content": {
+                                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                                "type": "AdaptiveCard",
+                                "version": "1.2",
+                                "body": [
+                                  {
+                                    "type": "TextBlock",
+                                    "text": "Data Factory Success! All fragmented indexes rebuilt.",
+                                    "weight": "Bolder",
+                                    "size": "Medium",
+                                    "color": "good",
+                                    "wrap": true
+                                  },
+                                  {
+                                    "type": "FactSet",
+                                    "facts": [
+                                      {
+                                        "title": "Data Factory",
+                                        "value": "@{pipeline().DataFactory}"
+                                      },
+                                      {
+                                        "title": "Pipeline",
+                                        "value": "@{pipeline().Pipeline}"
+                                      },
+                                      {
+                                        "title": "Duration",
+                                        "value": "@{activity('Rebuild indexes').Duration}"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               ],
               "defaultActivities": [
@@ -1006,6 +1021,18 @@
             "type": "string",
             "defaultValue": "[variables('fragmentationTables')]"
           },
+          "StoredProcedureStopInMinutes": {
+            "type": "string",
+            "defaultValue": "600"
+          },
+          "FragmentationThresholdReorganize": {
+            "type": "string",
+            "defaultValue": "10"
+          },
+          "FragmentationThresholdRebuild": {
+            "type": "string",
+            "defaultValue": "30"
+          },
           "RunMode": {
             "type": "string",
             "defaultValue": "Weekday"
@@ -1013,10 +1040,12 @@
         },
         "variables": {
           "storedProcedureActivityFailure": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "No failures"
           },
           "storedProcedureActivityFailureMessage": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "No failures"
           }
         },
         "annotations": [],
@@ -1406,6 +1435,7 @@
             },
             "parameters": {
               "Tables": "[variables('fragmentationTables')]",
+              "StoredProcedureStopInMinutes": "570",
               "RunMode": "Weekday"
             }
           }
@@ -1454,6 +1484,7 @@
             },
             "parameters": {
               "Tables": "[variables('fragmentationTables')]",
+              "StoredProcedureStopInMinutes": "1425",
               "RunMode": "Weekend"
             }
           }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624095629_Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder")]
+    partial class Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder.cs
@@ -1,0 +1,25 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class Ees6963UpdateRebuildIndexesProcedureToAmendWorkOrder : Migration
+    {
+        private const string MigrationId = "20260624095629";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.SqlFromFile(
+                MigrationConstants.MigrationsPath,
+                $"{MigrationId}_Routine_RebuildIndexes.sql"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder) { }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Routine_RebuildIndexes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20260624095629_Routine_RebuildIndexes.sql
@@ -1,0 +1,230 @@
+CREATE OR ALTER PROCEDURE RebuildIndexes 
+    @Tables NVARCHAR(MAX), -- This is a comma-delimited list of table names e.g. "Observation, ObservationFilterItem".
+    @FragmentationThresholdReorganize FLOAT = 5,
+    @FragmentationThresholdRebuild FLOAT = 30,
+    @StopInMinutes INT = 600
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF LEN(ISNULL(@Tables, '')) = 0
+    BEGIN
+        RAISERROR ('Empty @Tables argument provided', 0, 1, NULL) WITH NOWAIT;
+        RETURN;
+    END
+
+    DECLARE
+        @StatsCount INT,
+        @StatsRowIndex INT = 1,
+        @RunId INT,
+        @StopTime DATETIME = DATEADD(MINUTE, @StopInMinutes, GETUTCDATE()),
+        @SkipRemainingTasks BIT = 0,
+
+        -- Used when iterating over indexes
+        @Command NVARCHAR(MAX),
+        @FragPercentBefore FLOAT,
+        @IndexName NVARCHAR(MAX),
+        @SchemaName NVARCHAR(MAX),
+        @ObjectName NVARCHAR(MAX),
+        @ActionRequired NVARCHAR(MAX),
+
+        -- Used when iterating over tables
+        @ModifiedTables AS ModifiedTablesType;
+
+    DROP TABLE IF EXISTS #TableList;
+
+    CREATE TABLE #TableList
+    (
+        Id         INT IDENTITY (1, 1),
+        ObjectName NVARCHAR(128),
+        PRIMARY KEY (Id)
+    );
+
+    CREATE NONCLUSTERED INDEX ix_temp_idx ON #TableList (ObjectName);
+
+    INSERT INTO #TableList (ObjectName)
+    SELECT TRIM(value)
+    FROM STRING_SPLIT(@Tables, ',');
+
+    -- Create result tables if necessary
+    IF OBJECT_ID(N'__Log_RebuildIndexes', N'U') IS NULL
+    CREATE TABLE __Log_RebuildIndexes
+    (
+        Id         INT IDENTITY (1,1),
+        StartTime  DATETIME2 NOT NULL,
+        EndTime    DATETIME2,
+        HitTimeout BIT,
+        PRIMARY KEY (Id),
+    );
+
+    IF OBJECT_ID(N'__Log_RebuildIndexesAlterIndexes', N'U') IS NULL
+    CREATE TABLE __Log_RebuildIndexesAlterIndexes
+    (
+        Id               INT IDENTITY (1,1),
+        RunId            INT           NOT NULL,
+        IndexName        NVARCHAR(MAX) NOT NULL,
+        SchemaName       NVARCHAR(MAX) NOT NULL,
+        ObjectName       NVARCHAR(MAX) NOT NULL,
+        StartTime        DATETIME2,
+        EndTime          DATETIME2,
+        StartFragPercent FLOAT,
+        ActionRequired   NVARCHAR(MAX),
+        HitTimeout       BIT DEFAULT 0,
+        PRIMARY KEY (Id),
+        FOREIGN KEY (RunId) REFERENCES __Log_RebuildIndexes (Id),
+    );
+
+    -- Create new row for this stored procedure run
+    INSERT INTO __Log_RebuildIndexes (StartTime)
+    VALUES (GETUTCDATE())
+    -- The Id is generated, but we want it, so set @RunId equal to it here
+    SET @RunId = SCOPE_IDENTITY();
+
+    /*-----------------------------------------------------------------------*/
+
+    DROP TABLE IF EXISTS #Stats;
+
+    -- Get a list of all indexes and their fragmentation percentage
+    SELECT Id = IDENTITY(INT, 1, 1),
+                Fragmented.IndexName,
+                Fragmented.SchemaName,
+                Fragmented.ObjectName,
+                Fragmented.FragPercent,
+                CASE
+                    WHEN Fragmented.HasPausedResumable = 1 THEN 'Resume'
+                    WHEN Fragmented.FragPercent >= @FragmentationThresholdRebuild THEN 'Rebuild'
+                    WHEN Fragmented.FragPercent >= @FragmentationThresholdReorganize THEN 'Reorganize'
+                    ELSE 'None'
+                    END AS ActionRequired
+    INTO #Stats
+    FROM (SELECT idx.name                         AS IndexName,
+                 sch.name                         AS SchemaName,
+                 tl.ObjectName,
+                 ips.avg_fragmentation_in_percent AS FragPercent,
+                 CASE WHEN EXISTS (
+                     SELECT 1
+                     FROM sys.index_resumable_operations iro
+                     WHERE iro.object_id = ips.object_id
+                     AND iro.index_id  = ips.index_id
+                     AND iro.state_desc = N'PAUSED'
+                 ) THEN 1 ELSE 0 END AS HasPausedResumable
+          FROM #TableList AS tl
+                   JOIN sys.dm_db_index_physical_stats(DB_ID(), NULL, NULL, NULL, 'LIMITED') ips
+                        ON ips.object_id = OBJECT_ID(tl.ObjectName, 'U')
+                   JOIN sys.indexes idx ON idx.object_id = ips.object_id AND idx.index_id = ips.index_id
+                   JOIN sys.objects obj ON obj.object_id = ips.object_id
+                   JOIN sys.schemas sch ON sch.schema_id = obj.schema_id
+          WHERE ips.alloc_unit_type_desc = 'IN_ROW_DATA') AS Fragmented
+    ORDER BY Fragmented.HasPausedResumable DESC, -- Prefer to resume paused jobs first.
+             Fragmented.FragPercent DESC; -- Then secondarily order by most fragmented first.
+
+    ALTER TABLE #Stats
+        ADD PRIMARY KEY (Id);
+
+    /*-----------------------------------------------------------------------*/
+
+    -- Create rows for indexes
+    SELECT @StatsCount = COUNT(Id) FROM #Stats;
+
+    SET @StatsRowIndex = 1;
+
+    INSERT INTO __Log_RebuildIndexesAlterIndexes (RunId, IndexName, SchemaName,
+                                                  ObjectName, StartFragPercent, ActionRequired)
+    SELECT @RunId,
+           IndexName,
+           SchemaName,
+           ObjectName,
+           FragPercent,
+           ActionRequired
+    FROM #Stats;
+
+    /*-----------------------------------------------------------------------*/
+
+    -- Rebuild or reorganize each index depending on the fragmentation percentage
+    SET @StatsRowIndex = 1;
+
+    WHILE @StatsRowIndex <= @StatsCount AND @SkipRemainingTasks = 0
+        BEGIN
+            SELECT @Command =
+                   'ALTER INDEX ' + IndexName + ' ON ' + SchemaName + '.' + ObjectName + ' ' +
+                   CASE
+                       WHEN ActionRequired = 'Resume'
+                           THEN 'RESUME'
+                       WHEN ActionRequired = 'Rebuild'
+                           THEN 'REBUILD WITH (ONLINE = ON, RESUMABLE = ON, MAXDOP = 4)'
+                       WHEN ActionRequired = 'Reorganize'
+                           THEN 'REORGANIZE'
+                       ELSE ''
+                   END,
+                   @FragPercentBefore = FragPercent,
+                   @IndexName = IndexName,
+                   @SchemaName = SchemaName,
+                   @ObjectName = ObjectName,
+                   @ActionRequired = ActionRequired
+            FROM #Stats
+            WHERE Id = @StatsRowIndex;
+
+            -- Save start time for reporting
+            UPDATE __Log_RebuildIndexesAlterIndexes
+            SET StartTime = GETUTCDATE()
+            WHERE RunId = @RunId
+              AND ObjectName = @ObjectName
+              AND SchemaName = @SchemaName
+              AND IndexName = @IndexName;
+
+            -- Do this check after setting StartTime, as we rely on StartTime to determine which indexes we're going
+            -- to skip if we exceed @StopTime
+            IF @ActionRequired = 'None'
+                BEGIN
+                    SET @StatsRowIndex += 1;
+                    CONTINUE;
+                END
+
+            -- Reorganise or rebuild
+            RAISERROR ('Executing command ''%s''.', 0, 1, @Command) WITH NOWAIT;
+            EXEC (@Command);
+
+            -- Add table to the list of modified tables to ensure statistics get updated at the end
+            INSERT INTO @ModifiedTables (TableName)
+            SELECT @ObjectName
+            WHERE NOT EXISTS (SELECT * FROM @ModifiedTables WHERE TableName = @ObjectName);
+
+            -- Save end info for reporting
+            UPDATE __Log_RebuildIndexesAlterIndexes
+            SET __Log_RebuildIndexesAlterIndexes.EndTime = GETUTCDATE()
+            WHERE __Log_RebuildIndexesAlterIndexes.RunId = @RunId
+              AND __Log_RebuildIndexesAlterIndexes.ObjectName = @ObjectName
+              AND __Log_RebuildIndexesAlterIndexes.SchemaName = @SchemaName
+              AND __Log_RebuildIndexesAlterIndexes.IndexName = @IndexName;
+
+            IF @StopTime < GETUTCDATE()
+                BEGIN
+                    RAISERROR ('Hit timeout while processing indexes. Skipping remaining tasks', 0, 1, NULL) WITH NOWAIT;
+                    -- We set the StartTime even when ActionRequired = 'None'. This allows us to update rows that
+                    -- won't be processed if we've exceeded @StopTime
+                    UPDATE __Log_RebuildIndexesAlterIndexes
+                    SET HitTimeout = 1
+                    WHERE StartTime IS NULL;
+
+                    SET @SkipRemainingTasks = 1;
+                END
+
+            SET @StatsRowIndex += 1;
+        END
+
+    RAISERROR ('Completed optimising indexes for tables.', 0, 1, NULL) WITH NOWAIT;
+
+    /*-----------------------------------------------------------------------*/
+
+    -- Call UPDATE STATISTICS on any tables that have had their indexes rebuilt/reorganized
+    EXEC UpdateStatistics @ModifiedTables;
+
+    UPDATE __Log_RebuildIndexes
+    SET EndTime    = GETUTCDATE(),
+        HitTimeout = @SkipRemainingTasks
+    WHERE Id = @RunId;
+
+    IF @SkipRemainingTasks = 1
+        RAISERROR ('Reindexing did not complete in %d minutes. Remaining indexes skipped.', 16, 1, @StopInMinutes)
+            WITH NOWAIT;
+END

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_RebuildIndexes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_RebuildIndexes.sql
@@ -115,7 +115,8 @@ BEGIN
                    JOIN sys.objects obj ON obj.object_id = ips.object_id
                    JOIN sys.schemas sch ON sch.schema_id = obj.schema_id
           WHERE ips.alloc_unit_type_desc = 'IN_ROW_DATA') AS Fragmented
-    ORDER BY Fragmented.HasPausedResumable DESC; -- Prefer to resume paused jobs first.
+    ORDER BY Fragmented.HasPausedResumable DESC, -- Prefer to resume paused jobs first.
+             Fragmented.FragPercent DESC; -- Then secondarily order by most fragmented first.
 
     ALTER TABLE #Stats
         ADD PRIMARY KEY (Id);


### PR DESCRIPTION
This PR:
- replaces "Fail" activities in the Rebuild Indexes pipeline with an additional case to an existing "Switch" activity, to prevent App Insights alerting to failures in Data Factory even though they were handled previously.
- updates the order slightly in which we tackle fragmented indexes, to tackle the most fragmented first.
- adds more parameterisation to the pipeline runs to allow us to play with different fragmentation thresholds, and ups the default minimum fragmentation level for reorganizations to 10%.
- passes in the correct value for the "StopInMinutes" stored proc option, depending on if it is a weekday or weekend run.
- adds kill and pause activities to the *start* of the pipeline, to prevent any ongoing (for whatever reason) reindexing to interfere with the current pipeline run.

## The new changes

<img width="2049" height="795" alt="image" src="https://github.com/user-attachments/assets/6d08d963-31c0-48e8-9d80-89fc1631c8df" />
