### PR TITLE
EES-7338 - allowing rebuilds only in overnight reindexing jobs

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -1085,7 +1085,7 @@
           },
           "FragmentationThresholdRebuild": {
             "type": "string",
-            "defaultValue": "30"
+            "defaultValue": "10"
           },
           "RunMode": {
             "type": "string",


### PR DESCRIPTION
This PR:
- changes the Rebuild index threshold to 10%, so that only rebuilds will be chosen to run right now.

We've seen that rebuilds can potentially be a lot quicker than reorganises, so we're going to let the overnight jobs solely use rebuilds for a few runs and see how they get on.