### PR TITLE
EES-7144 - updating the public site health endpoint to accept GET requests

### DIFF
--- a/infrastructure/templates/common/components/application-gateway/appGateway.bicep
+++ b/infrastructure/templates/common/components/application-gateway/appGateway.bicep
@@ -260,7 +260,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
       properties: {
         protocol: 'Https'
         path: backend.healthProbePath
-        interval: 30
+        interval: backend.?intervalSeconds ?? 30
         timeout: 30
         unhealthyThreshold: 3
         pickHostNameFromBackendHttpSettings: true

--- a/infrastructure/templates/common/components/application-gateway/types.bicep
+++ b/infrastructure/templates/common/components/application-gateway/types.bicep
@@ -38,6 +38,9 @@ type AppGatewayBackend = {
 
   @description('Additional health probe HTTP status codes that indicate success')
   healthProbeAdditionalStatusCodeMatches: string[]?
+
+  @description('Interval in seconds that the health probe is called. Defaults to 30 seconds if not set.')
+  intervalSeconds: int?
 }
 
 @export()

--- a/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
@@ -135,7 +135,7 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
         name: '${publicSiteAppServiceName}-backend'
         fqdn: publicSiteInternalServiceFqdn
         healthProbePath: '/api/health'
-        healthProbeAdditionalStatusCodeMatches: ['405']
+        intervalSeconds: 60
       }
     ]
     routes: [

--- a/src/explore-education-statistics-frontend/src/pages/api/health.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/health.ts
@@ -2,11 +2,14 @@ import { ErrorBody } from '@frontend/modules/api/types/error';
 import { NextApiRequest, NextApiResponse } from 'next';
 import withMethods from '@frontend/middleware/api/withMethods';
 
+const health = async function (
+  _req: NextApiRequest,
+  res: NextApiResponse<string | ErrorBody>,
+) {
+  return res.status(200).send('Health check OK');
+};
+
 export default withMethods({
-  head: async function health(
-    _req: NextApiRequest,
-    res: NextApiResponse<string | ErrorBody>,
-  ) {
-    return res.status(200).send('Health check OK');
-  },
+  head: health,
+  get: health,
 });


### PR DESCRIPTION
This PR:
- updates the public site's healthcheck endpoint to accept GET requests.
- reduces frequency of health calls.

The reason we have to support GETs is because App Gateway's health probes only support sending GET requests.  We've previously worked around this limitation by allowing 405s to be interpreted as healthy, which works fine.  The issue with this is that it is filling up the public site App Insights with a lot of supposed failing calls, so this change rectifies this.

In addition, we reduce the frequency of health calls, as it is leading to a reported increase in traffic that we're not interested in! 