### PR TITLE
EES-6194 - Fixing bug checking screener progress for uploading subjects as an analyst

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
@@ -23,7 +23,8 @@ public class DataSetScreenerServicePermissionsTests
     [Fact]
     public async Task GetScreenerProgress()
     {
-        ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+        ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion().WithRelease(_dataFixture.DefaultRelease());
+
         DataSetUpload upload = _dataFixture.DefaultDataSetUpload().WithReleaseVersionId(releaseVersion.Id);
 
         await using var contentDbContext = DbUtils.InMemoryApplicationDbContext();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -577,7 +577,9 @@ public abstract class DataSetScreenerServiceTests
         public async Task DataSetWithScreenerProgress_ProgressUpdatesReturned()
         {
             // Arrange
-            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+            ReleaseVersion releaseVersion = _dataFixture
+                .DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease());
 
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
@@ -647,7 +649,9 @@ public abstract class DataSetScreenerServiceTests
         public async Task DataSetBeingScreened_NoProgressUpdatesYet_NullProgressUpdateReturned()
         {
             // Arrange
-            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+            ReleaseVersion releaseVersion = _dataFixture
+                .DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease());
 
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -202,7 +202,8 @@ public class DataSetScreenerService(
     )
     {
         return contentDbContext
-            .ReleaseVersions.SingleOrNotFound(rv => rv.Id == releaseVersionId)
+            .ReleaseVersions.Include(rv => rv.Release)
+            .SingleOrNotFound(rv => rv.Id == releaseVersionId)
             .OnSuccess(userService.CheckCanViewReleaseVersion)
             .OnSuccess(() =>
                 contentDbContext.DataSetUploads.SingleOrNotFoundAsync(


### PR DESCRIPTION
When EES-6194 was rebased onto dev, after sitting there for a couple of weeks, another authorization check sneaked into the code which now required a navigation property to successfully run the authorization check. We didn't re-run the robot tests at the time as it looked like everything should have been ok. This case was missed.

This PR fixes that bug, which stopped analysts from successfully checking the screener progress of an uploaded subject