### PR TITLE
EES-7312 - Fixing the robot test failure due to some dates being displayed in local time rather than British time in the dev environment DevOps pipeline

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -85,14 +85,16 @@ export default function PublicationPublishedReleasesTable({
                   </td>
                   <td>
                     {release.publishedDisplayDate && (
-                      <FormattedDate>
+                      <FormattedDate usingUkTime>
                         {release.publishedDisplayDate}
                       </FormattedDate>
                     )}
                   </td>
                   <td>
                     {release.lastPublished && (
-                      <FormattedDate>{release.lastPublished}</FormattedDate>
+                      <FormattedDate usingUkTime>
+                        {release.lastPublished}
+                      </FormattedDate>
                     )}
                   </td>
                   <td>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNote.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNote.tsx
@@ -41,7 +41,10 @@ export default function ReleaseNote({
         />
       ) : (
         <>
-          <FormattedDate className="govuk-body govuk-!-font-weight-bold">
+          <FormattedDate
+            className="govuk-body govuk-!-font-weight-bold"
+            usingUkTime
+          >
             {releaseNote.on}
           </FormattedDate>
           <p>{releaseNote.reason}</p>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummaryBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummaryBlock.tsx
@@ -109,7 +109,7 @@ export default function ReleaseSummaryBlock({
 
           <ListItem term="Published">
             {releaseDate ? (
-              <FormattedDate>{parseISO(releaseDate)}</FormattedDate>
+              <FormattedDate usingUkTime>{parseISO(releaseDate)}</FormattedDate>
             ) : (
               <p className="govuk-!-margin-bottom-0">TBA</p>
             )}
@@ -118,7 +118,9 @@ export default function ReleaseSummaryBlock({
           {(isEditing || lastUpdated) && (
             <ListItem term="Last updated">
               {lastUpdated ? (
-                <FormattedDate>{parseISO(lastUpdated)}</FormattedDate>
+                <FormattedDate usingUkTime>
+                  {parseISO(lastUpdated)}
+                </FormattedDate>
               ) : (
                 <p className="govuk-!-margin-bottom-0">TBA</p>
               )}

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummaryBlockMobile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummaryBlockMobile.tsx
@@ -72,13 +72,15 @@ export default function ReleaseSummaryBlockMobile({
               <p>
                 <span className="dfe-colour--dark-grey">Last updated</span>{' '}
                 {isEditing && !lastUpdated && 'Currently editing'}
-                {lastUpdated && <FormattedDate>{lastUpdated}</FormattedDate>}
+                {lastUpdated && (
+                  <FormattedDate usingUkTime>{lastUpdated}</FormattedDate>
+                )}
               </p>
             ) : (
               <p>
                 <span className="dfe-colour--dark-grey">Published</span>{' '}
                 {releaseDate ? (
-                  <FormattedDate>{releaseDate}</FormattedDate>
+                  <FormattedDate usingUkTime>{releaseDate}</FormattedDate>
                 ) : (
                   <span>TBA</span>
                 )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseUpdatesPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseUpdatesPage.tsx
@@ -73,7 +73,7 @@ const ReleaseUpdatesPage = ({
               {results.map(update => (
                 <tr key={update.date}>
                   <td>
-                    <FormattedDate>{update.date}</FormattedDate>
+                    <FormattedDate usingUkTime>{update.date}</FormattedDate>
                   </td>
                   <td>{update.summary}</td>
                 </tr>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationResultSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationResultSummary.tsx
@@ -70,7 +70,9 @@ const PublicationResultSummary = ({ publication }: Props) => {
           {releaseTypes[type]}
         </SummaryListItem>
         <SummaryListItem term="Published">
-          <FormattedDate format="d MMM yyyy">{published}</FormattedDate>
+          <FormattedDate format="d MMM yyyy" usingUkTime>
+            {published}
+          </FormattedDate>
         </SummaryListItem>
         <SummaryListItem term="Theme">{theme}</SummaryListItem>
       </SummaryList>


### PR DESCRIPTION
When viewing a release on the Admin site, or the Public site, the Published/Last Updated/Update Note dates are all being displayed in the machines local time. This is causing issues sometimes whereby we sometimes display a different date depending which time zone we are in (on the local machine).

All dates are stored in the database as UTC, and when we generate one of these dates in BST it will store it as 23:00:00 the night before for the Update Notes (because that would be the UTC time). Similarly for the published/last updated dates, these would be stored an hour behind BST too.

When the UI displays these, it assumes those dates are in UTC (which is correct, as they are), but displays them in the local time zone of the machine. So, if the local time zone was UTC,  and the stored date was `2018-04-18 23:00:00.0000000`, it would display the **18th April 2026,** rather than the **19th April 2026** (due to not shifting the clock forward 1 hour to account for BST). If you were viewing the page on a device which is in the BST time zone, the **19th April 2026** would be displayed instead.

 

We want to be consistent with how we are displaying these, and always display them in British time.

 

In addition to this, it was causing a UI robot test failure on the dev environment due to the fact that the robot test is hard-coded to expect the British time zone date (i.e. the **19th April 2026**), but the DevOps pipeline is running in the UTC time zone, so the robot test was seeing **18th April 2026** and failing. The test passes fine locally as we are all in British time zones.

So this work is to make the dates always display in British time, and also fix this robot test in the process.

 

**The test suite failing on the Dev environment is:**

`general_public/release_page_absence.robot`

**Test:**

`Verify the release updates page`

**Step:**

`user checks table cell contains 3, 1, 19 April 2018, testid:release-updates-table`

**Screenshot of actual date displayed:**

<img width="1920" height="1080" alt="18-selenium-screenshot-1" src="https://github.com/user-attachments/assets/25e0cb0c-14d1-4970-983d-c3f49af590a6" />
