### PR TITLE
EES-7266 Add Data API Url as an environment variable to the Natural Language Search function app

### DIFF
--- a/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
+++ b/infrastructure/templates/search/application/nlSearchFunctionApp.bicep
@@ -2,6 +2,9 @@ import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange, FirewallRule } from '../../common/types.bicep'
 import { ResourceNames } from '../types.bicep'
 
+@description('The URL of the Data API.')
+param dataApiUrl string
+
 @description('The IP address ranges that can access the Natural Language Search Function App endpoints.')
 param functionAppFirewallRules FirewallRule[]
 
@@ -102,6 +105,10 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
       {
         name: 'AZURE_OPENAI_API_VERSION'
         value: '2024-10-21'
+      }
+      {
+        name: 'EES_URL_API_DATA'
+        value: dataApiUrl
       }
     ]
     functionAppExists: functionAppExists

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -26,6 +26,9 @@ param dateProvisioned string = utcNow('u')
 @description('The URL of the Content API.')
 param contentApiUrl string
 
+@description('The URL of the Data API.')
+param dataApiUrl string
+
 @description('Specifies whether or not the Natural Language Search Function App already exists.')
 param naturalLanguageSearchFunctionAppExists bool = true
 
@@ -106,6 +109,7 @@ module nlSearchFunctionAppModule 'application/nlSearchFunctionApp.bicep' = if (d
     location: location
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
+    dataApiUrl: dataApiUrl
     functionAppExists: naturalLanguageSearchFunctionAppExists
     functionAppFirewallRules: []
     logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -4,6 +4,7 @@ using '../main.bicep'
 param environmentName = 'Development'
 
 param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
+param dataApiUrl = 'https://data.dev.explore-education-statistics.service.gov.uk'
 param searchServiceSemanticRankerAvailability = 'free'
 
 // Allow API key authentication for the Azure AI Search service to support local development.

--- a/infrastructure/templates/search/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-preprod.bicepparam
@@ -4,4 +4,5 @@ using '../main.bicep'
 param environmentName = 'Pre-Production'
 
 param contentApiUrl = 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
+param dataApiUrl = 'https://data.pre-production.explore-education-statistics.service.gov.uk'
 param searchServiceSemanticRankerAvailability = 'free'

--- a/infrastructure/templates/search/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-prod.bicepparam
@@ -4,4 +4,5 @@ using '../main.bicep'
 param environmentName = 'Production'
 
 param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
+param dataApiUrl = 'https://data.explore-education-statistics.service.gov.uk'
 param searchServiceSemanticRankerAvailability = 'standard'

--- a/infrastructure/templates/search/parameters/main-test.bicepparam
+++ b/infrastructure/templates/search/parameters/main-test.bicepparam
@@ -4,4 +4,5 @@ using '../main.bicep'
 param environmentName = 'Test'
 
 param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
+param dataApiUrl = 'https://data.test.explore-education-statistics.service.gov.uk'
 param searchServiceSemanticRankerAvailability = 'free'


### PR DESCRIPTION
This PR makes an infrastructure change to add the Data API URL as an environment variable to the Natural Language Search function app.

It corresponds with application code changes made in https://github.com/dfe-analytical-services/ees-natural-language-search/pull/28.