### PR TITLE
EES-6817 - switching local environments over to using background screening by default

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -51,7 +51,7 @@
   "DataScreener": {
     "Url": "http://localhost:7078/api",
     "ScreenerStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://data-storage:10001/devstoreaccount1;",
-    "EnhancedScreenerJourney": "false",
+    "EnhancedScreenerJourney": "true",
     "ScreenerProgressUpdateIntervalSeconds": 5,
     "ScreenerProgressUpdateFailureIntervalMinutes": 1440
   },


### PR DESCRIPTION
This PR:
- switches local environments over to using background screening by default.

Along with this, I'll send out instructions to get people to set `BACKGROUND_SCREENING=True` in their Robot .env files.