### PR TITLE
EES-7226 - (STEP 17) Improve data integrity around Users and their roles

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -135,16 +135,6 @@ public class UserManagementServicePermissionTests
 
                 userService.Setup(mock => mock.GetUserId()).Returns(CreatedById);
 
-                var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(Strict);
-                userPreReleaseRoleRepository
-                    .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
-                    .Returns(Task.CompletedTask);
-
-                var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-                userPublicationRoleRepository
-                    .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
-                    .Returns(Task.CompletedTask);
-
                 var userRepository = new Mock<IUserRepository>(Strict);
                 userRepository
                     .Setup(mock => mock.FindActiveUserByEmail(user.Email, It.IsAny<CancellationToken>()))
@@ -163,19 +153,12 @@ public class UserManagementServicePermissionTests
                     usersAndRolesDbContext: usersAndRolesDbContext,
                     userService: userService.Object,
                     userRepository: userRepository.Object,
-                    userPublicationRoleRepository: userPublicationRoleRepository.Object,
-                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
                     userManager: userManager.Object
                 );
 
                 var result = await service.DeleteUser(user.Email);
 
-                VerifyAllMocks(
-                    userRepository,
-                    userPublicationRoleRepository,
-                    userPreReleaseRoleRepository,
-                    userManager
-                );
+                VerifyAllMocks(userRepository, userManager);
 
                 return result;
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -431,9 +431,6 @@ public abstract class UserManagementServiceTests
 
             var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(Strict);
             userPreReleaseRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCreate.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            userPreReleaseRoleRepository
                 .Setup(mock =>
                     mock.CreateManyIfNotExists(
                         It.Is<HashSet<UserPreReleaseRoleCreateDto>>(l =>
@@ -454,9 +451,6 @@ public abstract class UserManagementServiceTests
                 .ReturnsAsync([]); // Don't actually need to return anything here for the test. Just want to check it was called correctly.
 
             var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-            userPublicationRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCreate.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
             userPublicationRoleRepository
                 .Setup(mock =>
                     mock.CreateManyIfNotExists(
@@ -616,9 +610,6 @@ public abstract class UserManagementServiceTests
                 .ReturnsAsync(userToCreate);
 
             var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(Strict);
-            userPreReleaseRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCreate.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
             // Should only try to create pre-release roles for releases 1 and 2, as releases 3 and 4 belong to
             // publications 3 and 4 which are already having more powerful publication roles created for them.
             userPreReleaseRoleRepository
@@ -644,9 +635,6 @@ public abstract class UserManagementServiceTests
                 .ReturnsAsync([]); // Don't actually need to return anything here for the test. Just want to check it was called correctly.
 
             var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-            userPublicationRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCreate.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
             userPublicationRoleRepository
                 .Setup(mock =>
                     mock.CreateManyIfNotExists(
@@ -784,16 +772,6 @@ public abstract class UserManagementServiceTests
             var contentDbContextId = Guid.NewGuid().ToString();
             var usersAndRolesDbContextId = Guid.NewGuid().ToString();
 
-            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(Strict);
-            userPreReleaseRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCancelInvitesFor.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-            userPublicationRoleRepository
-                .Setup(mock => mock.RemoveForUser(userToCancelInvitesFor.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
             var userRepository = new Mock<IUserRepository>(Strict);
             userRepository
                 .Setup(mock =>
@@ -812,8 +790,6 @@ public abstract class UserManagementServiceTests
                 var service = SetupService(
                     contentDbContext: contentDbContext,
                     usersAndRolesDbContext: usersAndRolesDbContext,
-                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
-                    userPublicationRoleRepository: userPublicationRoleRepository.Object,
                     userRepository: userRepository.Object
                 );
 
@@ -822,7 +798,7 @@ public abstract class UserManagementServiceTests
                 result.AssertRight();
             }
 
-            VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository, userRepository);
+            VerifyAllMocks(userRepository);
         }
 
         [Fact]
@@ -877,31 +853,19 @@ public abstract class UserManagementServiceTests
                 .Setup(mock => mock.SoftDeleteUser(internalUser.Id, CreatedById, It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(Strict);
-            userPreReleaseRoleRepository
-                .Setup(mock => mock.RemoveForUser(internalUser.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
-            userPublicationRoleRepository
-                .Setup(mock => mock.RemoveForUser(internalUser.Id, It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
             {
                 var service = SetupService(
                     usersAndRolesDbContext: usersAndRolesDbContext,
                     userManager: userManager.Object,
-                    userRepository: userRepository.Object,
-                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
-                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                    userRepository: userRepository.Object
                 );
 
                 var result = await service.DeleteUser(internalUser.Email);
                 result.AssertRight();
             }
 
-            VerifyAllMocks(userManager, userRepository, userPreReleaseRoleRepository, userPublicationRoleRepository);
+            VerifyAllMocks(userManager, userRepository);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRepositoryTests.cs
@@ -1,14 +1,17 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
@@ -646,12 +649,28 @@ public abstract class UserRepositoryTests
             Assert.Null(user.SoftDeleted);
             Assert.Null(user.DeletedById);
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 await repository.SoftDeleteUser(user.Id, deletedById);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -680,12 +699,28 @@ public abstract class UserRepositoryTests
             // Ensure initial state is correct
             Assert.True(user.IsInvitePending());
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 await repository.SoftDeleteUser(user.Id, deletedById);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -714,12 +749,28 @@ public abstract class UserRepositoryTests
             // Ensure initial state is correct
             Assert.True(user.IsInviteExpired());
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 await repository.SoftDeleteUser(user.Id, deletedById);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -837,9 +888,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -862,6 +927,8 @@ public abstract class UserRepositoryTests
                 Assert.Equal(expectedUpdatedRole.GetEnumValue(), result.RoleId);
                 Assert.Equal(newCreatedDate, result.Created);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -898,9 +965,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -911,6 +992,8 @@ public abstract class UserRepositoryTests
 
                 Assert.Equal(newCreatedDate, result.Created);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -936,9 +1019,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -948,6 +1045,8 @@ public abstract class UserRepositoryTests
 
                 result.Created.AssertUtcNow();
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -990,9 +1089,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1015,6 +1128,8 @@ public abstract class UserRepositoryTests
                 Assert.Equal(newCreatedById, result.CreatedById);
                 Assert.Equal(newCreatedDate, result.Created);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1051,9 +1166,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1064,6 +1193,8 @@ public abstract class UserRepositoryTests
 
                 Assert.Equal(newCreatedDate, result.Created);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1087,9 +1218,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1099,6 +1244,8 @@ public abstract class UserRepositoryTests
 
                 result.Created.AssertUtcNow();
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1143,9 +1290,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1168,6 +1329,8 @@ public abstract class UserRepositoryTests
                 Assert.Null(result.FirstName);
                 Assert.Null(result.LastName);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1204,9 +1367,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1217,6 +1394,8 @@ public abstract class UserRepositoryTests
 
                 Assert.Equal(newCreatedDate, result.Created);
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1242,9 +1421,23 @@ public abstract class UserRepositoryTests
                 await contentDbContext.SaveChangesAsync();
             }
 
+            var userPreReleaseRoleRepository = new Mock<IUserPreReleaseRoleRepository>(MockBehavior.Strict);
+            userPreReleaseRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(MockBehavior.Strict);
+            userPublicationRoleRepository
+                .Setup(mock => mock.RemoveForUser(user.Id, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var repository = BuildRepository(contentDbContext);
+                var repository = BuildRepository(
+                    contentDbContext: contentDbContext,
+                    userPreReleaseRoleRepository: userPreReleaseRoleRepository.Object,
+                    userPublicationRoleRepository: userPublicationRoleRepository.Object
+                );
 
                 var result = await repository.CreateOrUpdate(
                     email: user.Email,
@@ -1254,6 +1447,8 @@ public abstract class UserRepositoryTests
 
                 result.Created.AssertUtcNow();
             }
+
+            MockUtils.VerifyAllMocks(userPreReleaseRoleRepository, userPublicationRoleRepository);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -1401,8 +1596,18 @@ public abstract class UserRepositoryTests
         }
     }
 
-    private static UserRepository BuildRepository(ContentDbContext contentDbContext)
+    private static UserRepository BuildRepository(
+        ContentDbContext contentDbContext,
+        IUserPreReleaseRoleRepository? userPreReleaseRoleRepository = null,
+        IUserPublicationRoleRepository? userPublicationRoleRepository = null
+    )
     {
-        return new(contentDbContext);
+        return new(
+            contentDbContext: contentDbContext,
+            userPreReleaseRoleRepository: userPreReleaseRoleRepository
+                ?? Mock.Of<IUserPreReleaseRoleRepository>(MockBehavior.Strict),
+            userPublicationRoleRepository: userPublicationRoleRepository
+                ?? Mock.Of<IUserPublicationRoleRepository>(MockBehavior.Strict)
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260707095350_Ees7226AddingCheckConstraintToUsersTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260707095350_Ees7226AddingCheckConstraintToUsersTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707095350_Ees7226AddingCheckConstraintToUsersTable")]
+    partial class Ees7226AddingCheckConstraintToUsersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260707095350_Ees7226AddingCheckConstraintToUsersTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260707095350_Ees7226AddingCheckConstraintToUsersTable.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7226AddingCheckConstraintToUsersTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Users_Active_SoftDeleted",
+                table: "Users",
+                sql: "[Active] = 0 OR [SoftDeleted] IS NULL"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(name: "CK_Users_Active_SoftDeleted", table: "Users");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -219,11 +219,6 @@ public class UserManagementService(
                     createdDate: request.CreatedDate
                 );
 
-                // Clear out any pre-existing Release Roles or Publication Roles prior to adding
-                // new ones.
-                await userPreReleaseRoleRepository.RemoveForUser(user.Id);
-                await userPublicationRoleRepository.RemoveForUser(user.Id);
-
                 var preReleaseRoleLatestReleaseVersionDetails = await request
                     .UserPreReleaseRoles.Select(role => role.ReleaseId)
                     .Distinct()
@@ -277,15 +272,8 @@ public class UserManagementService(
             .CheckCanManageAllUsers()
             .OnSuccess(async () => await GetPendingUserInvite(email))
             .OnSuccessVoid(async invitedUser =>
-            {
-                await contentDbContext.RequireTransaction(async () =>
-                {
-                    await userPreReleaseRoleRepository.RemoveForUser(invitedUser.Id);
-                    await userPublicationRoleRepository.RemoveForUser(invitedUser.Id);
-
-                    await userRepository.SoftDeleteUser(invitedUser.Id, userService.GetUserId());
-                });
-            });
+                await userRepository.SoftDeleteUser(invitedUser.Id, userService.GetUserId())
+            );
     }
 
     public async Task<Either<ActionResult, Unit>> UpdateUserGlobalRole(string userId, string roleId)
@@ -308,9 +296,6 @@ public class UserManagementService(
                 await contentDbContext.RequireTransaction(async () =>
                 {
                     await userManager.DeleteAsync(identityUser);
-
-                    await userPreReleaseRoleRepository.RemoveForUser(activeInternalUser.Id);
-                    await userPublicationRoleRepository.RemoveForUser(activeInternalUser.Id);
 
                     await userRepository.SoftDeleteUser(activeInternalUser.Id, userService.GetUserId());
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserRepository.cs
@@ -10,7 +10,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
-public class UserRepository(ContentDbContext contentDbContext) : IUserRepository
+public class UserRepository(
+    ContentDbContext contentDbContext,
+    IUserPublicationRoleRepository userPublicationRoleRepository,
+    IUserPreReleaseRoleRepository userPreReleaseRoleRepository
+) : IUserRepository
 {
     public async Task<User?> FindPendingUserInviteByEmail(string email, CancellationToken cancellationToken = default)
     {
@@ -97,8 +101,9 @@ public class UserRepository(ContentDbContext contentDbContext) : IUserRepository
             throw new ArgumentException($"{nameof(User)} created date cannot be a future date.");
         }
 
-        var existingUser = await contentDbContext.Users.SingleOrDefaultAsync(i =>
-            i.Email.ToLower().Equals(normalizedEmail)
+        var existingUser = await contentDbContext.Users.SingleOrDefaultAsync(
+            i => i.Email.ToLower().Equals(normalizedEmail),
+            cancellationToken: cancellationToken
         );
 
         return existingUser is null
@@ -118,19 +123,25 @@ public class UserRepository(ContentDbContext contentDbContext) : IUserRepository
             );
     }
 
-    public async Task SoftDeleteUser(Guid activeUserId, Guid deletedById, CancellationToken cancellationToken = default)
+    public async Task SoftDeleteUser(Guid userId, Guid deletedById, CancellationToken cancellationToken = default)
     {
         var activeUser =
-            await FindUserById(activeUserId, cancellationToken)
+            await FindUserById(userId, cancellationToken)
             ?? throw new InvalidOperationException(
                 "Cannot soft delete a user that is already soft deleted, or does not exist."
             );
 
-        activeUser.Active = false;
-        activeUser.SoftDeleted = DateTime.UtcNow;
-        activeUser.DeletedById = deletedById;
+        await contentDbContext.RequireTransaction(async () =>
+        {
+            await userPreReleaseRoleRepository.RemoveForUser(userId, cancellationToken);
+            await userPublicationRoleRepository.RemoveForUser(userId, cancellationToken);
 
-        await contentDbContext.SaveChangesAsync(cancellationToken);
+            activeUser.Active = false;
+            activeUser.SoftDeleted = DateTime.UtcNow;
+            activeUser.DeletedById = deletedById;
+
+            await contentDbContext.SaveChangesAsync(cancellationToken);
+        });
     }
 
     private async Task<User> CreateNewUser(
@@ -166,29 +177,39 @@ public class UserRepository(ContentDbContext contentDbContext) : IUserRepository
         CancellationToken cancellationToken
     )
     {
-        return existingUser.Active ? throw new InvalidOperationException("Cannot update a user that is active.")
-            : existingUser.SoftDeleted.HasValue
-                ? await ResetSoftDeletedUser(
+        if (existingUser.Active)
+        {
+            throw new InvalidOperationException("Cannot update a user that is active.");
+        }
+
+        return await contentDbContext.RequireTransaction(async () =>
+        {
+            await userPreReleaseRoleRepository.RemoveForUser(existingUser.Id);
+            await userPublicationRoleRepository.RemoveForUser(existingUser.Id);
+
+            return existingUser.SoftDeleted.HasValue
+                    ? await ResetSoftDeletedUser(
+                        user: existingUser,
+                        createdById: createdById,
+                        createdDate: createdDate,
+                        roleId: roleId,
+                        cancellationToken: cancellationToken
+                    )
+                : existingUser.IsInviteExpired()
+                    ? await ResetExpiredUserInvite(
+                        user: existingUser,
+                        createdById: createdById,
+                        createdDate: createdDate,
+                        roleId: roleId,
+                        cancellationToken: cancellationToken
+                    )
+                : await ResetPendingUserInvite(
                     user: existingUser,
-                    createdById: createdById,
-                    createdDate: createdDate,
                     roleId: roleId,
-                    cancellationToken: cancellationToken
-                )
-            : existingUser.IsInviteExpired()
-                ? await ResetExpiredUserInvite(
-                    user: existingUser,
-                    createdById: createdById,
                     createdDate: createdDate,
-                    roleId: roleId,
                     cancellationToken: cancellationToken
-                )
-            : await ResetPendingUserInvite(
-                user: existingUser,
-                roleId: roleId,
-                createdDate: createdDate,
-                cancellationToken: cancellationToken
-            );
+                );
+        });
     }
 
     private async Task<User> ResetPendingUserInvite(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -636,6 +636,10 @@ public class ContentDbContext : DbContext
         modelBuilder.Entity<User>().HasOne(e => e.Role).WithMany().OnDelete(DeleteBehavior.Restrict);
 
         modelBuilder.Entity<User>().HasIndex(u => u.Email).IsUnique();
+
+        modelBuilder
+            .Entity<User>()
+            .ToTable(t => t.HasCheckConstraint("CK_Users_Active_SoftDeleted", "[Active] = 0 OR [SoftDeleted] IS NULL"));
     }
 
     private static void ConfigureUserPublicationRole(ModelBuilder modelBuilder)


### PR DESCRIPTION
`Users` have a `Active` flag, and a `SoftDeleted` timestamp, and can have roles associated with them via the `UserPublicationRoles` & `UserPreReleaseRoles` tables.

It should be impossible for a `User` to have:

- both `Active = true` and have the `SoftDeleted` date set (wouldn't make any sense)
- any publication or pre-release roles assigned to them (they wouldn't serve any purpose)

Currently, the code will protect against these two scenarios.

However, there is no database-level restrictions stopping either of these cases from occurring. And the guard checks in the code which prevent the roles existing for users which are soft-deleted aren’t in the most appropriate place to guarantee that `Users` never end up in one of these states.

The purpose of this ticket is to:

- Add a strict database restriction to stop a `User` falling into a state where they have both `Active = 1` and `SoftDeleted` set. This will ensure that it cannot happen even if the application logic fails.

- Move our guard checks around ensuring that a soft-deleted user cannot have any roles assigned to them to the `UserRepository` (the closest point to the database where `Users` are being created/amended).

  - We can add some calls to the `SoftDelete` method so that the publication and pre-release roles are always removed prior to soft-deleting the User.

  - We can add some calls to the `CreateOrUpdate` method so that when you are re-creating/updating a user (**say they are soft-deleted or expired and you want to reinstate them, or they already have a pending invite but you want to override it with a fresh one**), it will firstly remove any publication or pre-release roles already associated with them (just in case these weren’t cleared up beforehand), before reinstating them as a pending invite on the system. This will ensure that you do not accidentally carry over historic roles to the newly invited user, just because they once existed on the system before.

    - _NOTE: Expired invites do not automatically have their roles removed until they try to sign in. We do not have a CRON job or anything of the sort for this. So this additional logic that removes the roles when re-instating the user as a fresh invite is crucial to ensure that those historic roles are definitely removed before continuing from a fresh state._