### PR TITLE
EES-7342 Fix ReplaceIndicatorMapping bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -654,7 +654,7 @@ public class ReplacementServiceHelperTests
                     },
                 ],
             },
-            // Group c will be added in replacements - we skip it to check it gets appended after Group d, not alphabetically ordered
+            // No Group c here, as it will be added in replacements - we check it gets appended after Group d, not alphabetically ordered
             new()
             {
                 Id = Guid.NewGuid(),
@@ -1057,6 +1057,153 @@ public class ReplacementServiceHelperTests
 
         var indicatorAId = Assert.Single(groupD.ChildSequence);
         Assert.Equal(replacementGroups[2].Indicators[0].Id, indicatorAId);
+    }
+
+    [Fact]
+    public void ReplaceIndicatorSequence_MappedToNewGroupWithDifferentLabel_Success()
+    {
+        var originalGroupAId = Guid.NewGuid();
+        var originalGroups = new List<IndicatorGroup>
+        {
+            new()
+            {
+                Id = originalGroupAId,
+                Label = "Group a",
+                Indicators =
+                [
+                    new Indicator
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "indicator_a",
+                        Label = "Indicator A",
+                        IndicatorGroupId = originalGroupAId,
+                    },
+                    new Indicator
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "indicator_b",
+                        Label = "Indicator B",
+                        IndicatorGroupId = originalGroupAId,
+                    },
+                ],
+            },
+        };
+
+        var originalReleaseFile = new ReleaseFile
+        {
+            IndicatorSequence =
+            [
+                new IndicatorGroupSequenceEntry(
+                    Id: originalGroupAId, // Group a
+                    ChildSequence:
+                    [
+                        originalGroups[0].Indicators[1].Id, // indicator b
+                        originalGroups[0].Indicators[0].Id, // indicator a
+                    ]
+                ),
+            ],
+        };
+
+        var replacementGroupAId = Guid.NewGuid();
+        var replacementGroupBId = Guid.NewGuid();
+        var replacementGroups = new List<IndicatorGroup>
+        {
+            new()
+            {
+                Id = replacementGroupAId,
+                Label = "Group a",
+                Indicators =
+                [
+                    new Indicator
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "indicator_a",
+                        Label = "Indicator A",
+                        IndicatorGroupId = replacementGroupAId,
+                    },
+                ],
+            },
+            new() // 'Group b' is a new group
+            {
+                Id = replacementGroupBId,
+                Label = "Group b",
+                Indicators =
+                [
+                    new Indicator
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "indicator_b",
+                        Label = "Indicator B",
+                        IndicatorGroupId = replacementGroupBId,
+                    },
+                ],
+            },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = Guid.NewGuid(),
+            ReplacementDataFileId = Guid.NewGuid(),
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
+            {
+                {
+                    // "Indicator A" mapped to "Indicator A"
+                    // original/replacement have matching group label
+                    originalGroups[0].Indicators[0].Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalGroups[0].Indicators[0].Id,
+                        OriginalLabel = originalGroups[0].Indicators[0].Label,
+                        OriginalGroupId = originalGroups[0].Id,
+                        OriginalGroupLabel = originalGroups[0].Label,
+                        ReplacementId = replacementGroups[0].Indicators[0].Id,
+                        ReplacementLabel = replacementGroups[0].Indicators[0].Label,
+                        ReplacementGroupId = replacementGroups[0].Id,
+                        ReplacementGroupLabel = replacementGroups[0].Label,
+                        Status = MapStatus.AutoSet,
+                    }
+                },
+                {
+                    // "Indicator B" mapped to "Indicator B"
+                    // original/replacement have different group label!
+                    originalGroups[0].Indicators[1].Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalGroups[0].Indicators[1].Id,
+                        OriginalLabel = originalGroups[0].Indicators[1].Label,
+                        OriginalGroupId = originalGroups[0].Id,
+                        OriginalGroupLabel = originalGroups[0].Label,
+                        ReplacementId = replacementGroups[1].Indicators[0].Id,
+                        ReplacementLabel = replacementGroups[1].Indicators[0].Label,
+                        ReplacementGroupId = replacementGroups[1].Id,
+                        ReplacementGroupLabel = replacementGroups[1].Label,
+                        Status = MapStatus.ManuallySet,
+                    }
+                },
+            },
+            UnmappedReplacementIndicators = [],
+        };
+
+        var updatedSequence = ReplacementServiceHelper.ReplaceIndicatorSequence(
+            mapping: mapping,
+            originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
+            replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
+            originalReleaseFile.IndicatorSequence
+        );
+
+        Assert.NotNull(updatedSequence);
+
+        Assert.Equal(2, updatedSequence.Count);
+        var groupA = updatedSequence[0];
+        var groupB = updatedSequence[1];
+        Assert.Equal(replacementGroups[0].Id, groupA.Id);
+        Assert.Equal(replacementGroups[1].Id, groupB.Id);
+
+        var indicatorAId = Assert.Single(groupA.ChildSequence);
+        Assert.Equal(replacementGroups[0].Indicators[0].Id, indicatorAId);
+
+        var indicatorBId = Assert.Single(groupB.ChildSequence);
+        Assert.Equal(replacementGroups[1].Indicators[0].Id, indicatorBId);
     }
 
     private static DataSetMapping GenerateMapping(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ValidateIndicatorSequencesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/ValidateIndicatorSequencesController.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api/bau")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class ValidateIndicatorSequencesController(
+    ContentDbContext contentDbContext,
+    StatisticsDbContext statisticsDbContext
+) : ControllerBase
+{
+    [HttpGet("validate-indicator-sequences")]
+    public async Task<ActionResult> ValidateIndicatorSequences(CancellationToken cancellationToken = default)
+    {
+        var subjectIdsAndSequences = await contentDbContext
+            .ReleaseFiles.Include(rf => rf.File)
+            .Where(rf => rf.IndicatorSequence != null && rf.File.SubjectId != null)
+            .Select(rf => new { SubjectId = rf.File.SubjectId!.Value, rf.IndicatorSequence })
+            .ToListAsync(cancellationToken);
+
+        var subjectIds = subjectIdsAndSequences.Select(x => x.SubjectId).ToHashSet();
+
+        var dbGroupsLookup = (
+            await statisticsDbContext
+                .IndicatorGroup.Where(group => subjectIds.Contains(group.SubjectId))
+                .Select(group => new { group.SubjectId, group.Id })
+                .ToListAsync(cancellationToken)
+        ).ToLookup(group => group.SubjectId, group => group.Id);
+
+        var dbIndicatorsLookup = (
+            await statisticsDbContext
+                .Indicator.Where(indicator => subjectIds.Contains(indicator.IndicatorGroup.SubjectId))
+                .Select(indicator => new { indicator.IndicatorGroup.SubjectId, indicator.Id })
+                .ToListAsync(cancellationToken)
+        ).ToLookup(x => x.SubjectId, x => x.Id);
+
+        foreach (var subjectIdAndSequence in subjectIdsAndSequences)
+        {
+            var subjectId = subjectIdAndSequence.SubjectId;
+            var indicatorSequence = subjectIdAndSequence.IndicatorSequence!;
+            var sequenceGroupIds = indicatorSequence.Select(groupEntry => groupEntry.Id).ToHashSet();
+            var sequenceIndicatorIds = indicatorSequence.SelectMany(groupEntry => groupEntry.ChildSequence).ToHashSet();
+
+            var dbGroupIds = dbGroupsLookup[subjectId].ToList();
+            var dbIndicatorIds = dbIndicatorsLookup[subjectId].ToList();
+
+            var groupsMatch = sequenceGroupIds.SetEquals(dbGroupIds);
+            var indicatorsMatch = sequenceIndicatorIds.SetEquals(dbIndicatorIds);
+
+            if (!groupsMatch)
+            {
+                return BadRequest(
+                    $"IndicatorSequence groups incorrect for subject: {subjectId}\nSequenceGroups: {sequenceGroupIds.JoinToString(',')}\nDBGroups: {dbGroupIds.JoinToString(',')}\n"
+                );
+            }
+
+            if (!indicatorsMatch)
+            {
+                return BadRequest(
+                    $"IndicatorSequence indicators incorrect for subject: {subjectId}\nSequenceIndicators: {sequenceIndicatorIds.JoinToString(',')}\nDBIndicators: {dbIndicatorIds.JoinToString(',')}\n"
+                );
+            }
+        }
+
+        return Ok("All indicator sequences valid");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -282,7 +282,7 @@ public abstract class ReplacementServiceHelper
                 map.ReplacementGroupId is not null
                 && !groupIdsInReplacementSequence.Contains(map.ReplacementGroupId.Value)
             )
-            .GroupBy(map => new { GroupId = map.OriginalGroupId, GroupLabel = map.OriginalGroupLabel })
+            .GroupBy(map => new { GroupId = map.ReplacementGroupId!.Value, GroupLabel = map.ReplacementGroupLabel! })
             .OrderBy(group => group.Key.GroupLabel)
             .ToList();
 


### PR DESCRIPTION
This PR fixes an issue with ReplaceIndicatorMapping. I've also added a unit test to cover this.

I don't think it's particularly likely that this has happened on production - but to ensure that's the case I've also created a bau endpoint to validate all existing IndicatorSequences matches the groups/indicators found for that subject in the statsDB.