### PR TITLE
EES-7285 Disable npm data source in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,20 +22,6 @@
   },
   "packageRules": [
     {
-      "matchDatasources": ["npm"],
-      "groupName": "Minor frontend dependencies",
-      "matchUpdateTypes": ["minor", "patch"],
-      "schedule": ["every month"],
-      "enabled": true
-    },
-    {
-      "matchDatasources": ["npm"],
-      "groupName": "Major frontend dependencies",
-      "matchUpdateTypes": ["major"],
-      "schedule": ["every 3 months"],
-      "enabled": true
-    },
-    {
       "matchDatasources": ["nuget"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
@@ -110,27 +96,26 @@
     },
     {
       "matchDatasources": ["pypi"],
-      "groupName": "Python dependencies",
       "enabled": false
     },
     {
       "matchDatasources": ["docker"],
-      "groupName": "Docker image updates",
       "enabled": false
     },
     {
       "matchDatasources": ["dotnet-version"],
-      "groupName": ".NET version",
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["npm"],
       "enabled": false
     },
     {
       "matchPackageNames": ["node"],
-      "groupName": "Node version",
       "enabled": false
     },
     {
       "matchDatasources": ["ruby-version"],
-      "groupName": "Ruby version",
       "enabled": false
     },
     {
@@ -139,8 +124,6 @@
     },
     {
       "matchDatasources": ["azure-bicep-resource"],
-      "groupName": "Azure Bicep resources",
-      "description": "Prevent unofficial resource versions being suggested",
       "enabled": false
     }
   ]


### PR DESCRIPTION
Renovate has been raising PR's for minor and major package updates. These contain so many outdated packages (which also have interdependencies that would need to be resolved), that it’s unfeasible that all of the changes necessary to get them building can be done in one go.

The PR’s are also regularly being updated with new package changes all the time, causing unnecessary rebuilds in DevOps, since they are never going to pass the build checks in their current state.

We've agreed that we will move to managing frontend dependencies via Jira tickets.

Although it was handy to be able to view the PR’s to see a list of the outdated packages, it will be possible to identify outdated and vulnerable packages using straightforward commands that can be run on a terminal in the frontend codebase, e.g. `pnpm audit` and `pnpm outdated`.

### Other changes

- Remove unnecessary group names for disabled data sources.