### PR TITLE
EES-7327 - Stop sending raw OData from the browser. Send only structu…

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/api/search/__tests__/buildPublicationSearchFilter.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/search/__tests__/buildPublicationSearchFilter.test.ts
@@ -1,0 +1,41 @@
+import buildPublicationSearchFilter from '@frontend/modules/api/search/buildPublicationSearchFilter';
+
+jest.mock('@azure/search-documents', () => ({
+  odata: (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let result = '';
+    strings.forEach((str, i) => {
+      result += str;
+      if (i < values.length) {
+        result += `'${values[i]}'`;
+      }
+    });
+    return result;
+  },
+}));
+
+describe('buildPublicationSearchFilter', () => {
+  test('returns undefined when no filters provided', () => {
+    expect(buildPublicationSearchFilter({})).toBeUndefined();
+  });
+
+  test('builds a release type filter', () => {
+    expect(
+      buildPublicationSearchFilter({ releaseType: 'AdHocStatistics' }),
+    ).toBe("releaseType eq 'AdHocStatistics'");
+  });
+
+  test('builds a theme filter', () => {
+    expect(buildPublicationSearchFilter({ themeId: 'theme-1' })).toBe(
+      "themeId eq 'theme-1'",
+    );
+  });
+
+  test('builds a combined release type and theme filter', () => {
+    expect(
+      buildPublicationSearchFilter({
+        releaseType: 'AdHocStatistics',
+        themeId: 'theme-1',
+      }),
+    ).toBe("releaseType eq 'AdHocStatistics' and themeId eq 'theme-1'");
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/api/search/buildPublicationSearchFilter.ts
+++ b/src/explore-education-statistics-frontend/src/modules/api/search/buildPublicationSearchFilter.ts
@@ -1,0 +1,25 @@
+import { odata } from '@azure/search-documents';
+
+interface PublicationSearchFilters {
+  releaseType?: string;
+  themeId?: string;
+}
+
+export default function buildPublicationSearchFilter({
+  releaseType,
+  themeId,
+}: PublicationSearchFilters): string | undefined {
+  if (releaseType && themeId) {
+    return odata`releaseType eq ${releaseType} and themeId eq ${themeId}`;
+  }
+
+  if (releaseType) {
+    return odata`releaseType eq ${releaseType}`;
+  }
+
+  if (themeId) {
+    return odata`themeId eq ${themeId}`;
+  }
+
+  return undefined;
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/__tests__/createPublicationListRequest.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/__tests__/createPublicationListRequest.test.ts
@@ -1,0 +1,34 @@
+import { FindStatisticsPageQuery } from '@frontend/modules/find-statistics/FindStatisticsPage';
+import createPublicationListRequest, {
+  createPublicationSuggestRequest,
+} from '@frontend/modules/find-statistics/utils/createPublicationListRequest';
+
+describe('createPublicationListRequest', () => {
+  test('does not include a raw OData filter when release type or theme filters are provided', () => {
+    const testQuery: FindStatisticsPageQuery = {
+      releaseType: 'AdHocStatistics',
+      themeId: 'theme-1',
+    };
+
+    expect(createPublicationListRequest(testQuery)).toEqual({
+      orderBy: 'published desc',
+      page: 1,
+      releaseType: 'AdHocStatistics',
+      search: '',
+      themeId: 'theme-1',
+    });
+  });
+
+  test('does not include a raw OData filter in suggest requests', () => {
+    const testQuery: FindStatisticsPageQuery = {
+      releaseType: 'AdHocStatistics',
+      themeId: 'theme-1',
+    };
+
+    expect(createPublicationSuggestRequest(testQuery, 'absence')).toEqual({
+      releaseType: 'AdHocStatistics',
+      search: 'absence',
+      themeId: 'theme-1',
+    });
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/createPublicationListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/createPublicationListRequest.ts
@@ -1,4 +1,3 @@
-import { odata } from '@azure/search-documents';
 import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
 import getFirst from '@common/utils/getFirst';
 import parseNumber from '@common/utils/number/parseNumber';
@@ -26,22 +25,12 @@ export default function createPublicationListRequest(
 
   const orderBy = getSortParam(sortBy);
 
-  let filter: string | undefined;
-  if (releaseType && themeId) {
-    filter = odata`releaseType eq ${releaseType} and themeId eq ${themeId}`;
-  } else if (releaseType) {
-    filter = odata`releaseType eq ${releaseType}`;
-  } else if (themeId) {
-    filter = odata`themeId eq ${themeId}`;
-  }
-
   const minSearchCharacters = 3;
   const search =
     searchParam && searchParam.length >= minSearchCharacters ? searchParam : '';
 
   return omitBy(
     {
-      filter,
       page: parseNumber(query.page) ?? 1,
       releaseType,
       search,
@@ -58,18 +47,8 @@ export function createPublicationSuggestRequest(
 ): AzurePublicationListRequest {
   const { releaseType, themeId } = getParamsFromQuery(query);
 
-  let filter: string | undefined;
-  if (releaseType && themeId) {
-    filter = odata`releaseType eq ${releaseType} and themeId eq ${themeId}`;
-  } else if (releaseType) {
-    filter = odata`releaseType eq ${releaseType}`;
-  } else if (themeId) {
-    filter = odata`themeId eq ${themeId}`;
-  }
-
   return omitBy(
     {
-      filter,
       releaseType,
       search: searchTerm,
       themeId,

--- a/src/explore-education-statistics-frontend/src/pages/api/search-publications.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/search-publications.ts
@@ -10,6 +10,7 @@ import {
 } from '@azure/search-documents';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { initialiseAzurePublicationsSearchClient } from '@frontend/modules/api/search/initialiseAzureSearchClient';
+import buildPublicationSearchFilter from '@frontend/modules/api/search/buildPublicationSearchFilter';
 import { ErrorBody } from '@frontend/modules/api/types/error';
 import {
   AzurePublicationListRequest,
@@ -43,7 +44,6 @@ export default withMethods({
 
     try {
       const {
-        filter,
         orderBy,
         page = 1,
         pageSize = 10,
@@ -51,6 +51,8 @@ export default withMethods({
         search = '',
         themeId,
       } = searchOptions;
+
+      const filter = buildPublicationSearchFilter({ releaseType, themeId });
 
       const searchOptionsBase: SharedSearchOptionsBase = {
         includeTotalCount: true,

--- a/src/explore-education-statistics-frontend/src/pages/api/suggest-publications.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/suggest-publications.ts
@@ -2,6 +2,7 @@ import withMethods from '@frontend/middleware/api/withMethods';
 import logger from '@common/services/logger';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { initialiseAzurePublicationsSearchClient } from '@frontend/modules/api/search/initialiseAzureSearchClient';
+import buildPublicationSearchFilter from '@frontend/modules/api/search/buildPublicationSearchFilter';
 import { ErrorBody } from '@frontend/modules/api/types/error';
 import {
   AzurePublicationListRequest,
@@ -26,7 +27,8 @@ export default withMethods({
     const azureSearchClient = initialiseAzurePublicationsSearchClient();
 
     try {
-      const { filter, search = '' } = searchOptions;
+      const { releaseType, search = '', themeId } = searchOptions;
+      const filter = buildPublicationSearchFilter({ releaseType, themeId });
 
       const suggestResults =
         search?.length > 2


### PR DESCRIPTION
…red fields like themeId and releaseType, then build the OData filter inside the Next API route.
<img width="987" height="899" alt="image" src="https://github.com/user-attachments/assets/ed4155d2-4892-4b78-a4c2-db1717fe3e24" />
<img width="961" height="491" alt="image" src="https://github.com/user-attachments/assets/50c18bc4-cb62-4148-a0fd-80bc1d9d7f7e" />
<img width="965" height="476" alt="image" src="https://github.com/user-attachments/assets/6b60e8a5-5e71-410f-a74e-6a6d613631f7" />