### PR TITLE
EES-6616 - add public site proxy to application gateway

### DIFF
--- a/infrastructure/templates/common/components/application-gateway/appGateway.bicep
+++ b/infrastructure/templates/common/components/application-gateway/appGateway.bicep
@@ -3,6 +3,7 @@ import { staticAverageGreaterThanZero } from '../alerts/staticAlertConfig.bicep'
 import { removeMultiple } from '../../functions.bicep'
 
 import {
+  AppGatewayFrontendConfig
   AppGatewayBackend
   AppGatewayRewriteSet
   AppGatewayRoute
@@ -23,6 +24,9 @@ param appGatewayName string = ''
 
 @description('Name of the user-assigned managed identity for the App Gateway')
 param managedIdentityName string = ''
+
+@description('Frontend and public IP address configuration')
+param frontendConfig AppGatewayFrontendConfig
 
 @description('Sites that the App Gateway can accept traffic from')
 param sites AppGatewaySite[]
@@ -85,9 +89,9 @@ module keyVaultCertificateUserRoleAssignmentModule '../key-vault/keyVaultRoleAss
 
 var invalidDomainLabelCharacters = ['.', '-']
 
-// Create public IP addresses for every site we will expose through this App Gateway.
-resource publicIPAddresses 'Microsoft.Network/publicIPAddresses@2024-01-01' = [for site in sites: {
-  name: '${site.name}-pip'
+// Create a public IP address for the frontend config for this App Gateway.
+resource publicIPAddresses 'Microsoft.Network/publicIPAddresses@2024-01-01' = {
+  name: frontendConfig.publicIpAddressName
   location: location
   sku: {
     name: 'Standard'
@@ -97,22 +101,24 @@ resource publicIPAddresses 'Microsoft.Network/publicIPAddresses@2024-01-01' = [f
     publicIPAllocationMethod: 'Static'
     idleTimeoutInMinutes: 4
     dnsSettings: {
-      domainNameLabel: removeMultiple(site.fqdn, invalidDomainLabelCharacters)
-      fqdn: '${removeMultiple(site.fqdn, invalidDomainLabelCharacters)}.${location}.cloudapp.azure.com'
+      domainNameLabel: removeMultiple(sites[0].fqdn, invalidDomainLabelCharacters)
+      fqdn: '${removeMultiple(sites[0].fqdn, invalidDomainLabelCharacters)}.${location}.cloudapp.azure.com'
     }
   }
   zones: availabilityZones
-}]
+}
 
-module pathRulesModule 'appGatewayPathRules.bicep' = [for route in routes: {
+var routesWithPathRules = filter(routes, route => route.?pathRules != null && length(route.pathRules!) > 0)
+
+module pathRulesModule 'appGatewayPathRules.bicep' = [for route in routesWithPathRules: {
   name: '${route.name}-route-paths'
   params: {
     appGatewayName: appGatewayName
-    pathRules: route.pathRules
+    pathRules: route.pathRules!
   }
 }]
 
-var allPathRules = flatten(map(routes, route => route.pathRules))
+var allPathRules = flatten(map(routesWithPathRules, route => route.pathRules!))
 
 var allRedirectRules = filter(allPathRules, rule => rule.type == 'redirect')
 
@@ -150,12 +156,12 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
         keyVaultSecretId: 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${site.certificateName}'
       }
     }]
-    frontendIPConfigurations: [for site in sites: {
-      name: '${site.name}-public-frontend-ip-config'
+    frontendIPConfigurations: [{
+      name: frontendConfig.name
       properties: {
         privateIPAllocationMethod: 'Dynamic'
         publicIPAddress: {
-          id: resourceId('Microsoft.Network/publicIPAddresses', '${site.name}-pip')
+          id: resourceId('Microsoft.Network/publicIPAddresses', frontendConfig.publicIpAddressName)
         }
       }
     }]
@@ -194,7 +200,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
       name: '${site.name}-https-443-listener'
       properties: {
         frontendIPConfiguration: {
-          id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayName, '${site.name}-public-frontend-ip-config')
+          id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayName, frontendConfig.name)
         }
         frontendPort: {
           id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayName, 'port443')
@@ -213,17 +219,23 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
     requestRoutingRules: [for (route, index) in routes: {
       name: '${route.name}-rule'
       properties: {
-        ruleType: 'PathBasedRouting'
+        ruleType: route.?pathRules != null && length(route.pathRules!) > 0 ? 'PathBasedRouting' : 'Basic'
         priority: index + 1
         httpListener: {
           id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, '${route.siteName}-https-443-listener')
         }
-        urlPathMap: {
+        backendAddressPool: route.?pathRules == null || length(route.pathRules!) == 0 ? {
+          id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGatewayName, '${route.defaultBackendName}-backend-pool')
+        } : null
+        backendHttpSettings: route.?pathRules == null || length(route.pathRules!) == 0 ? {
+          id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, '${route.defaultBackendName}-backend')
+        } : null
+        urlPathMap: route.?pathRules != null && length(route.pathRules!) > 0 ? {
           id: resourceId('Microsoft.Network/applicationGateways/urlPathMaps', appGatewayName, '${route.name}-url-path-map')
-        }
+        } : null
       }
     }]
-    urlPathMaps: [for (route, index) in routes: {
+    urlPathMaps: [for (route, index) in routesWithPathRules: {
       name: '${route.name}-url-path-map'
       properties: {
         defaultBackendAddressPool: {
@@ -253,7 +265,9 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
         unhealthyThreshold: 3
         pickHostNameFromBackendHttpSettings: true
         minServers: 0
-        match: {}
+        match: {
+          statusCodes: concat(['200-399'], backend.?healthProbeAdditionalStatusCodeMatches ?? [])
+        }
       }
     }]
     rewriteRuleSets: [for rewriteSet in rewrites: {

--- a/infrastructure/templates/common/components/application-gateway/types.bicep
+++ b/infrastructure/templates/common/components/application-gateway/types.bicep
@@ -1,4 +1,13 @@
 @export()
+type AppGatewayFrontendConfig = {
+  @description('Name of the frontend config')
+  name: string
+
+  @description('Name of the public IP address to associate with this frontend config')
+  publicIpAddressName: string
+}
+
+@export()
 type AppGatewaySite = {
   @description('Name of the site')
   name: string
@@ -26,6 +35,9 @@ type AppGatewayBackend = {
 
   @description('Path that the health probe should periodically ping e.g. /')
   healthProbePath: string
+
+  @description('Additional health probe HTTP status codes that indicate success')
+  healthProbeAdditionalStatusCodeMatches: string[]?
 }
 
 @export()
@@ -40,7 +52,7 @@ type AppGatewayRoute = {
   defaultBackendName: string
 
   @description('A set of path rules to apply')
-  pathRules: AppGatewayPathRule[]
+  pathRules: AppGatewayPathRule[]?
 }
 
 @export()

--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -10,7 +10,7 @@ param siteHostName string
 @description('Name of the certificate.')
 param certificateName string
 
-var keyVaultName = '${legacyResourcePrefix}kv-ees-01'
+var keyVaultName = '${legacyResourcePrefix}-kv-ees-01'
 
 resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorName

--- a/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
@@ -1,18 +1,30 @@
-import { ResourceNames } from '../../types.bicep'
+import { abbreviations } from '../../../common/abbreviations.bicep'
 
 @description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
 param subscription string
 
-@description('Common resource naming variables')
-param resourceNames ResourceNames
-
 @description('The location to create resources in')
 param location string
 
-@description('The FQDN for accessing the public API via Application Gateway. Used by FaUAPI to proxy traffic to the public API.')
+@description('')
+param publicApiAppName string
+
+@description('')
+param publicApiDocsAppName string
+
+@description('')
+param publicSiteAppServiceName string
+
+@description('')
+param keyVaultName string
+
+@description('')
+param vnetName string
+
+@description('FQDN of the public API listener in Application Gateway. This is the FQDN that FaUAPI proxies traffic to to access the public API from Application Gateway.')
 param publicApiAppGatewayFqdn string
 
-@description('The base public URL for accessing the public API and its documentation site. This is the base FaUAPI URL for the API.')
+@description('The base public URL for accessing the public API and its documentation site. This is the base FaUAPI URL that users use to interact with the API.')
 param publicApiPublicUrl string
 
 @description('FQDN of the public site public URL that users use to access the site.')
@@ -21,52 +33,62 @@ param publicSiteFqdn string
 @description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
 param publicSiteInternalServiceFqdn string
 
+@description('')
+param alertsGroupName string
+
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param deployAlerts bool
 
 @description('Tags for the resources')
 param tagValues object
 
-// The resource prefix for anything specific to the Public API.
+var commonResourcePrefix = '${subscription}-ees'
+
 var publicApiResourcePrefix = '${subscription}-ees-papi'
+
+var appGatewayName = '${commonResourcePrefix}-${abbreviations.networkApplicationGateways}-01'
+    
+var appGatewayIdentityName = '${commonResourcePrefix}-${abbreviations.managedIdentityUserAssignedIdentities}-${abbreviations.networkApplicationGateways}-01'
+
+var appGatewaySubnetName = '${commonResourcePrefix}-snet-${abbreviations.networkApplicationGateways}-01'
 
 var docsRewriteSetName = '${publicApiResourcePrefix}-docs-rewrites'
 
 resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
-  name: resourceNames.existingResources.vNet
+  name: vnetName
 }
 
 resource subnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
-  name: resourceNames.existingResources.subnets.appGateway
+  name: appGatewaySubnetName
   parent: vNet
 }
 
 resource apiApp 'Microsoft.App/containerApps@2024-03-01' existing = {
-  name: resourceNames.publicApi.apiApp
+  name: publicApiAppName
 }
 
 resource apiDocsSite 'Microsoft.Web/staticSites@2023-12-01' existing = {
-  name: resourceNames.publicApi.docsApp
+  name: publicApiDocsAppName
 }
 
 module globalWafPolicyModule '../../../common/components/application-gateway/appGatewayWafPolicy.bicep' = {
   name: 'globalWafPolicyModuleDeploy'
   params: {
-    name: '${resourceNames.sharedResources.appGateway}-global-afwp'
+    name: '${appGatewayName}-global-afwp'
     location: location
     tagValues: tagValues
   }
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
-  name: resourceNames.existingResources.keyVault
+  name: keyVaultName
 }
 
-module publicApiWafPolicyModule '../public-api/publicApiWafPolicy.bicep' = {
+module publicApiWafPolicyModule 'publicApiWafPolicy.bicep' = {
   name: 'publicApiWafPolicyModuleDeploy'
   params: {
     location: location
-    resourceNames: resourceNames
+    appGatewayName: appGatewayName
     fuapiSecretValue: keyVault.getSecret('ees-publicapi-app-gateway-fuapi-header')
     tagValues: tagValues
   }
@@ -76,9 +98,9 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
   name: 'appGatewayDeploy'
   params: {
     location: location
-    appGatewayName: resourceNames.sharedResources.appGateway
-    managedIdentityName: resourceNames.sharedResources.appGatewayIdentity
-    keyVaultName: resourceNames.existingResources.keyVault
+    appGatewayName: appGatewayName
+    managedIdentityName: appGatewayIdentityName
+    keyVaultName: keyVaultName
     subnetId: subnet.id
     frontendConfig: {
       name: '${publicApiResourcePrefix}-public-frontend-ip-config'
@@ -92,25 +114,25 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
         wafPolicyName: publicApiWafPolicyModule.outputs.name
       }
       {
-        name: '${resourceNames.existingResources.publicSiteAppService}-site'
-        certificateName: '${resourceNames.existingResources.publicSiteAppService}-certificate'
+        name: '${publicSiteAppServiceName}-site'
+        certificateName: '${publicSiteAppServiceName}-certificate'
         fqdn: publicSiteFqdn
-        wafPolicyName: '${resourceNames.sharedResources.appGateway}-global-afwp'
+        wafPolicyName: '${appGatewayName}-global-afwp'
       }
     ]
     backends: [
       {
-        name: resourceNames.publicApi.apiApp
+        name: publicApiAppName
         fqdn: apiApp.properties.configuration.ingress.fqdn
         healthProbePath: '/health'
       }
       {
-        name: resourceNames.publicApi.docsApp
+        name: publicApiDocsAppName
         fqdn: apiDocsSite.properties.defaultHostname
         healthProbePath: '/'
       }
       {
-        name: '${resourceNames.existingResources.publicSiteAppService}-backend'
+        name: '${publicSiteAppServiceName}-backend'
         fqdn: publicSiteInternalServiceFqdn
         healthProbePath: '/api/health'
         healthProbeAdditionalStatusCodeMatches: ['405']
@@ -120,13 +142,13 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
       {
         name: publicApiResourcePrefix
         siteName: publicApiResourcePrefix
-        defaultBackendName: resourceNames.publicApi.apiApp
+        defaultBackendName: publicApiAppName
         pathRules: [
           {
             name: 'docs-backend'
             paths: ['/docs/*']
             type: 'backend'
-            backendName: resourceNames.publicApi.docsApp
+            backendName: publicApiDocsAppName
             rewriteSetName: docsRewriteSetName
           }
           {
@@ -143,9 +165,9 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
         ]
       }
       {
-        name: '${resourceNames.existingResources.publicSiteAppService}-route'
-        siteName: '${resourceNames.existingResources.publicSiteAppService}-site'
-        defaultBackendName: '${resourceNames.existingResources.publicSiteAppService}-backend'
+        name: '${publicSiteAppServiceName}-route'
+        siteName: '${publicSiteAppServiceName}-site'
+        defaultBackendName: '${publicSiteAppServiceName}-backend'
       }
     ]
     rewrites: [
@@ -194,7 +216,7 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
       responseTime: true
       failedRequests: true
       responseStatuses: true
-      alertsGroupName: resourceNames.existingResources.alertsGroup
+      alertsGroupName: alertsGroupName
     } : null
     tagValues: tagValues
   }

--- a/infrastructure/templates/core/application/applicationGateway/publicApiWafPolicy.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/publicApiWafPolicy.bicep
@@ -1,10 +1,8 @@
-import { ResourceNames } from '../../types.bicep'
-
-@description('Specifies common resource naming variables.')
-param resourceNames ResourceNames
-
 @description('Specifies the location for all resources.')
 param location string
+
+@description('Specifies the name of the Application Gateway.')
+param appGatewayName string
 
 @description('Secret header value from FUAPI.')
 @secure()
@@ -13,7 +11,7 @@ param fuapiSecretValue string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
-var policyName = '${resourceNames.sharedResources.appGateway}-public-api-afwp'
+var policyName = '${appGatewayName}-public-api-afwp'
 
 module wafPolicyModule '../../../common/components/application-gateway/appGatewayWafPolicy.bicep' = {
   name: 'publicApiWafPolicyDeploy'

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -40,7 +40,7 @@ var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}
 
 var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
 
-var certificateName = '${legacyResourcePrefix}as-ees-public-site-certificate'
+var certificateName = '${legacyResourcePrefix}-as-ees-public-site-certificate'
 
 var nextJsRuleSetName = 'nextjsruleset'
 

--- a/infrastructure/templates/core/ci/azure-pipelines.yml
+++ b/infrastructure/templates/core/ci/azure-pipelines.yml
@@ -12,6 +12,20 @@ trigger:
 pr: none
 
 parameters:
+  - name: deployApplicationGateway
+    displayName: Does Application Gateway need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No  
+  - name: deployAlerts
+    displayName: Do the Azure Monitor alerts need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
   - name: forceDeployToEnvironment
     displayName: Set to either dev or test to force a deploy to that environment from the chosen branch.
     type: string
@@ -21,13 +35,6 @@ parameters:
       - test
       - preprod
     default: none
-  - name: deployAlerts
-    displayName: Do the Azure Monitor alerts need creating or updating?
-    type: string
-    values:
-      - Yes
-      - No
-    default: No
 
 variables:
   - group: Common
@@ -43,6 +50,8 @@ variables:
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
     value: ubuntu-latest
+  - name: deployApplicationGateway
+    value: ${{ iif(eq(parameters.deployApplicationGateway, 'Yes'), true, false) }}
   - name: deployAlerts
     value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
 

--- a/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
@@ -29,6 +29,7 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deployApplicationGateway: false
                 deployAlerts: false
 
             - template: ../tasks/deploy-bicep.yml
@@ -37,4 +38,5 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deployApplicationGateway: $(deployApplicationGateway)
                 deployAlerts: $(deployAlerts)

--- a/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
@@ -11,6 +11,8 @@ parameters:
     type: string
   - name: parameterFile
     type: string
+  - name: deployApplicationGateway
+    type: string
   - name: deployAlerts
     type: string
 
@@ -33,5 +35,6 @@ steps:
           --parameters \
               subscription='$(subscription)' \
               publicSiteUrl='$(publicSiteUrl)' \
+              deployApplicationGateway=${{ parameters.deployApplicationGateway }} \
               deployAlerts=${{ parameters.deployAlerts }} \
               resourceTags='$(resourceTags)'

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -13,11 +13,23 @@ param environmentName string
 @description('The public site URL for use with Azure Front Door.')
 param publicSiteUrl string = ''
 
+@description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
+param publicSiteInternalServiceFqdn string
+
+@description('The base public URL for accessing the public API and its documentation site. This is the base FaUAPI URL that users use to interact with the API.')
+param publicApiPublicUrl string
+
+@description('FQDN of the public API listener in Application Gateway. This is the FQDN that FaUAPI uses to proxy traffic to the public API.')
+param publicApiApplicationGatewayFqdn string = ''
+
 @description('Certificate type for Azure Front Door.')
 param certificateType FrontDoorCertificateType = 'BringYourOwn'
 
 @description('Whether or not to create role assignments necessary for performing certain backup actions.')
 param deployBackupVaultReaderRoleAssignment bool = true
+
+@description('Whether or not to deploy Application Gateway and its confirmation.')
+param deployApplicationGateway bool = false
 
 @description('The minimum average response time from the public site (via Azure Front Door) before latency alerts fire.')
 param averagePublicSiteResponseTimeAlertThresholdMillis int = 2500
@@ -44,16 +56,22 @@ var tagValues = union(resourceTags ?? {}, {
 })
 
 var resourcePrefix = '${subscription}-ees'
-var legacyResourcePrefix = '${subscription}-'
+var legacyResourcePrefix = subscription
+var publicApiResourcePrefix = '${subscription}-ees-papi'
 
 var resourceNames = {
   existingResources: {
     adminApp: '${subscription}-as-ees-admin'
+    keyVault: '${legacyResourcePrefix}-kv-ees-01'
+    publicApiApp: '${publicApiResourcePrefix}-${abbreviations.appContainerApps}-api'
+    publicApiDocsApp: '${publicApiResourcePrefix}-${abbreviations.staticWebApps}-docs'
+    publicSiteApp: '${legacyResourcePrefix}-as-ees-public-site'
     publisherFunction: '${subscription}-${abbreviations.webSitesFunctions}-ees-publisher'
     vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
     alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
     subnets: {
       eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
+      appGateway: '${resourcePrefix}-snet-${abbreviations.networkApplicationGateways}-01'
     }
   }
 }
@@ -102,6 +120,26 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = {
     certificateType: certificateType
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     averagePublicSiteResponseTimeAlertThresholdMillis: averagePublicSiteResponseTimeAlertThresholdMillis
+    deployAlerts: deployAlerts
+    tagValues: tagValues
+  }
+}
+
+module appGatewayModule 'application/applicationGateway/appGateway.bicep' = if (deployApplicationGateway) {
+  name: 'appGatewayModuleDeploy'
+  params: {
+    location: location
+    subscription: subscription
+    alertsGroupName: resourceNames.existingResources.alertsGroup
+    keyVaultName: resourceNames.existingResources.keyVault
+    publicApiAppName: resourceNames.existingResources.publicApiApp
+    publicApiDocsAppName: resourceNames.existingResources.publicApiDocsApp
+    publicSiteAppServiceName: resourceNames.existingResources.publicSiteApp
+    vnetName: resourceNames.existingResources.vNet
+    publicApiAppGatewayFqdn: publicApiApplicationGatewayFqdn
+    publicApiPublicUrl: publicApiPublicUrl
+    publicSiteFqdn: replace(publicSiteUrl, 'https://', '')
+    publicSiteInternalServiceFqdn: publicSiteInternalServiceFqdn
     deployAlerts: deployAlerts
     tagValues: tagValues
   }

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -2,3 +2,8 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Development'
+
+param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'
+
+param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
+param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -2,3 +2,8 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Pre-Production'
+
+param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'
+
+param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
+param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -4,3 +4,8 @@ using '../main.bicep'
 param environmentName = 'Production'
 
 param averagePublicSiteResponseTimeAlertThresholdMillis = 1000
+
+param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
+
+param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
+param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -2,3 +2,8 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Test'
+
+param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'
+
+param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
+param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'

--- a/infrastructure/templates/public-api/application/public-api/publicApiWafPolicy.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiWafPolicy.bicep
@@ -16,7 +16,7 @@ param tagValues object
 var policyName = '${resourceNames.sharedResources.appGateway}-public-api-afwp'
 
 module wafPolicyModule '../../../common/components/application-gateway/appGatewayWafPolicy.bicep' = {
-  name: 'wafPolicy'
+  name: 'publicApiWafPolicyDeploy'
   params: {
     name: policyName
     location: location

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -1,11 +1,7 @@
-import {
-  AppGatewayBackend
-  AppGatewayRewriteSet
-  AppGatewayRoute
-  AppGatewaySite
-} from '../../../common/components/application-gateway/types.bicep'
-
 import { ResourceNames } from '../../types.bicep'
+
+@description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string
 
 @description('Common resource naming variables')
 param resourceNames ResourceNames
@@ -13,23 +9,28 @@ param resourceNames ResourceNames
 @description('The location to create resources in')
 param location string
 
-@description('Sites that the App Gateway handles')
-param sites AppGatewaySite[]
+@description('The FQDN for accessing the public API via Application Gateway. Used by FaUAPI to proxy traffic to the public API.')
+param publicApiAppGatewayFqdn string
 
-@description('Backend resources the App Gateway can direct traffic to')
-param backends AppGatewayBackend[]
+@description('The base public URL for accessing the public API and its documentation site. This is the base FaUAPI URL for the API.')
+param publicApiPublicUrl string
 
-@description('Routes the App Gateway should direct traffic through')
-param routes AppGatewayRoute[]
+@description('FQDN of the public site public URL that users use to access the site.')
+param publicSiteFqdn string
 
-@description('Rules for how the App Gateway should rewrite URLs')
-param rewrites AppGatewayRewriteSet[]
+@description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
+param publicSiteInternalServiceFqdn string
 
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param deployAlerts bool
 
 @description('Tags for the resources')
 param tagValues object
+
+// The resource prefix for anything specific to the Public API.
+var publicApiResourcePrefix = '${subscription}-ees-papi'
+
+var docsRewriteSetName = '${publicApiResourcePrefix}-docs-rewrites'
 
 resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
   name: resourceNames.existingResources.vNet
@@ -40,11 +41,33 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing 
   parent: vNet
 }
 
+resource apiApp 'Microsoft.App/containerApps@2024-03-01' existing = {
+  name: resourceNames.publicApi.apiApp
+}
+
+resource apiDocsSite 'Microsoft.Web/staticSites@2023-12-01' existing = {
+  name: resourceNames.publicApi.docsApp
+}
+
 module globalWafPolicyModule '../../../common/components/application-gateway/appGatewayWafPolicy.bicep' = {
-  name: 'wafPolicy'
+  name: 'globalWafPolicyModuleDeploy'
   params: {
     name: '${resourceNames.sharedResources.appGateway}-global-afwp'
     location: location
+    tagValues: tagValues
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
+module publicApiWafPolicyModule '../public-api/publicApiWafPolicy.bicep' = {
+  name: 'publicApiWafPolicyModuleDeploy'
+  params: {
+    location: location
+    resourceNames: resourceNames
+    fuapiSecretValue: keyVault.getSecret('ees-publicapi-app-gateway-fuapi-header')
     tagValues: tagValues
   }
 }
@@ -57,10 +80,114 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
     managedIdentityName: resourceNames.sharedResources.appGatewayIdentity
     keyVaultName: resourceNames.existingResources.keyVault
     subnetId: subnet.id
-    sites: sites
-    backends: backends
-    routes: routes
-    rewrites: rewrites
+    frontendConfig: {
+      name: '${publicApiResourcePrefix}-public-frontend-ip-config'
+      publicIpAddressName: '${publicApiResourcePrefix}-pip'
+    }
+    sites: [
+      {
+        name: publicApiResourcePrefix
+        certificateName: '${publicApiResourcePrefix}-certificate'
+        fqdn: replace(publicApiAppGatewayFqdn, 'https://', '')
+        wafPolicyName: publicApiWafPolicyModule.outputs.name
+      }
+      {
+        name: '${resourceNames.existingResources.publicSiteAppService}-site'
+        certificateName: '${resourceNames.existingResources.publicSiteAppService}-certificate'
+        fqdn: publicSiteFqdn
+        wafPolicyName: '${resourceNames.sharedResources.appGateway}-global-afwp'
+      }
+    ]
+    backends: [
+      {
+        name: resourceNames.publicApi.apiApp
+        fqdn: apiApp.properties.configuration.ingress.fqdn
+        healthProbePath: '/health'
+      }
+      {
+        name: resourceNames.publicApi.docsApp
+        fqdn: apiDocsSite.properties.defaultHostname
+        healthProbePath: '/'
+      }
+      {
+        name: '${resourceNames.existingResources.publicSiteAppService}-backend'
+        fqdn: publicSiteInternalServiceFqdn
+        healthProbePath: '/api/health'
+        healthProbeAdditionalStatusCodeMatches: ['405']
+      }
+    ]
+    routes: [
+      {
+        name: publicApiResourcePrefix
+        siteName: publicApiResourcePrefix
+        defaultBackendName: resourceNames.publicApi.apiApp
+        pathRules: [
+          {
+            name: 'docs-backend'
+            paths: ['/docs/*']
+            type: 'backend'
+            backendName: resourceNames.publicApi.docsApp
+            rewriteSetName: docsRewriteSetName
+          }
+          {
+            // Redirect non-rooted URL (has no trailing slash) to the
+            // rooted URL so that relative links in the docs site
+            // can resolve correctly.
+            name: 'docs-root-redirect'
+            paths: ['/docs']
+            type: 'redirect'
+            redirectUrl: '${publicApiPublicUrl}/docs/'
+            redirectType: 'Permanent'
+            includePath: false
+          }
+        ]
+      }
+      {
+        name: '${resourceNames.existingResources.publicSiteAppService}-route'
+        siteName: '${resourceNames.existingResources.publicSiteAppService}-site'
+        defaultBackendName: '${resourceNames.existingResources.publicSiteAppService}-backend'
+      }
+    ]
+    rewrites: [
+      {
+        name: docsRewriteSetName
+        rules: [
+          {
+            name: 'trim-docs-path-prefix'
+            conditions: [
+              {
+                variable: 'var_uri_path'
+                pattern: '^/docs/(.*)'
+                ignoreCase: true
+              }
+            ]
+            actionSet: {
+              urlConfiguration: {
+                modifiedPath: '/{var_uri_path_1}'
+              }
+            }
+          }
+          {
+            name: 'replace-docs-backend-fqdn-with-public-docs-url'
+            conditions: [
+              {
+                variable: 'http_resp_Location'
+                pattern: 'https://${apiDocsSite.properties.defaultHostname}/(.*)'
+                ignoreCase: true
+              }
+            ]
+            actionSet: {
+              responseHeaderConfigurations: [
+                {
+                  headerName: 'Location'
+                  headerValue: '${publicApiPublicUrl}/docs/{http_resp_Location_1}'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
     globalWafPolicyId: globalWafPolicyModule.outputs.id
     alerts: deployAlerts ? {
       health: true

--- a/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
@@ -39,11 +39,6 @@ resource psqlFlexibleServerSubnet 'Microsoft.Network/virtualNetworks/subnets@202
   parent: vNet
 }
 
-resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
-  name: subnets.appGateway
-  parent: vNet
-}
-
 resource storageAccountPrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
   name: subnets.storagePrivateEndpoints
   parent: vNet
@@ -105,9 +100,6 @@ output psqlFlexibleServerSubnetStartIpAddress string = parseCidr(psqlFlexibleSer
 
 @description('The last usable IP address for the PSQL Flexible Server Subnet.')
 output psqlFlexibleServerSubnetEndIpAddress string = parseCidr(psqlFlexibleServerSubnet.properties.addressPrefix).lastUsable
-
-@description('The fully qualified Azure resource ID of the App Gateway Subnet.')
-output appGatewaySubnetRef string = appGatewaySubnet.id
 
 @description('The fully qualified Azure resource ID of the Public API Storage Account Private Endpoint Subnet.')
 output storageAccountPrivateEndpointSubnetRef string = storageAccountPrivateEndpointSubnet.id

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -123,6 +123,9 @@ param publicUrls {
   publicApiAppGateway: string
 }
 
+@description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
+param publicSiteInternalServiceFqdn string = ''
+
 @description('Specifies whether or not the Data Processor Function App already exists.')
 param dataProcessorFunctionAppExists bool = false
 
@@ -205,6 +208,7 @@ var resourceNames = {
     keyVault: '${legacyResourcePrefix}-kv-ees-01'
     logAnalyticsWorkspace: '${commonResourcePrefix}-log'
     publisherFunction: '${legacyResourcePrefix}-fa-ees-publisher'
+    publicSiteAppService: '${legacyResourcePrefix}-as-ees-public-site'
     subnets: {
       adminApp: '${legacyResourcePrefix}-snet-ees-admin'
       publisherFunction: '${legacyResourcePrefix}-snet-ees-publisher'
@@ -415,115 +419,17 @@ module docsModule 'application/public-api/publicApiDocs.bicep' = if (deployDocsS
   }
 }
 
-var docsRewriteSetName = '${publicApiResourcePrefix}-docs-rewrites'
-
-resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
-  name: resourceNames.existingResources.keyVault
-}
-
-module publicApiWafPolicyModule 'application/public-api/publicApiWafPolicy.bicep' = {
-  name: 'publicApiWafPolicyModuleDeploy'
-  params: {
-    location: location
-    resourceNames: resourceNames
-    fuapiSecretValue: keyVault.getSecret('ees-publicapi-app-gateway-fuapi-header')
-    tagValues: tagValues
-  }
-}
-
 // Create an Application Gateway to serve public traffic for the Public API Container App.
 module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContainerApp && deployDocsSite) {
   name: 'appGatewayModuleDeploy'
   params: {
     location: location
+    subscription: subscription
     resourceNames: resourceNames
-    sites: [
-      {
-        name: publicApiResourcePrefix
-        certificateName: '${publicApiResourcePrefix}-certificate'
-        fqdn: replace(publicUrls.publicApiAppGateway, 'https://', '')
-        wafPolicyName: publicApiWafPolicyModule.outputs.name
-      }
-    ]
-    backends: [
-      {
-        name: resourceNames.publicApi.apiApp
-        fqdn: apiAppModule.outputs.containerAppFqdn
-        healthProbePath: apiAppModule.outputs.healthProbePath
-      }
-      {
-        name: resourceNames.publicApi.docsApp
-        fqdn: docsModule.outputs.appFqdn
-        healthProbePath: docsModule.outputs.healthProbePath
-      }
-    ]
-    routes: [
-      {
-        name: publicApiResourcePrefix
-        siteName: publicApiResourcePrefix
-        defaultBackendName: resourceNames.publicApi.apiApp
-        pathRules: [
-          {
-            name: 'docs-backend'
-            paths: ['/docs/*']
-            type: 'backend'
-            backendName: resourceNames.publicApi.docsApp
-            rewriteSetName: docsRewriteSetName
-          }
-          {
-            // Redirect non-rooted URL (has no trailing slash) to the
-            // rooted URL so that relative links in the docs site
-            // can resolve correctly.
-            name: 'docs-root-redirect'
-            paths: ['/docs']
-            type: 'redirect'
-            redirectUrl: '${publicUrls.publicApi}/docs/'
-            redirectType: 'Permanent'
-            includePath: false
-          }
-        ]
-      }
-    ]
-    rewrites: [
-      {
-        name: docsRewriteSetName
-        rules: [
-          {
-            name: 'trim-docs-path-prefix'
-            conditions: [
-              {
-                variable: 'var_uri_path'
-                pattern: '^/docs/(.*)'
-                ignoreCase: true
-              }
-            ]
-            actionSet: {
-              urlConfiguration: {
-                modifiedPath: '/{var_uri_path_1}'
-              }
-            }
-          }
-          {
-            name: 'replace-docs-backend-fqdn-with-public-docs-url'
-            conditions: [
-              {
-                variable: 'http_resp_Location'
-                pattern: 'https://${docsModule.outputs.appFqdn}/(.*)'
-                ignoreCase: true
-              }
-            ]
-            actionSet: {
-              responseHeaderConfigurations: [
-                {
-                  headerName: 'Location'
-                  headerValue: '${publicUrls.publicApi}/docs/{http_resp_Location_1}'
-                }
-              ]
-            }
-          }
-        ]
-      }
-    ]
+    publicApiAppGatewayFqdn: publicUrls.publicApiAppGateway
+    publicApiPublicUrl: publicUrls.publicApi
+    publicSiteFqdn: replace(publicUrls.publicSite, 'https://', '')
+    publicSiteInternalServiceFqdn: publicSiteInternalServiceFqdn
     deployAlerts: deployAlerts
     tagValues: tagValues
   }
@@ -575,17 +481,18 @@ output dataProcessorContentDbConnectionStringSecretKey string = 'ees-publicapi-d
 output dataProcessorPsqlConnectionStringSecretKey string = 'ees-publicapi-data-processor-connectionstring-publicdatadb'
 
 output dataProcessorFunctionAppManagedIdentityClientId string = deployDataProcessor
-  ? dataProcessorModule.outputs.managedIdentityClientId
+  ? dataProcessorModule!.outputs.managedIdentityClientId
   : ''
 
-output dataProcessorFunctionAppUrl string = deployDataProcessor ? dataProcessorModule.outputs.url : ''
-output dataProcessorFunctionAppStagingUrl string = deployDataProcessor ? dataProcessorModule.outputs.stagingUrl : ''
+output dataProcessorFunctionAppUrl string = deployDataProcessor ? dataProcessorModule!.outputs.url : ''
+output dataProcessorFunctionAppStagingUrl string = deployDataProcessor ? dataProcessorModule!.outputs.stagingUrl : ''
 
 output dataProcessorPublicApiDataFileShareMountPath string = deployDataProcessor
-  ? dataProcessorModule.outputs.publicApiDataFileShareMountPath
+  ? dataProcessorModule!.outputs.publicApiDataFileShareMountPath
   : ''
 
 output coreStorageConnectionStringSecretKey string = coreStorage.outputs.coreStorageConnectionStringSecretKey
 output keyVaultName string = resourceNames.existingResources.keyVault
 
 output enableThemeDeletion bool = enableThemeDeletion
+

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -120,11 +120,7 @@ param publicUrls {
   contentApi: string
   publicSite: string
   publicApi: string
-  publicApiAppGateway: string
 }
-
-@description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
-param publicSiteInternalServiceFqdn string = ''
 
 @description('Specifies whether or not the Data Processor Function App already exists.')
 param dataProcessorFunctionAppExists bool = false
@@ -208,11 +204,9 @@ var resourceNames = {
     keyVault: '${legacyResourcePrefix}-kv-ees-01'
     logAnalyticsWorkspace: '${commonResourcePrefix}-log'
     publisherFunction: '${legacyResourcePrefix}-fa-ees-publisher'
-    publicSiteAppService: '${legacyResourcePrefix}-as-ees-public-site'
     subnets: {
       adminApp: '${legacyResourcePrefix}-snet-ees-admin'
       publisherFunction: '${legacyResourcePrefix}-snet-ees-publisher'
-      appGateway: '${commonResourcePrefix}-snet-${abbreviations.networkApplicationGateways}-01'
       containerAppEnvironment: '${commonResourcePrefix}-snet-${abbreviations.appManagedEnvironments}-01'
       dataProcessor: '${publicApiResourcePrefix}-snet-${abbreviations.webSitesFunctions}-processor'
       dataProcessorPrivateEndpoints: '${publicApiResourcePrefix}-snet-${abbreviations.webSitesFunctions}-processor-pep'
@@ -222,8 +216,6 @@ var resourceNames = {
     vNet: '${legacyResourcePrefix}-vnet-ees'
   }
   sharedResources: {
-    appGateway: '${commonResourcePrefix}-${abbreviations.networkApplicationGateways}-01'
-    appGatewayIdentity: '${commonResourcePrefix}-${abbreviations.managedIdentityUserAssignedIdentities}-${abbreviations.networkApplicationGateways}-01'
     containerAppEnvironment: '${commonResourcePrefix}-${abbreviations.appManagedEnvironments}-01'
     logAnalyticsWorkspace: '${commonResourcePrefix}-${abbreviations.operationalInsightsWorkspaces}'
     postgreSqlFlexibleServer: '${commonResourcePrefix}-${publicApiAbbreviations.dBforPostgreSQLServers}'
@@ -415,22 +407,6 @@ module docsModule 'application/public-api/publicApiDocs.bicep' = if (deployDocsS
   params: {
     appSku: docsAppSku
     resourceNames: resourceNames
-    tagValues: tagValues
-  }
-}
-
-// Create an Application Gateway to serve public traffic for the Public API Container App.
-module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContainerApp && deployDocsSite) {
-  name: 'appGatewayModuleDeploy'
-  params: {
-    location: location
-    subscription: subscription
-    resourceNames: resourceNames
-    publicApiAppGatewayFqdn: publicUrls.publicApiAppGateway
-    publicApiPublicUrl: publicUrls.publicApi
-    publicSiteFqdn: replace(publicUrls.publicSite, 'https://', '')
-    publicSiteInternalServiceFqdn: publicSiteInternalServiceFqdn
-    deployAlerts: deployAlerts
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -7,7 +7,6 @@ param publicUrls = {
   contentApi: 'https://content.dev.explore-education-statistics.service.gov.uk'
   publicSite: 'https://dev.explore-education-statistics.service.gov.uk'
   publicApi: 'https://pp-api.education.gov.uk/statistics-dev'
-  publicApiAppGateway: 'https://dev.statistics.api.education.gov.uk'
 }
 
 param publicApiContainerAppConfig = {
@@ -35,5 +34,3 @@ param enableSwagger = true
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
-
-param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -35,3 +35,5 @@ param enableSwagger = true
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
+
+param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -7,7 +7,6 @@ param publicUrls = {
   contentApi: 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
   publicSite: 'https://pre-production.explore-education-statistics.service.gov.uk'
   publicApi: 'https://pp-api.education.gov.uk/statistics-preprod'
-  publicApiAppGateway: 'https://pre-production.statistics.api.education.gov.uk'
 }
 
 // PostgreSQL Database Params
@@ -46,5 +45,3 @@ param enableSwagger = true
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
-
-param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -46,3 +46,5 @@ param enableSwagger = true
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
+
+param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -59,3 +59,5 @@ param enableThemeDeletion = false
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
+
+param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -7,7 +7,6 @@ param publicUrls = {
   contentApi: 'https://content.explore-education-statistics.service.gov.uk'
   publicSite: 'https://explore-education-statistics.service.gov.uk'
   publicApi: 'https://api.education.gov.uk/statistics'
-  publicApiAppGateway: 'https://statistics.api.education.gov.uk'
 }
 
 param publicApiContainerAppConfig = {
@@ -59,5 +58,3 @@ param enableThemeDeletion = false
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
-
-param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -7,7 +7,6 @@ param publicUrls = {
   contentApi: 'https://content.test.explore-education-statistics.service.gov.uk'
   publicSite: 'https://test.explore-education-statistics.service.gov.uk'
   publicApi: 'https://pp-api.education.gov.uk/statistics-test'
-  publicApiAppGateway: 'https://test.statistics.api.education.gov.uk'
 }
 
 param searchServiceIndexName = 'index-1'
@@ -17,5 +16,3 @@ param enableThemeDeletion = false
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
-
-param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -17,3 +17,5 @@ param enableThemeDeletion = false
 param deployPsqlBackupVaultRoleAssignment = true
 
 param deployPsqlBackupVaultRegistration = true
+
+param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -36,6 +36,7 @@ type ResourceNames = {
     keyVault: string
     logAnalyticsWorkspace: string
     publisherFunction: string
+    publicSiteAppService: string
     subnets: {
       dataProcessor: string
       dataProcessorPrivateEndpoints: string

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -36,13 +36,11 @@ type ResourceNames = {
     keyVault: string
     logAnalyticsWorkspace: string
     publisherFunction: string
-    publicSiteAppService: string
     subnets: {
       dataProcessor: string
       dataProcessorPrivateEndpoints: string
       containerAppEnvironment: string
       psqlFlexibleServer: string
-      appGateway: string
       adminApp: string
       publisherFunction: string
       storagePrivateEndpoints: string
@@ -50,8 +48,6 @@ type ResourceNames = {
     vNet: string
   }
   sharedResources: {
-    appGateway: string
-    appGatewayIdentity: string
     containerAppEnvironment: string
     logAnalyticsWorkspace: string
     postgreSqlFlexibleServer: string


### PR DESCRIPTION
This PR:
- Adds configuration to put the public site behind Application Gateway.
- Moves Application Gateway deployments to the Core Infrastructure pipeline.

## Commits

This work is broken into 2 main commits:

* Commit 1 adds the public site config into Application Gateway, still under the control of the public API pipeline.  This was tested using the public API pipeline and shown to be successful.
* Commit 2 moves all of the Application Gateway code out of the public API pipeline and into the Core Infrastructure pipeline.  A new "deployApplicationGateway" deploy flag has been added to that pipeline defaulted to false, to speed up day-to-day pipeline runs, as App Gateway config rarely changes.

## Why this piece of work?

Currently we have a technical limitation on Production using Azure Front Door, because the main site is served using the apex domain (and therefore using an A record), and you cannot point a DNS record at an Azure Front Door IP address because they're always changing.  Because of limitations of the DNS provider, we cannot point its A record at Azure Front Door's hostname.

In order to support this, we'd have to migrate to another DNS provider, or alternatively move the site to the `www.` subdomain.

Neither of these options is going to be quick, and so this interim solution has been put in place to still allow us to move forward with Azure Front Door.  

## How will traffic flow?

The DNS records for the public sites will be updated to point to our App Gateways' public IP addresses.

The vast majority of the user audience are based in the UK.  When they visit the site, they will be directed to the Application Gateway in West Europe.  This will then proxy straight through to Azure Front Door which will then hit a caching edge in West Europe also.  We will get cached content returned from Azure Front Door.

So the downside is that we don't get the optimisation of using the closest CDN edges to the users, but West Europe isn't a terrible internet hop to make for users in the UK.  The advantage is we get to use Azure Front Door's caching until we've resolved the apex domain issue, plus the public site will now be behind a WAF.