### PR TITLE
EES-7248: Revert default table tool time period ordering back to ascending

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -137,8 +137,8 @@ describe('getDefaultTableHeadersConfig', () => {
     expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(2);
-    expect(columns[0].label).toBe('2015/16');
-    expect(columns[1].label).toBe('2014/15');
+    expect(columns[0].label).toBe('2014/15');
+    expect(columns[1].label).toBe('2015/16');
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
@@ -243,11 +243,11 @@ describe('getDefaultTableHeadersConfig', () => {
     expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(5);
-    expect(columns[0].label).toBe('2018/19');
-    expect(columns[1].label).toBe('2017/18');
+    expect(columns[0].label).toBe('2014/15');
+    expect(columns[1].label).toBe('2015/16');
     expect(columns[2].label).toBe('2016/17');
-    expect(columns[3].label).toBe('2015/16');
-    expect(columns[4].label).toBe('2014/15');
+    expect(columns[3].label).toBe('2017/18');
+    expect(columns[4].label).toBe('2018/19');
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
@@ -323,8 +323,8 @@ describe('getDefaultTableHeadersConfig', () => {
     expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(2);
-    expect(columns[0].label).toBe('2015/16');
-    expect(columns[1].label).toBe('2014/15');
+    expect(columns[0].label).toBe('2014/15');
+    expect(columns[1].label).toBe('2015/16');
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
@@ -542,7 +542,7 @@ describe('getDefaultTableHeadersConfig', () => {
     const { columns } = getDefaultTableHeaderConfig(testSubjectMeta);
 
     expect(columns).toHaveLength(2);
-    expect(columns[0].label).toBe('2018/19 Autumn Term');
-    expect(columns[1].label).toBe('2017/18 Autumn Term');
+    expect(columns[0].label).toBe('2017/18 Autumn Term');
+    expect(columns[1].label).toBe('2018/19 Autumn Term');
   });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
@@ -80,8 +80,7 @@ function getFixedTimePeriodAndIndicatorTableHeadersConfig(
   return {
     columnGroups,
     rowGroups,
-    // Reverse the order of time periods in columns so they are latest - oldest.
-    columns: filteredTimePeriodRange.reverse(),
+    columns: filteredTimePeriodRange,
     rows: indicators,
   };
 }

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -557,31 +557,31 @@ Validate results table column headings
     user checks table row heading contains    10    1    Indicator 6
 
 Validate row headings
-    user checks table column heading contains    1    1    2022
-    user checks table column heading contains    1    2    2021
+    user checks table column heading contains    1    1    2021
+    user checks table column heading contains    1    2    2022
 
 Validate table cells
-    user checks table cell contains    1    1    56,920,389
-    user checks table cell contains    2    1    75,873,610
-    user checks table cell contains    3    1    49,220,007
-    user checks table cell contains    4    1    31,859,890
-    user checks table cell contains    5    1    63,230,370
-    user checks table cell contains    6    1    54,759,203
-    user checks table cell contains    7    1    10,214,603
-    user checks table cell contains    8    1    28,403,292
-    user checks table cell contains    9    1    24,284,255
-    user checks table cell contains    10    1    39,761,905
+    user checks table cell contains    1    1    91,732,417
+    user checks table cell contains    2    1    89,626,171
+    user checks table cell contains    3    1    51,029,335
+    user checks table cell contains    4    1    83,771,711
+    user checks table cell contains    5    1    91,439,757
+    user checks table cell contains    6    1    84,288,196
+    user checks table cell contains    7    1    68,482,122
+    user checks table cell contains    8    1    65,182,202
+    user checks table cell contains    9    1    61,121,060
+    user checks table cell contains    10    1    37,961,046
 
-    user checks table cell contains    1    2    91,732,417
-    user checks table cell contains    2    2    89,626,171
-    user checks table cell contains    3    2    51,029,335
-    user checks table cell contains    4    2    83,771,711
-    user checks table cell contains    5    2    91,439,757
-    user checks table cell contains    6    2    84,288,196
-    user checks table cell contains    7    2    68,482,122
-    user checks table cell contains    8    2    65,182,202
-    user checks table cell contains    9    2    61,121,060
-    user checks table cell contains    10    2    37,961,046
+    user checks table cell contains    1    2    56,920,389
+    user checks table cell contains    2    2    75,873,610
+    user checks table cell contains    3    2    49,220,007
+    user checks table cell contains    4    2    31,859,890
+    user checks table cell contains    5    2    63,230,370
+    user checks table cell contains    6    2    54,759,203
+    user checks table cell contains    7    2    10,214,603
+    user checks table cell contains    8    2    28,403,292
+    user checks table cell contains    9    2    24,284,255
+    user checks table cell contains    10    2    39,761,905
 
 Go back to locations step
     user clicks button    Edit locations

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -595,25 +595,25 @@ Select indicators and filters in table tool
 
 Validate table
     user waits until results table appears    %{WAIT_LONG}
-    user checks table column heading contains    1    1    2018
-    user checks table column heading contains    1    2    2017
+    user checks table column heading contains    1    1    2014
+    user checks table column heading contains    1    2    2015
     user checks table column heading contains    1    3    2016
-    user checks table column heading contains    1    4    2015
-    user checks table column heading contains    1    5    2014
+    user checks table column heading contains    1    4    2017
+    user checks table column heading contains    1    5    2018
 
     ${row}=    user gets row number with heading    Barnsley
-    user checks table cell in offset row contains    ${row}    0    1    8,123
-    user checks table cell in offset row contains    ${row}    0    2    5,032
+    user checks table cell in offset row contains    ${row}    0    1    9,854
+    user checks table cell in offset row contains    ${row}    0    2    1,134
     user checks table cell in offset row contains    ${row}    0    3    7,419
-    user checks table cell in offset row contains    ${row}    0    4    1,134
-    user checks table cell in offset row contains    ${row}    0    5    9,854
+    user checks table cell in offset row contains    ${row}    0    4    5,032
+    user checks table cell in offset row contains    ${row}    0    5    8,123
 
     ${row}=    user gets row number with heading    Birmingham
-    user checks table cell in offset row contains    ${row}    0    1    3,962
-    user checks table cell in offset row contains    ${row}    0    2    8,530
+    user checks table cell in offset row contains    ${row}    0    1    3,708
+    user checks table cell in offset row contains    ${row}    0    2    9,303
     user checks table cell in offset row contains    ${row}    0    3    8,856
-    user checks table cell in offset row contains    ${row}    0    4    9,303
-    user checks table cell in offset row contains    ${row}    0    5    3,708
+    user checks table cell in offset row contains    ${row}    0    4    8,530
+    user checks table cell in offset row contains    ${row}    0    5    3,962
 
 Validate table has footnotes
     user checks list has x items    testid:footnotes    2

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -90,26 +90,26 @@ Create table
     user waits until results table appears    %{WAIT_SMALL}
 
 Validate results table column headings
-    user checks table column heading contains    1    1    2015/16
-    user checks table column heading contains    1    2    2014/15
-    user checks table column heading contains    1    3    2013/14
-    user checks table column heading contains    1    4    2012/13
+    user checks table column heading contains    1    1    2012/13
+    user checks table column heading contains    1    2    2013/14
+    user checks table column heading contains    1    3    2014/15
+    user checks table column heading contains    1    4    2015/16
 
 Validate Gender male Authorised absence rate row
     ${row}=    user gets row with group and indicator    Gender male    Authorised absence rate
     user checks row contains heading    ${row}    Authorised absence rate
-    user checks row cell contains text    ${row}    1    3.5%
-    user checks row cell contains text    ${row}    2    3.6%
-    user checks row cell contains text    ${row}    3    3.4%
-    user checks row cell contains text    ${row}    4    4.2%
+    user checks row cell contains text    ${row}    1    4.2%
+    user checks row cell contains text    ${row}    2    3.4%
+    user checks row cell contains text    ${row}    3    3.6%
+    user checks row cell contains text    ${row}    4    3.5%
 
 Validate Gender male Overall absence rate row
     ${row}=    user gets row with group and indicator    Gender male    Overall absence rate
     user checks row contains heading    ${row}    Overall absence rate
-    user checks row cell contains text    ${row}    1    4.6%
-    user checks row cell contains text    ${row}    2    4.6%
-    user checks row cell contains text    ${row}    3    4.5%
-    user checks row cell contains text    ${row}    4    5.2%
+    user checks row cell contains text    ${row}    1    5.2%
+    user checks row cell contains text    ${row}    2    4.5%
+    user checks row cell contains text    ${row}    3    4.6%
+    user checks row cell contains text    ${row}    4    4.6%
 
 Validate Gender male Unauthorised absence rate row
     ${row}=    user gets row with group and indicator    Gender male    Unauthorised absence rate
@@ -122,18 +122,18 @@ Validate Gender male Unauthorised absence rate row
 Validate Gender female Authorised absence rate row
     ${row}=    user gets row with group and indicator    Gender female    Authorised absence rate
     user checks row contains heading    ${row}    Authorised absence rate
-    user checks row cell contains text    ${row}    1    3.4%
+    user checks row cell contains text    ${row}    1    4.2%
     user checks row cell contains text    ${row}    2    3.5%
     user checks row cell contains text    ${row}    3    3.5%
-    user checks row cell contains text    ${row}    4    4.2%
+    user checks row cell contains text    ${row}    4    3.4%
 
 Validate Gender female Overall absence rate row
     ${row}=    user gets row with group and indicator    Gender female    Overall absence rate
     user checks row contains heading    ${row}    Overall absence rate
-    user checks row cell contains text    ${row}    1    4.5%
-    user checks row cell contains text    ${row}    2    4.6%
-    user checks row cell contains text    ${row}    3    4.5%
-    user checks row cell contains text    ${row}    4    5.3%
+    user checks row cell contains text    ${row}    1    5.3%
+    user checks row cell contains text    ${row}    2    4.5%
+    user checks row cell contains text    ${row}    3    4.6%
+    user checks row cell contains text    ${row}    4    4.5%
 
 Validate Gender female Unauthorised absence rate row
     ${row}=    user gets row with group and indicator    Gender female    Unauthorised absence rate
@@ -187,14 +187,14 @@ Reorder Overall absence rate to be first
     user presses keys    ${SPACE}
     user clicks button    Done
 
-Reorder 2012/13 to be first
+Reorder 2012/13 to be last
     user clicks button    Reorder    testId:columnGroups-1
     # The /../.. to get to a focusable element
     user sets focus to element    xpath://*[text()="2012/13"]/../..    testId:columnGroups-1
     user presses keys    ${SPACE}
-    user presses keys    ARROW_UP
-    user presses keys    ARROW_UP
-    user presses keys    ARROW_UP
+    user presses keys    ARROW_DOWN
+    user presses keys    ARROW_DOWN
+    user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
     user clicks button    Done
 
@@ -205,14 +205,14 @@ Validate results table column headings after reordering
     user checks table column heading contains    1    1    Gender
     user checks table column heading contains    2    1    Gender male
     user checks table column heading contains    2    2    Gender female
-    user checks table column heading contains    3    1    2012/13
-    user checks table column heading contains    3    2    2015/16
-    user checks table column heading contains    3    3    2014/15
-    user checks table column heading contains    3    4    2013/14
-    user checks table column heading contains    3    5    2012/13
-    user checks table column heading contains    3    6    2015/16
-    user checks table column heading contains    3    7    2014/15
-    user checks table column heading contains    3    8    2013/14
+    user checks table column heading contains    3    1    2013/14
+    user checks table column heading contains    3    2    2014/15
+    user checks table column heading contains    3    3    2015/16
+    user checks table column heading contains    3    4    2012/13
+    user checks table column heading contains    3    5    2013/14
+    user checks table column heading contains    3    6    2014/15
+    user checks table column heading contains    3    7    2015/16
+    user checks table column heading contains    3    8    2012/13
 
 Validate results table row headings after reordering
     user checks table row heading contains    1    1    Overall absence rate
@@ -221,14 +221,14 @@ Validate results table row headings after reordering
 
 Validate rows after reordering
     # Overall absence rate
-    user checks table cell contains    1    1    5.2%
+    user checks table cell contains    1    1    4.5%
     user checks table cell contains    1    2    4.6%
     user checks table cell contains    1    3    4.6%
-    user checks table cell contains    1    4    4.5%
-    user checks table cell contains    1    5    5.3%
-    user checks table cell contains    1    6    4.5%
-    user checks table cell contains    1    7    4.6%
-    user checks table cell contains    1    8    4.5%
+    user checks table cell contains    1    4    5.2%
+    user checks table cell contains    1    5    4.5%
+    user checks table cell contains    1    6    4.6%
+    user checks table cell contains    1    7    4.5%
+    user checks table cell contains    1    8    5.3%
 
     # Unauthorised absence rate
     user checks table cell contains    2    1    1.1%
@@ -241,14 +241,14 @@ Validate rows after reordering
     user checks table cell contains    2    8    1.1%
 
     # Authorised absence rate
-    user checks table cell contains    3    1    4.2%
-    user checks table cell contains    3    2    3.5%
-    user checks table cell contains    3    3    3.6%
-    user checks table cell contains    3    4    3.4%
-    user checks table cell contains    3    5    4.2%
-    user checks table cell contains    3    6    3.4%
-    user checks table cell contains    3    7    3.5%
-    user checks table cell contains    3    8    3.5%
+    user checks table cell contains    3    1    3.4%
+    user checks table cell contains    3    2    3.6%
+    user checks table cell contains    3    3    3.5%
+    user checks table cell contains    3    4    4.2%
+    user checks table cell contains    3    5    3.5%
+    user checks table cell contains    3    6    3.5%
+    user checks table cell contains    3    7    3.4%
+    user checks table cell contains    3    8    4.2%
 
 User generates a permanent link
     user waits until page contains button    Generate shareable link
@@ -265,28 +265,28 @@ User validates permalink table
     user checks table column heading contains    1    1    Gender
     user checks table column heading contains    2    1    Gender male
     user checks table column heading contains    2    2    Gender female
-    user checks table column heading contains    3    1    2012/13
-    user checks table column heading contains    3    2    2015/16
-    user checks table column heading contains    3    3    2014/15
-    user checks table column heading contains    3    4    2013/14
-    user checks table column heading contains    3    5    2012/13
-    user checks table column heading contains    3    6    2015/16
-    user checks table column heading contains    3    7    2014/15
-    user checks table column heading contains    3    8    2013/14
+    user checks table column heading contains    3    1    2013/14
+    user checks table column heading contains    3    2    2014/15
+    user checks table column heading contains    3    3    2015/16
+    user checks table column heading contains    3    4    2012/13
+    user checks table column heading contains    3    5    2013/14
+    user checks table column heading contains    3    6    2014/15
+    user checks table column heading contains    3    7    2015/16
+    user checks table column heading contains    3    8    2012/13
 
     user checks table row heading contains    1    1    Overall absence rate
     user checks table row heading contains    2    1    Unauthorised absence rate
     user checks table row heading contains    3    1    Authorised absence rate
 
     # Overall absence rate
-    user checks table cell contains    1    1    5.2%
+    user checks table cell contains    1    1    4.5%
     user checks table cell contains    1    2    4.6%
     user checks table cell contains    1    3    4.6%
-    user checks table cell contains    1    4    4.5%
-    user checks table cell contains    1    5    5.3%
-    user checks table cell contains    1    6    4.5%
-    user checks table cell contains    1    7    4.6%
-    user checks table cell contains    1    8    4.5%
+    user checks table cell contains    1    4    5.2%
+    user checks table cell contains    1    5    4.5%
+    user checks table cell contains    1    6    4.6%
+    user checks table cell contains    1    7    4.5%
+    user checks table cell contains    1    8    5.3%
 
     # Unauthorised absence rate
     user checks table cell contains    2    1    1.1%
@@ -299,11 +299,11 @@ User validates permalink table
     user checks table cell contains    2    8    1.1%
 
     # Authorised absence rate
-    user checks table cell contains    3    1    4.2%
-    user checks table cell contains    3    2    3.5%
-    user checks table cell contains    3    3    3.6%
-    user checks table cell contains    3    4    3.4%
-    user checks table cell contains    3    5    4.2%
-    user checks table cell contains    3    6    3.4%
-    user checks table cell contains    3    7    3.5%
-    user checks table cell contains    3    8    3.5%
+    user checks table cell contains    3    1    3.4%
+    user checks table cell contains    3    2    3.6%
+    user checks table cell contains    3    3    3.5%
+    user checks table cell contains    3    4    4.2%
+    user checks table cell contains    3    5    3.5%
+    user checks table cell contains    3    6    3.5%
+    user checks table cell contains    3    7    3.4%
+    user checks table cell contains    3    8    4.2%

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -61,19 +61,19 @@ Create table
     user checks related information panel is visible
 
 Validate results table column headings
-    user checks table column heading contains    1    1    2016/17
-    user checks table column heading contains    1    2    2015/16
-    user checks table column heading contains    1    3    2014/15
-    user checks table column heading contains    1    4    2013/14
+    user checks table column heading contains    1    1    2013/14
+    user checks table column heading contains    1    2    2014/15
+    user checks table column heading contains    1    3    2015/16
+    user checks table column heading contains    1    4    2016/17
 
 Validate results table row headings
     user checks table row heading contains    1    1    Number of schools
 
 Validate Number of schools row results
-    user checks table cell contains    1    1    349
-    user checks table cell contains    1    2    350
-    user checks table cell contains    1    3    363
-    user checks table cell contains    1    4    361
+    user checks table cell contains    1    1    361
+    user checks table cell contains    1    2    363
+    user checks table cell contains    1    3    350
+    user checks table cell contains    1    4    349
 
 Go back to Locations step
     user clicks button    Edit locations
@@ -132,41 +132,41 @@ Create table again
     user checks related information panel is visible
 
 Validate new table column headings
-    user checks table column heading contains    1    1    2015/16
-    user checks table column heading contains    1    2    2014/15
+    user checks table column heading contains    1    1    2014/15
+    user checks table column heading contains    1    2    2015/16
 
 Validate Barnet Number of pupil enrolments row
     ${row}=    user gets row with group and indicator    Barnet    Number of pupil enrolments
     user checks row contains heading    ${row}    Number of pupil enrolments
-    user checks row cell contains text    ${row}    1    210
-    user checks row cell contains text    ${row}    2    224
+    user checks row cell contains text    ${row}    1    224
+    user checks row cell contains text    ${row}    2    210
 
 Validate Barnet Number of sessions possible row
     ${row}=    user gets row with group and indicator    Barnet    Number of sessions possible
     user checks row contains heading    ${row}    Number of sessions possible
-    user checks row cell contains text    ${row}    1    36,820
-    user checks row cell contains text    ${row}    2    38,345
+    user checks row cell contains text    ${row}    1    38,345
+    user checks row cell contains text    ${row}    2    36,820
 
 Validate Barnsley Number of pupil enrolments row
     ${row}=    user gets row with group and indicator    Barnsley    Number of pupil enrolments
     user checks row contains heading    ${row}    Number of pupil enrolments
-    user checks row cell contains text    ${row}    1    146
-    user checks row cell contains text    ${row}    2    149
+    user checks row cell contains text    ${row}    1    149
+    user checks row cell contains text    ${row}    2    146
 
 Validate Barnsley Number of sessions possible row
     ${row}=    user gets row with group and indicator    Barnsley    Number of sessions possible
     user checks row contains heading    ${row}    Number of sessions possible
-    user checks row cell contains text    ${row}    1    36,250
-    user checks row cell contains text    ${row}    2    31,938
+    user checks row cell contains text    ${row}    1    31,938
+    user checks row cell contains text    ${row}    2    36,250
 
 Validate Bedford Number of pupil enrolments row
     ${row}=    user gets row with group and indicator    Bedford    Number of pupil enrolments
     user checks row contains heading    ${row}    Number of pupil enrolments
-    user checks row cell contains text    ${row}    1    178
-    user checks row cell contains text    ${row}    2    176
+    user checks row cell contains text    ${row}    1    176
+    user checks row cell contains text    ${row}    2    178
 
 Validate Bedford Number of sessions possible row
     ${row}=    user gets row with group and indicator    Bedford    Number of sessions possible
     user checks row contains heading    ${row}    Number of sessions possible
-    user checks row cell contains text    ${row}    1    21,847
-    user checks row cell contains text    ${row}    2    17,687
+    user checks row cell contains text    ${row}    1    17,687
+    user checks row cell contains text    ${row}    2    21,847

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -129,16 +129,16 @@ Create table again
     ...    xpath://*[@data-testid="dataTableCaption" and text()="'Exclusions by geographic level' for State-funded secondary in Bury, Sheffield and York between 2006/07 and 2008/09"]
 
 Validate results table column headings
-    user checks table column heading contains    1    1    2008/09
+    user checks table column heading contains    1    1    2006/07
     user checks table column heading contains    1    2    2007/08
-    user checks table column heading contains    1    3    2006/07
+    user checks table column heading contains    1    3    2008/09
 
 Validate Bury Number of fixed period exclusions row
     ${row}=    user gets row with group and indicator    Bury    Number of fixed period exclusions
     user checks row contains heading    ${row}    Number of fixed period exclusions
-    user checks row cell contains text    ${row}    1    1,298
+    user checks row cell contains text    ${row}    1    1,539
     user checks row cell contains text    ${row}    2    1,469
-    user checks row cell contains text    ${row}    3    1,539
+    user checks row cell contains text    ${row}    3    1,298
 
 User generates a permanent link
     user waits until page contains button    Generate shareable link    %{WAIT_MEDIUM}
@@ -156,63 +156,63 @@ User validates permalink contains correct date
     user checks page contains element    xpath://*[@data-testid="created-date"]//strong//time[text()="${date}"]
 
 User validates permalink table headers
-    user checks table column heading contains    1    1    2008/09
+    user checks table column heading contains    1    1    2006/07
     user checks table column heading contains    1    2    2007/08
-    user checks table column heading contains    1    3    2006/07
+    user checks table column heading contains    1    3    2008/09
 
 User validates permalink table rows for Bury
     ${row}=    user gets row with group and indicator    Bury    Number of fixed period exclusions
     user checks row contains heading    ${row}    Number of fixed period exclusions
-    user checks row cell contains text    ${row}    1    1,298
+    user checks row cell contains text    ${row}    1    1,539
     user checks row cell contains text    ${row}    2    1,469
-    user checks row cell contains text    ${row}    3    1,539
+    user checks row cell contains text    ${row}    3    1,298
 
     ${row}=    user gets row with group and indicator    Bury    Number of permanent exclusions
     user checks row contains heading    ${row}    Number of permanent exclusions
-    user checks row cell contains text    ${row}    1    65
+    user checks row cell contains text    ${row}    1    74
     user checks row cell contains text    ${row}    2    75
-    user checks row cell contains text    ${row}    3    74
+    user checks row cell contains text    ${row}    3    65
 
     ${row}=    user gets row with group and indicator    Bury    Number of pupils
     user checks row contains heading    ${row}    Number of pupils
-    user checks row cell contains text    ${row}    1    11,217
+    user checks row cell contains text    ${row}    1    11,618
     user checks row cell contains text    ${row}    2    11,389
-    user checks row cell contains text    ${row}    3    11,618
+    user checks row cell contains text    ${row}    3    11,217
 
 User validates permalink table rows for Sheffield
     ${row}=    user gets row with group and indicator    Sheffield    Number of fixed period exclusions
     user checks row contains heading    ${row}    Number of fixed period exclusions
-    user checks row cell contains text    ${row}    1    3,374
+    user checks row cell contains text    ${row}    1    5,351
     user checks row cell contains text    ${row}    2    3,869
-    user checks row cell contains text    ${row}    3    5,351
+    user checks row cell contains text    ${row}    3    3,374
 
     ${row}=    user gets row with group and indicator    Sheffield    Number of permanent exclusions
     user checks row contains heading    ${row}    Number of permanent exclusions
-    user checks row cell contains text    ${row}    1    4
+    user checks row cell contains text    ${row}    1    12
     user checks row cell contains text    ${row}    2    8
-    user checks row cell contains text    ${row}    3    12
+    user checks row cell contains text    ${row}    3    4
 
     ${row}=    user gets row with group and indicator    Sheffield    Number of pupils
     user checks row contains heading    ${row}    Number of pupils
-    user checks row cell contains text    ${row}    1    30,948
+    user checks row cell contains text    ${row}    1    31,261
     user checks row cell contains text    ${row}    2    31,105
-    user checks row cell contains text    ${row}    3    31,261
+    user checks row cell contains text    ${row}    3    30,948
 
 User validates permalink table rows for York
     ${row}=    user gets row with group and indicator    York    Number of fixed period exclusions
     user checks row contains heading    ${row}    Number of fixed period exclusions
-    user checks row cell contains text    ${row}    1    892
+    user checks row cell contains text    ${row}    1    1,073
     user checks row cell contains text    ${row}    2    1,214
-    user checks row cell contains text    ${row}    3    1,073
+    user checks row cell contains text    ${row}    3    892
 
     ${row}=    user gets row with group and indicator    York    Number of permanent exclusions
     user checks row contains heading    ${row}    Number of permanent exclusions
-    user checks row cell contains text    ${row}    1    3
+    user checks row cell contains text    ${row}    1    55
     user checks row cell contains text    ${row}    2    25
-    user checks row cell contains text    ${row}    3    55
+    user checks row cell contains text    ${row}    3    3
 
     ${row}=    user gets row with group and indicator    York    Number of pupils
     user checks row contains heading    ${row}    Number of pupils
-    user checks row cell contains text    ${row}    1    9,870
+    user checks row cell contains text    ${row}    1    10,179
     user checks row cell contains text    ${row}    2    9,955
-    user checks row cell contains text    ${row}    3    10,179
+    user checks row cell contains text    ${row}    3    9,870


### PR DESCRIPTION
This PR reverts the changes made in [this PR](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5819).