### PR TITLE
EES-7341 - disabled AFD health probes. Added new leightweight, cachin…

### DIFF
--- a/infrastructure/templates/common/components/front-door/frontDoor.bicep
+++ b/infrastructure/templates/common/components/front-door/frontDoor.bicep
@@ -27,6 +27,12 @@ param certificateType FrontDoorCertificateType = 'BringYourOwn'
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
 param certificateName string?
 
+@description('The path to a healthcheck endpoint in the origin.')
+param healthProbePath string?
+
+@description('Choose whether or not to deploy health probes. Best practice is to enable them only when there is more than 1 origin in an origin group.')
+param deployHealthProbes bool = false
+
 @description('Optional names of rulesets to attach to routes.')
 param ruleSetNames string[]
 
@@ -86,12 +92,12 @@ resource originGroup 'Microsoft.Cdn/profiles/origingroups@2025-04-15' = {
       successfulSamplesRequired: 3
       additionalLatencyInMilliseconds: 50
     }
-    healthProbeSettings: {
-      probePath: '/api/health'
+    healthProbeSettings: deployHealthProbes ? {
+      probePath: healthProbePath
       probeRequestType: 'HEAD'
       probeProtocol: 'Https'
       probeIntervalInSeconds: 100
-    }
+    } : null
     sessionAffinityState: 'Disabled'
   }
 }

--- a/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
+++ b/infrastructure/templates/core/application/applicationGateway/appGateway.bicep
@@ -135,7 +135,7 @@ module appGatewayModule '../../../common/components/application-gateway/appGatew
       {
         name: '${publicSiteAppServiceName}-backend'
         fqdn: publicSiteInternalServiceFqdn
-        healthProbePath: '/api/health'
+        healthProbePath: '/health'
         intervalSeconds: 60
         requestTimeout: 220 // Timeout set to just under Azure's standard App Service timeout of 3.8 minutes.
       }

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -75,6 +75,15 @@ async function startServer() {
 
   const server = express();
 
+  server.head('/health', (req, res) => {
+    return res.status(200);
+  });
+
+  server.get('/health', (req, res) => {
+    res.set('Cache-Control', 'public, max-age=0, s-maxage=30');
+    return res.status(200).send('OK');
+  });
+
   function replaceLastOccurrence(input, pattern, replacement) {
     if (!input || !input.endsWith(pattern)) {
       return input;

--- a/src/explore-education-statistics-frontend/src/pages/api/health.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/health.ts
@@ -1,3 +1,5 @@
+// TODO EES-7341 - remove this old healthcheck endpoint when App Gateway is requesting the new lightweight one successfully,
+// otherwise Application Gateway will report an unhealthy backend during deploy.
 import { ErrorBody } from '@frontend/modules/api/types/error';
 import { NextApiRequest, NextApiResponse } from 'next';
 import withMethods from '@frontend/middleware/api/withMethods';


### PR DESCRIPTION
This PR:
- disables Azure Front Door health probes, as per recommendations when dealing with a single-origin origin group.
- replaces public site app service's healthcheck endpoint with a super-lightweight Express route.
- allows AFD to cache healthcheck responses and soak up excessive requests from application gateway.

Because of the unusual configuration we have where App Gateway is in front of AFD (in order to temporarily support the use of the EES apex domain in Route 53, A DNS records and the use of AFD), Application Gateway is (I think) making healthcheck requests to every IP address in AFD's anycast range, many of which hit the app service but at least one of which fails, App Gateway is treating the backend as healthy because it received at least one 200 response, but repeats its healthcheck requests again because it also received at least one failure. This repeats the pattern again and again!

Once the site is migrated to a subdomain (or DNS provider changes that can support CNAME flattening and the apex domain), we can undo this and go back to a standard AFD setup.

## App Gateway healthcheck now once every 30 seconds

<img width="2109" height="1155" alt="image" src="https://github.com/user-attachments/assets/432cfdfc-3bf2-45d2-952a-022f65ebe01c" />

## Removing old healthcheck endpoint

https://github.com/dfe-analytical-services/explore-education-statistics/pull/7149 can be merged in when all environments have switched over to using the new healthcheck endpoint.