### PR TITLE
EES-6891: Download large data cuts in the table tool in CSV format

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterItemRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterItemRepository.cs
@@ -113,14 +113,8 @@ public class FilterItemRepository(
         );
     }
 
-    public async Task<IList<FilterItem>> GetFilterItemsFromObservations(IEnumerable<Observation> observations)
+    public async Task<IList<FilterItem>> GetFilterItems(IEnumerable<Guid> filterItemIds)
     {
-        var filterItemIds = observations
-            .SelectMany(observation => observation.FilterItems)
-            .Select(ofi => ofi.FilterItemId)
-            .Distinct()
-            .ToList();
-
         return await statisticsDbContext
             .FilterItem.AsNoTracking()
             .Include(fi => fi.FilterGroup)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
@@ -34,14 +34,11 @@ public interface IFilterItemRepository
 
     /// <summary>
     /// Method to retrieve a set of <see cref="FilterItem" />s, their <see cref="FilterGroup" />s and
-    /// <see cref="Filter" />s that are present on a given set of Observations.
-    ///
-    /// Note that this method is for use when there is a set of Observations that has been fetched into memory
-    /// already, as it is optimised for this scenario.
+    /// <see cref="Filter" />s that are related to a given set of <paramref name="filterItemIds"/>.
     /// </summary>
     ///
-    /// <param name="observations">A set of Observations that have been already fetched into memory.</param>
+    /// <param name="filterItemIds">A set of Filter Item IDs to retrieve.</param>
     /// <returns>a set of <see cref="FilterItem" />s, their <see cref="FilterGroup" />s and
     /// <see cref="Filter" />s</returns>
-    Task<IList<FilterItem>> GetFilterItemsFromObservations(IEnumerable<Observation> observations);
+    Task<IList<FilterItem>> GetFilterItems(IEnumerable<Guid> filterItemIds);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServicePermissionTests.cs
@@ -37,7 +37,7 @@ public class SubjectCsvMetaServicePermissionTests
 
                 var query = new FullTableQuery { SubjectId = SubjectId };
 
-                return await service.GetSubjectCsvMeta(ReleaseSubject, query, new List<Observation>());
+                return await service.GetSubjectCsvMeta(ReleaseSubject, query);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServiceTests.cs
@@ -170,10 +170,12 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filter0Items.Concat(filter1Items).Concat(filter2Items).Select(fi => fi.Id)],
+                LocationIds = [.. locations.Select(l => l.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -297,10 +299,21 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
+                Filters = new[]
+                {
+                    filter0Items[0],
+                    filter0Items[1],
+                    filter1Items[0],
+                    filter1Items[1],
+                    filter2Items[0],
+                    filter2Items[1],
+                }
+                    .Select(fi => fi.Id)
+                    .ToList(),
                 Indicators = indicators.Select(i => i.Id),
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -404,7 +417,7 @@ public class SubjectCsvMetaServiceTests
                 Indicators = indicators[1..2].Concat(indicators[4..6]).Select(i => i.Id),
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -486,7 +499,7 @@ public class SubjectCsvMetaServiceTests
                 Indicators = ListOf(Guid.NewGuid(), Guid.NewGuid()),
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -572,10 +585,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
+                LocationIds = new List<Guid> { locations[0].Id, locations[3].Id },
                 Indicators = indicators.Select(i => i.Id),
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -646,7 +660,7 @@ public class SubjectCsvMetaServiceTests
 
             var query = new FullTableQuery { SubjectId = releaseSubject.SubjectId };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, new List<Observation>());
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -763,10 +777,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -941,10 +956,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filter0Items.Concat(filter1Items).Concat(filter2Items).Select(fi => fi.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -1065,10 +1081,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = ListOf(indicators[1].Id, indicators[3].Id),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                Indicators = [.. ListOf(indicators[1].Id, indicators[3].Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -1178,10 +1195,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = ListOf(Guid.NewGuid(), Guid.NewGuid()),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                Indicators = [.. ListOf(Guid.NewGuid(), Guid.NewGuid())],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -1290,10 +1308,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -1438,10 +1457,11 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 
@@ -1527,10 +1547,12 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                LocationIds = [.. observations.Select(o => o.Location.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             var viewModel = result.AssertRight();
 
@@ -1643,10 +1665,12 @@ public class SubjectCsvMetaServiceTests
             var query = new FullTableQuery
             {
                 SubjectId = releaseSubject.SubjectId,
-                Indicators = indicators.Select(i => i.Id).ToList(),
+                Filters = [.. filterItems.Select(fi => fi.Id)],
+                LocationIds = [.. observations.Select(o => o.Location.Id)],
+                Indicators = [.. indicators.Select(i => i.Id)],
             };
 
-            var result = await service.GetSubjectCsvMeta(releaseSubject, query, observations);
+            var result = await service.GetSubjectCsvMeta(releaseSubject, query);
 
             VerifyAllMocks(releaseFileBlobService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
@@ -121,7 +121,7 @@ public class SubjectResultMetaServiceTests
 
         boundaryLevelRepository.Setup(s => s.FindByGeographicLevels(new List<GeographicLevel>())).Returns([]);
 
-        filterItemRepository.Setup(s => s.GetFilterItemsFromObservations(observations)).ReturnsAsync([]);
+        filterItemRepository.Setup(s => s.GetFilterItems(query.GetFilterItemIds())).ReturnsAsync([]);
 
         locationService
             .Setup(s =>
@@ -286,7 +286,7 @@ public class SubjectResultMetaServiceTests
             )
             .Returns(new List<BoundaryLevel> { _countriesBoundaryLevel, _regionsBoundaryLevel });
 
-        filterItemRepository.Setup(s => s.GetFilterItemsFromObservations(observations)).ReturnsAsync([]);
+        filterItemRepository.Setup(s => s.GetFilterItems(query.GetFilterItemIds())).ReturnsAsync([]);
 
         footnoteRepository
             .Setup(s => s.GetFilteredFootnotes(releaseVersion.Id, subject.Id, new List<Guid>(), query.Indicators))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -703,7 +703,6 @@ public class TableBuilderServiceTests
             var observationService = new Mock<IObservationService>(Strict);
             var matchedObservationsTable = Mock.Of<ITempTableReference>(Strict);
             var subjectCsvMetaService = new Mock<ISubjectCsvMetaService>(Strict);
-            var tableBuilderQueryOptimiser = new Mock<ITableBuilderQueryOptimiser>(Strict);
 
             observationService
                 .Setup(s => s.GetMatchedObservations(query, default))
@@ -747,27 +746,23 @@ public class TableBuilderServiceTests
                             && rs.SubjectId == releaseSubject.SubjectId
                         ),
                         query,
-                        It.IsAny<IList<Observation>>(),
                         default
                     )
                 )
                 .ReturnsAsync(subjectCsvMeta);
 
-            tableBuilderQueryOptimiser.Setup(s => s.IsCroppingRequired(query)).ReturnsAsync(true);
-
             var service = BuildTableBuilderService(
                 statisticsDbContext,
                 contentDbContext,
                 observationService: observationService.Object,
-                subjectCsvMetaService: subjectCsvMetaService.Object,
-                tableBuilderQueryOptimiser: tableBuilderQueryOptimiser.Object
+                subjectCsvMetaService: subjectCsvMetaService.Object
             );
 
             using var stream = new MemoryStream();
 
             var result = await service.QueryToCsvStream(query, stream);
 
-            VerifyAllMocks(observationService, subjectCsvMetaService, tableBuilderQueryOptimiser);
+            VerifyAllMocks(observationService, subjectCsvMetaService);
 
             result.AssertRight();
 
@@ -986,7 +981,6 @@ public class TableBuilderServiceTests
             var observationService = new Mock<IObservationService>(Strict);
             var matchedObservationsTable = Mock.Of<ITempTableReference>(Strict);
             var subjectCsvMetaService = new Mock<ISubjectCsvMetaService>(Strict);
-            var tableBuilderQueryOptimiser = new Mock<ITableBuilderQueryOptimiser>(Strict);
 
             observationService
                 .Setup(s => s.GetMatchedObservations(query, default))
@@ -1027,27 +1021,23 @@ public class TableBuilderServiceTests
                             && rs.SubjectId == releaseSubject.SubjectId
                         ),
                         query,
-                        It.IsAny<IList<Observation>>(),
                         default
                     )
                 )
                 .ReturnsAsync(subjectCsvMeta);
 
-            tableBuilderQueryOptimiser.Setup(s => s.IsCroppingRequired(query)).ReturnsAsync(true);
-
             var service = BuildTableBuilderService(
                 statisticsDbContext,
                 contentDbContext,
                 observationService: observationService.Object,
-                subjectCsvMetaService: subjectCsvMetaService.Object,
-                tableBuilderQueryOptimiser: tableBuilderQueryOptimiser.Object
+                subjectCsvMetaService: subjectCsvMetaService.Object
             );
 
             using var stream = new MemoryStream();
 
             var result = await service.QueryToCsvStream(releaseSubject.ReleaseVersionId, query, stream);
 
-            VerifyAllMocks(observationService, subjectCsvMetaService, tableBuilderQueryOptimiser);
+            VerifyAllMocks(observationService, subjectCsvMetaService);
 
             result.AssertRight();
 
@@ -1127,7 +1117,6 @@ public class TableBuilderServiceTests
             var observationService = new Mock<IObservationService>(Strict);
             var matchedObservationsTable = Mock.Of<ITempTableReference>(Strict);
             var subjectCsvMetaService = new Mock<ISubjectCsvMetaService>(Strict);
-            var tableBuilderQueryOptimiser = new Mock<ITableBuilderQueryOptimiser>(Strict);
 
             observationService
                 .Setup(s => s.GetMatchedObservations(query, default))
@@ -1159,27 +1148,23 @@ public class TableBuilderServiceTests
                             && rs.SubjectId == releaseSubject.SubjectId
                         ),
                         query,
-                        It.IsAny<IList<Observation>>(),
                         default
                     )
                 )
                 .ReturnsAsync(subjectCsvMeta);
 
-            tableBuilderQueryOptimiser.Setup(s => s.IsCroppingRequired(query)).ReturnsAsync(false);
-
             var service = BuildTableBuilderService(
                 statisticsDbContext,
                 contentDbContext,
                 observationService: observationService.Object,
-                subjectCsvMetaService: subjectCsvMetaService.Object,
-                tableBuilderQueryOptimiser: tableBuilderQueryOptimiser.Object
+                subjectCsvMetaService: subjectCsvMetaService.Object
             );
 
             using var stream = new MemoryStream();
 
             var result = await service.QueryToCsvStream(releaseSubject.ReleaseVersionId, query, stream);
 
-            VerifyAllMocks(observationService, subjectCsvMetaService, tableBuilderQueryOptimiser);
+            VerifyAllMocks(observationService, subjectCsvMetaService);
 
             result.AssertRight();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IObservationService.cs
@@ -8,10 +8,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 public interface IObservationService
 {
     /// <summary>
-    /// Finds <see cref="Observation">Observation rows</see> that match the given
-    /// <see cref="FullTableQuery">Observation query</see> and stores the matching row Ids in the
-    /// <see cref="MatchedObservation">#MatchedObservation temporary table.</see>
-    /// This method then returns the query to select those matching Ids from the temporary table. This query can
+    /// Finds <see cref="Observation" /> rows that match the given
+    /// <see cref="FullTableQuery" /> and stores the matching row Ids in the
+    /// <see cref="MatchedObservation" /> temporary table.
+    /// This method then returns the query to select those matching IDs from the temporary table. This query can
     /// be used by client code to then quickly select against the matched Observations by making use of the
     /// populated temporary table results.
     ///

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectCsvMetaService.cs
@@ -12,7 +12,6 @@ public interface ISubjectCsvMetaService
     Task<Either<ActionResult, SubjectCsvMetaViewModel>> GetSubjectCsvMeta(
         ReleaseSubject releaseSubject,
         FullTableQuery query,
-        IList<Observation> observations,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
@@ -49,7 +49,6 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
     public async Task<Either<ActionResult, SubjectCsvMetaViewModel>> GetSubjectCsvMeta(
         ReleaseSubject releaseSubject,
         FullTableQuery query,
-        IList<Observation> observations,
         CancellationToken cancellationToken = default
     )
     {
@@ -58,8 +57,8 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
             .OnSuccess(() => GetCsvStream(releaseSubject, cancellationToken))
             .OnSuccess(async csvStream =>
             {
-                var locations = GetLocations(observations);
-                var filters = await GetFilters(observations);
+                var locations = GetLocations(query.LocationIds.Distinct());
+                var filters = await GetFilters(query.GetFilterItemIds().Distinct());
                 var indicators = await GetIndicators(query);
                 var headers = csvStream is not null
                     ? await ListCsvHeaders(csvStream, filters, indicators)
@@ -158,18 +157,19 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
         return filteredHeaders;
     }
 
-    private static Dictionary<Guid, Dictionary<string, string>> GetLocations(IEnumerable<Observation> observations)
+    private Dictionary<Guid, Dictionary<string, string>> GetLocations(IEnumerable<Guid> locationIds)
     {
-        return observations
-            .Select(observation => observation.Location)
-            .Distinct()
-            .ToDictionary(location => location.Id, location => location.GetCsvValues());
+        var distinctLocationIds = locationIds.Distinct().ToList();
+
+        var locations = _statisticsDbContext
+            .Location.AsNoTracking()
+            .Where(location => distinctLocationIds.Contains(location.Id));
+        return locations.ToDictionary(location => location.Id, location => location.GetCsvValues());
     }
 
-    private async Task<Dictionary<string, FilterCsvMetaViewModel>> GetFilters(IEnumerable<Observation> observations)
+    private async Task<Dictionary<string, FilterCsvMetaViewModel>> GetFilters(IEnumerable<Guid> filterItemIds)
     {
-        var filterItems = await _filterItemRepository.GetFilterItemsFromObservations(observations);
-
+        var filterItems = await _filterItemRepository.GetFilterItems(filterItemIds);
         return FiltersMetaViewModelBuilder.BuildCsvFiltersFromFilterItems(filterItems);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
@@ -57,8 +57,8 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
             .OnSuccess(() => GetCsvStream(releaseSubject, cancellationToken))
             .OnSuccess(async csvStream =>
             {
-                var locations = GetLocations(query.LocationIds.Distinct());
-                var filters = await GetFilters(query.GetFilterItemIds().Distinct());
+                var locations = GetLocations([.. query.LocationIds]);
+                var filters = await GetFilters([.. query.GetFilterItemIds()]);
                 var indicators = await GetIndicators(query);
                 var headers = csvStream is not null
                     ? await ListCsvHeaders(csvStream, filters, indicators)
@@ -157,17 +157,15 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
         return filteredHeaders;
     }
 
-    private Dictionary<Guid, Dictionary<string, string>> GetLocations(IEnumerable<Guid> locationIds)
+    private Dictionary<Guid, Dictionary<string, string>> GetLocations(HashSet<Guid> locationIds)
     {
-        var distinctLocationIds = locationIds.Distinct().ToList();
-
         var locations = _statisticsDbContext
             .Location.AsNoTracking()
-            .Where(location => distinctLocationIds.Contains(location.Id));
+            .Where(location => locationIds.Contains(location.Id));
         return locations.ToDictionary(location => location.Id, location => location.GetCsvValues());
     }
 
-    private async Task<Dictionary<string, FilterCsvMetaViewModel>> GetFilters(IEnumerable<Guid> filterItemIds)
+    private async Task<Dictionary<string, FilterCsvMetaViewModel>> GetFilters(HashSet<Guid> filterItemIds)
     {
         var filterItems = await _filterItemRepository.GetFilterItems(filterItemIds);
         return FiltersMetaViewModelBuilder.BuildCsvFiltersFromFilterItems(filterItems);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
@@ -95,7 +95,7 @@ public class SubjectResultMetaService : ISubjectResultMetaService
                     subjectId: releaseSubject.SubjectId
                 );
 
-                var filterItems = await _filterItemRepository.GetFilterItemsFromObservations(observations);
+                var filterItems = await _filterItemRepository.GetFilterItems(query.GetFilterItemIds());
                 var filterViewModels = FiltersMetaViewModelBuilder.BuildFiltersFromFilterItems(
                     filterItems,
                     releaseFile.FilterSequence

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Dynamic;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using CsvHelper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -29,6 +30,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services;
 
 public class TableBuilderService : ITableBuilderService
 {
+    private const int ObservationBatchSize = 1000;
+
     private readonly StatisticsDbContext _statisticsDbContext;
     private readonly ContentDbContext _contentDbContext;
     private readonly ILocationService _locationService;
@@ -163,34 +166,44 @@ public class TableBuilderService : ITableBuilderService
             .OnSuccess(_userService.CheckCanViewSubjectData)
             .OnSuccessVoid(async releaseSubject =>
             {
-                await ListQueryObservations(query, cancellationToken)
-                    .OnSuccessVoid(
-                        async (result) =>
+                await _subjectCsvMetaService
+                    .GetSubjectCsvMeta(releaseSubject, query, cancellationToken)
+                    .OnSuccessVoid(async meta =>
+                    {
+                        await using var writer = new StreamWriter(stream, leaveOpen: true);
+                        await using var csv = new CsvWriter(writer, CultureInfo.InvariantCulture, leaveOpen: true);
+
+                        await WriteCsvHeaderRow(csv, meta);
+                        await foreach (var batch in ListQueryObservationBatches(query, cancellationToken))
                         {
-                            var (observations, _) = result;
-
-                            await _subjectCsvMetaService
-                                .GetSubjectCsvMeta(releaseSubject, query, observations, cancellationToken)
-                                .OnSuccessVoid(async meta =>
-                                {
-                                    await using var writer = new StreamWriter(stream, leaveOpen: true);
-                                    await using var csv = new CsvWriter(
-                                        writer,
-                                        CultureInfo.InvariantCulture,
-                                        leaveOpen: true
-                                    );
-
-                                    await WriteCsvHeaderRow(csv, meta);
-                                    await WriteCsvRows(csv, observations, meta, cancellationToken);
-                                });
+                            await WriteCsvRows(csv, batch, meta, cancellationToken);
                         }
-                    );
+                    });
             });
     }
 
     private async Task<Either<ActionResult, (List<Observation>, bool)>> ListQueryObservations(
         FullTableQuery query,
         CancellationToken cancellationToken = default
+    )
+    {
+        return await PrepareObservationQuery(query, cancellationToken)
+            .OnSuccess(async preparedQuery =>
+            {
+                var observationsQuery = await BuildMatchedObservationsQuery(preparedQuery.Query, cancellationToken);
+                var observations = await observationsQuery.ToListAsync(cancellationToken);
+
+                return (observations, preparedQuery.RequiresCropping);
+            });
+    }
+
+    /// <summary>
+    /// Determines whether the query needs cropping to stay within the maximum allowable table size and, if so,
+    /// either crops it or fails validation. Returns the (possibly cropped) query ready to be executed.
+    /// </summary>
+    private async Task<Either<ActionResult, PreparedObservationQuery>> PrepareObservationQuery(
+        FullTableQuery query,
+        CancellationToken cancellationToken
     )
     {
         var requiresCropping = await _tableBuilderQueryOptimiser.IsCroppingRequired(query);
@@ -205,18 +218,63 @@ public class TableBuilderService : ITableBuilderService
             query = await _tableBuilderQueryOptimiser.CropQuery(query, cancellationToken);
         }
 
+        return new PreparedObservationQuery(query, requiresCropping);
+    }
+
+    /// <summary>
+    /// Populates the matched observations for the query and returns a queryable over the corresponding
+    /// observations. The query is not executed here, allowing callers to either materialise it in full or
+    /// stream it.
+    /// </summary>
+    private async Task<IQueryable<Observation>> BuildMatchedObservationsQuery(
+        FullTableQuery query,
+        CancellationToken cancellationToken
+    )
+    {
         await _observationService.GetMatchedObservations(query, cancellationToken);
 
         var matchedObservationIds = _statisticsDbContext.MatchedObservations.Select(o => o.Id);
 
-        var results = _statisticsDbContext
+        return _statisticsDbContext
             .Observation.AsNoTracking()
             .Include(o => o.Location)
             .Include(o => o.FilterItems)
             .Where(o => matchedObservationIds.Contains(o.Id));
-
-        return (await results.ToListAsync(cancellationToken), requiresCropping);
     }
+
+    /// <summary>
+    /// Streams the observations matching the query from the database in batches of
+    /// <see cref="ObservationBatchSize"/>. Each batch is yielded as it is read so that callers only need to hold a
+    /// single batch in memory at any one time. Once a batch has been consumed it becomes eligible for garbage
+    /// collection.
+    /// </summary>
+    private async IAsyncEnumerable<List<Observation>> ListQueryObservationBatches(
+        FullTableQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        var observations = await BuildMatchedObservationsQuery(query, cancellationToken);
+
+        var batch = new List<Observation>(ObservationBatchSize);
+
+        await foreach (var observation in observations.AsAsyncEnumerable().WithCancellation(cancellationToken))
+        {
+            batch.Add(observation);
+
+            if (batch.Count == ObservationBatchSize)
+            {
+                yield return batch;
+                batch = new List<Observation>(ObservationBatchSize);
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            yield return batch;
+        }
+    }
+
+    private record PreparedObservationQuery(FullTableQuery Query, bool RequiresCropping);
 
     private async Task<Either<ActionResult, Guid>> FindLatestPublishedReleaseVersionId(Guid subjectId)
     {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -12,7 +12,6 @@ import Yup from '@common/validation/yup';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import copyElementToClipboard from '@common/utils/copyElementToClipboard';
 import React, { createElement, RefObject } from 'react';
-import WarningMessage from '@common/components/WarningMessage';
 
 export type FileFormat = 'ods' | 'csv';
 
@@ -61,16 +60,19 @@ const DownloadTable = ({
 
   const options = [
     {
-      label: 'Table in ODS format (spreadsheet, with title and footnotes)',
-      value: 'ods',
-    },
-    {
       label: 'Table in CSV format (flat file, with location codes)',
       value: 'csv',
     },
   ];
 
   const isCroppedTable = fullTable && fullTable.subjectMeta.isCroppedTable;
+
+  if (!isCroppedTable) {
+    options.push({
+      label: 'Table in ODS format (spreadsheet, with title and footnotes)',
+      value: 'ods',
+    });
+  }
 
   return (
     <FormProvider
@@ -85,72 +87,59 @@ const DownloadTable = ({
     >
       {({ formState }) => {
         return (
-          <>
-            <Form
-              id="downloadTableForm"
-              onSubmit={async ({ fileFormat }) => {
-                // TODO EES-5852 analytics for table tool/permalink csv/ods downloads
-                await onSubmit?.(fileFormat);
+          <Form
+            id="downloadTableForm"
+            onSubmit={async ({ fileFormat }) => {
+              // TODO EES-5852 analytics for table tool/permalink csv/ods downloads
+              onSubmit?.(fileFormat);
 
-                if (fileFormat === 'csv') {
-                  await handleCsvDownload();
-                } else {
-                  await handleOdsDownload();
-                }
-              }}
-            >
-              <>
-                {createElement(
-                  headingTag,
-                  {
-                    className: `govuk-heading-${headingSize}`,
-                  },
-                  'Download Table',
-                )}
-                {!isCroppedTable && (
-                  <FormFieldRadioGroup<FormValues>
-                    legend="Select a file format to download:"
-                    legendSize="s"
-                    legendWeight="regular"
-                    name="fileFormat"
-                    small
-                    order={[]}
-                    options={options}
-                  />
-                )}
-                <ButtonGroup>
-                  {!isCroppedTable && (
-                    <Button type="submit" disabled={formState.isSubmitting}>
-                      Download table
-                    </Button>
-                  )}
-                  <Button
-                    variant="secondary"
-                    onClick={() => copyElementToClipboard(tableRef)}
-                  >
-                    Copy table to clipboard
-                  </Button>
-                  <LoadingSpinner
-                    alert
-                    className="govuk-!-margin-left-2"
-                    inline
-                    hideText
-                    loading={formState.isSubmitting}
-                    size="md"
-                    text="Preparing download"
-                  />
-                </ButtonGroup>
-              </>
-            </Form>
-
-            {isCroppedTable && (
-              <WarningMessage>
-                The selections used to generate this table returned too many
-                rows to generate a file download. The full set of relevant data
-                can be downloaded from the publication linked to below.
-              </WarningMessage>
-            )}
-          </>
+              if (fileFormat === 'csv') {
+                await handleCsvDownload();
+              } else {
+                handleOdsDownload();
+              }
+            }}
+          >
+            <>
+              {createElement(
+                headingTag,
+                {
+                  className: `govuk-heading-${headingSize}`,
+                },
+                'Download Table',
+              )}
+              <FormFieldRadioGroup<FormValues>
+                legend="Select a file format to download full results given by your selection:"
+                legendSize="s"
+                hint="The ODS download option is currently unavailable for large selections"
+                legendWeight="regular"
+                name="fileFormat"
+                small
+                order={[]}
+                options={options}
+              />
+              <ButtonGroup>
+                <Button type="submit" disabled={formState.isSubmitting}>
+                  Download table
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => copyElementToClipboard(tableRef)}
+                >
+                  Copy table to clipboard
+                </Button>
+                <LoadingSpinner
+                  alert
+                  className="govuk-!-margin-left-2"
+                  inline
+                  hideText
+                  loading={formState.isSubmitting}
+                  size="md"
+                  text="Preparing download"
+                />
+              </ButtonGroup>
+            </>
+          </Form>
         );
       }}
     </FormProvider>


### PR DESCRIPTION
This PR separates `Location` and `FilterItem` retrieval from `Observation`s, with the aim of reducing the load on memory by deferring the latter's retrieval until it is ready to be streamed directly into the response CSV downloaded by the client.

The memory load is reduced by splitting the retrieval into small batches of 1,000 rows at a time, which are cleared after writing to the CSV, thus providing the framework with the opportunity to allocate the data to the GC (garbage collector).