### PR TITLE
EES-7332 Enable detection mode for the global WAF and increase public site backend request time-out

### DIFF
--- a/infrastructure/templates/common/components/application-gateway/appGateway.bicep
+++ b/infrastructure/templates/common/components/application-gateway/appGateway.bicep
@@ -190,7 +190,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2024-01-01' = {
         protocol: 'Https'
         cookieBasedAffinity: 'Disabled'
         pickHostNameFromBackendAddress: true
-        requestTimeout: 20
+        requestTimeout: backend.?requestTimeout ?? 30
         probe: {
           id: resourceId('Microsoft.Network/applicationGateways/probes', appGatewayName, '${backend.name}-health-probe')
         }

--- a/infrastructure/templates/common/components/application-gateway/appGatewayWafPolicy.bicep
+++ b/infrastructure/templates/common/components/application-gateway/appGatewayWafPolicy.bicep
@@ -29,6 +29,13 @@ param managedRuleSets {
 @description('A set of custom rules to include alongside the managed rulesets')
 param customRules AppGatewayFirewallPolicyCustomRule[] = []
 
+@description('The mode of the policy')
+@allowed([
+  'Detection'
+  'Prevention'
+])
+param mode string = 'Prevention'
+
 @description('Specifies a set of tags with which to tag the resource in Azure')
 param tagValues object
 
@@ -41,7 +48,7 @@ resource policy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolic
       maxRequestBodySizeInKb: 128
       fileUploadLimitInMb: 100
       state: 'Enabled'
-      mode: 'Prevention'
+      mode: mode
       requestBodyInspectLimitInKB: 128
       fileUploadEnforcement: true
       requestBodyEnforcement: true

--- a/infrastructure/templates/common/components/application-gateway/types.bicep
+++ b/infrastructure/templates/common/components/application-gateway/types.bicep
@@ -41,6 +41,9 @@ type AppGatewayBackend = {
 
   @description('Interval in seconds that the health probe is called. Defaults to 30 seconds if not set.')
   intervalSeconds: int?
+
+  @description('Request timeout in seconds that the appplication gateway will wait before it returns a connection timed out error message. Acceptable values are from 1 second to 86400 seconds. Defaults to 30 seconds if not set.')
+  requestTimeout: int?
 }
 
 @export()

--- a/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
@@ -136,6 +136,7 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
         fqdn: publicSiteInternalServiceFqdn
         healthProbePath: '/api/health'
         intervalSeconds: 60
+        requestTimeout: 220 // Timeout set to just under Azure's standard App Service timeout of 3.8 minutes.
       }
     ]
     routes: [

--- a/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
@@ -76,6 +76,7 @@ module globalWafPolicyModule '../../../common/components/application-gateway/app
   params: {
     name: '${appGatewayName}-global-afwp'
     location: location
+    mode: 'Detection'
     tagValues: tagValues
   }
 }


### PR DESCRIPTION
This PR enables 'Detection' mode for the global WAF, and increases the public site frontends request time-out in the Application Gateway backend settings.

We decided it would be safer to switch from Prevention Mode to Detection mode for now, as described here in [WAF Modes](https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/ag-overview#waf-modes).

That documentation also says:

> Run a newly deployed WAF in detection mode for a short period in a production environment. This period provides the opportunity to obtain firewall logs and update any exceptions or custom rules before transitioning to prevention mode. It also helps reduce the occurrence of unexpected blocked traffic.

**WAF Policy changes:**

* Adds a `mode` parameter to the WAF policy template, allowing selection between `Detection` and `Prevention` modes (defaults to `Prevention`).
* Sets the global WAF policy mode to `Detection`.

**Application Gateway changes:**
* Adds an optional `requestTimeout` property to the `AppGatewayBackend` type, allowing per-backend configuration of the request timeout for backends (**now defaults to 30 sections rather than 20 seconds if not set**).
* Set a custom `requestTimeout` of 220 seconds for the public site frontend backend in the core Application Gateway module. This  is set to just below Azure's standard App Service timeout of 3.8 minutes.