### PR TITLE
EES-7315 Remove the nl-search-locations-dictionary container and associated environment variables

### DIFF
--- a/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
+++ b/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
@@ -17,16 +17,6 @@ param searchServiceNLSearchFilterIndexName string
 @description('Name of the \'Natural language search dataset\' index in Azure AI Search.')
 param searchServiceNLSearchDatasetIndexName string
 
-@description('Name of the Search storage account.')
-param searchStorageAccountName string
-
-@description('The connection string to the Search storage account.')
-@secure()
-param searchStorageAccountConnectionStringSecretName string
-
-@description('Name of the storage container in the Search storage account that stores the locations dictionary.')
-param locationsDictionaryContainerName string
-
 @description('The IP address ranges that can access the Natural Language Search Function App storage account.')
 param storageFirewallRules IpRange[]
 
@@ -64,20 +54,6 @@ resource outboundVnetSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-07-0
 resource nlSearchFunctionAppPrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' existing = {
   name: resourceNames.existingResources.subnets.nlSearchFunctionAppPrivateEndpoints
   parent: vNet
-}
-
-resource searchStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
-  name: searchStorageAccountName
-}
-
-resource searchBlobStorage 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
-  name: 'default'
-  parent: searchStorageAccount
-}
-
-resource locationsDictionaryContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' existing = {
-  parent: searchBlobStorage
-  name: locationsDictionaryContainerName
 }
 
 resource searchService 'Microsoft.Search/searchServices@2025-05-01' existing = {
@@ -126,14 +102,6 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
       {
         name: 'AZURE_OPENAI_API_VERSION'
         value: '2024-10-21'
-      }
-      {
-        name: 'LOCATIONS_DICT_CONTAINER_NAME'
-        value: locationsDictionaryContainer.name
-      }
-      {
-        name: 'SEARCH_STORAGE_CONN_STRING'
-        value: '@Microsoft.KeyVault(VaultName=${keyVault.name};SecretName=${searchStorageAccountConnectionStringSecretName})'
       }
     ]
     functionAppExists: functionAppExists

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -16,7 +16,6 @@ param searchStorageDocumentContainers object = {
   searchDocuments: 'searchable-documents'
   nlSearchDatasetDocuments: 'nl-search-dataset-documents'
   nlSearchFilterDocuments: 'nl-search-filter-documents'
-  nlSearchLocationsDictionary: 'nl-search-locations-dictionary'
 }
 
 @description('Indicates whether API keys are permitted for authentication to the Azure AI Search service in addition to role-based access control (RBAC). Disabling API keys forces all clients to use RBAC only.')

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -110,9 +110,6 @@ module nlSearchFunctionAppModule 'application/nlSearchFunctionApp.bicep' = if (d
     functionAppFirewallRules: []
     logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId
     searchServiceName: searchServiceModule.outputs.searchServiceName
-    searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
-    searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
-    locationsDictionaryContainerName: searchServiceModule.outputs.searchStorageDocumentContainers.nlSearchLocationsDictionary
     searchServiceNLSearchFilterIndexName: searchServiceNLSearchFilterIndexName
     searchServiceNLSearchDatasetIndexName: searchServiceNLSearchDatasetIndexName
     storageFirewallRules: maintenanceIpRanges


### PR DESCRIPTION
This PR removes the `nl-search-locations-dictionary` container from Azure Blob Storage and associated environment variables  from the Natural language search function app - `LOCATIONS_DICT_CONTAINER_NAME` and `SEARCH_STORAGE_CONN_STRING`.

These are no longer required following a corresponding change to the app made by https://github.com/dfe-analytical-services/ees-natural-language-search/pull/30.