### PR TITLE
EES-7343 Filter time period range to exclude non-existent terms in ob…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
@@ -249,4 +249,88 @@ public abstract class TimePeriodServiceTests
             }
         }
     }
+
+    public class GetTimePeriodRangeTests : TimePeriodServiceTests
+    {
+        [Fact]
+        public void AcademicYearRange_IncludesAllYearsInRange()
+        {
+            List<Observation> observations =
+            [
+                new() { Year = 2024, TimeIdentifier = AcademicYear },
+                new() { Year = 2026, TimeIdentifier = AcademicYear },
+            ];
+
+            using var statisticsDbContext = InMemoryStatisticsDbContext();
+            var service = new TimePeriodService(statisticsDbContext);
+            var result = service.GetTimePeriodRange(observations);
+
+            Assert.Equal(3, result.Count);
+            Assert.Equal((2024, AcademicYear), result[0]);
+            Assert.Equal((2025, AcademicYear), result[1]);
+            Assert.Equal((2026, AcademicYear), result[2]);
+        }
+
+        [Fact]
+        public void TermRange_ExcludesTermsNotInObservations()
+        {
+            List<Observation> observations =
+            [
+                new() { Year = 2025, TimeIdentifier = AutumnTerm },
+                new() { Year = 2025, TimeIdentifier = SummerTerm },
+            ];
+
+            using var statisticsDbContext = InMemoryStatisticsDbContext();
+            var service = new TimePeriodService(statisticsDbContext);
+            var result = service.GetTimePeriodRange(observations);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal((2025, AutumnTerm), result[0]);
+            Assert.Equal((2025, SummerTerm), result[1]);
+        }
+
+        [Fact]
+        public void TermRangeIncludesAutumnSpringTerm_IncludesAutumnSpringTermInResult()
+        {
+            List<Observation> observations =
+            [
+                new() { Year = 2025, TimeIdentifier = AutumnTerm },
+                new() { Year = 2025, TimeIdentifier = SpringTerm },
+                new() { Year = 2025, TimeIdentifier = AutumnSpringTerm },
+                new() { Year = 2025, TimeIdentifier = SummerTerm },
+            ];
+
+            using var statisticsDbContext = InMemoryStatisticsDbContext();
+            var service = new TimePeriodService(statisticsDbContext);
+            var result = service.GetTimePeriodRange(observations);
+
+            Assert.Equal(4, result.Count);
+            Assert.Equal((2025, AutumnTerm), result[0]);
+            Assert.Equal((2025, SpringTerm), result[1]);
+            Assert.Equal((2025, AutumnSpringTerm), result[2]);
+            Assert.Equal((2025, SummerTerm), result[3]);
+        }
+
+        [Fact]
+        public void TermRangeSpansMultipleYears_ExcludesTermsNotInObservations()
+        {
+            List<Observation> observations =
+            [
+                new() { Year = 2024, TimeIdentifier = AutumnTerm },
+                new() { Year = 2024, TimeIdentifier = SummerTerm },
+                new() { Year = 2025, TimeIdentifier = AutumnTerm },
+                new() { Year = 2025, TimeIdentifier = SummerTerm },
+            ];
+
+            using var statisticsDbContext = InMemoryStatisticsDbContext();
+            var service = new TimePeriodService(statisticsDbContext);
+            var result = service.GetTimePeriodRange(observations);
+
+            Assert.Equal(4, result.Count);
+            Assert.Equal((2024, AutumnTerm), result[0]);
+            Assert.Equal((2024, SummerTerm), result[1]);
+            Assert.Equal((2025, AutumnTerm), result[2]);
+            Assert.Equal((2025, SummerTerm), result[3]);
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
@@ -6,241 +6,247 @@ using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.S
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
 
-public class TimePeriodServiceTests
+public abstract class TimePeriodServiceTests
 {
-    [Fact]
-    public async Task GetTimePeriods_Subject_CorrectlyOrderWeeklyTimeIdentifiers()
+    public class GetTimePeriodsTests : TimePeriodServiceTests
     {
-        var subject = new Subject
+        [Fact]
+        public async Task SubjectHasWeeklyTimeIdentifiers_CorrectlyOrdered()
         {
-            Observations = new List<Observation>
+            var subject = new Subject
             {
-                new() { Year = 2001, TimeIdentifier = Week1 },
-                new() { Year = 2000, TimeIdentifier = Week20 },
-                new() { Year = 2000, TimeIdentifier = Week2 },
-                new() { Year = 2000, TimeIdentifier = Week1 },
-                new() { Year = 2000, TimeIdentifier = Week10 },
-            },
-        };
+                Observations =
+                [
+                    new Observation { Year = 2001, TimeIdentifier = Week1 },
+                    new Observation { Year = 2000, TimeIdentifier = Week20 },
+                    new Observation { Year = 2000, TimeIdentifier = Week2 },
+                    new Observation { Year = 2000, TimeIdentifier = Week1 },
+                    new Observation { Year = 2000, TimeIdentifier = Week10 },
+                ],
+            };
 
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            await statisticsDbContext.AddAsync(subject);
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = new TimePeriodService(statisticsDbContext);
-            var result = await service.GetTimePeriods(subject.Id);
-
-            Assert.Equal(5, result.Count);
-            Assert.Equal((2000, Week1), result[0]);
-            Assert.Equal((2000, Week2), result[1]);
-            Assert.Equal((2000, Week10), result[2]);
-            Assert.Equal((2000, Week20), result[3]);
-            Assert.Equal((2001, Week1), result[4]);
-        }
-    }
-
-    [Fact]
-    public async Task GetTimePeriods_Subject_CorrectlyOrderMonthlyTimeIdentifiers()
-    {
-        var subject = new Subject
-        {
-            Observations = new List<Observation>
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                new() { Year = 2001, TimeIdentifier = January },
-                new() { Year = 2000, TimeIdentifier = February },
-                new() { Year = 2000, TimeIdentifier = December },
-                new() { Year = 2000, TimeIdentifier = October },
-                new() { Year = 2000, TimeIdentifier = March },
-            },
-        };
+                statisticsDbContext.Add(subject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
 
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            await statisticsDbContext.AddAsync(subject);
-            await statisticsDbContext.SaveChangesAsync();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+                var result = await service.GetTimePeriods(subject.Id);
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal((2000, Week1), result[0]);
+                Assert.Equal((2000, Week2), result[1]);
+                Assert.Equal((2000, Week10), result[2]);
+                Assert.Equal((2000, Week20), result[3]);
+                Assert.Equal((2001, Week1), result[4]);
+            }
         }
 
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        [Fact]
+        public async Task SubjectHasMonthlyTimeIdentifiers_CorrectlyOrdered()
         {
-            var service = new TimePeriodService(statisticsDbContext);
-            var result = await service.GetTimePeriods(subject.Id);
+            var subject = new Subject
+            {
+                Observations =
+                [
+                    new Observation { Year = 2001, TimeIdentifier = January },
+                    new Observation { Year = 2000, TimeIdentifier = February },
+                    new Observation { Year = 2000, TimeIdentifier = December },
+                    new Observation { Year = 2000, TimeIdentifier = October },
+                    new Observation { Year = 2000, TimeIdentifier = March },
+                ],
+            };
 
-            Assert.Equal(5, result.Count);
-            Assert.Equal((2000, February), result[0]);
-            Assert.Equal((2000, March), result[1]);
-            Assert.Equal((2000, October), result[2]);
-            Assert.Equal((2000, December), result[3]);
-            Assert.Equal((2001, January), result[4]);
-        }
-    }
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                statisticsDbContext.Add(subject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
 
-    [Fact]
-    public async Task GetTimePeriods_Observations_CorrectlyOrderWeeklyTimeIdentifiers()
-    {
-        var obs1 = new Observation { Year = 2001, TimeIdentifier = Week1 };
-        var obs2 = new Observation { Year = 2000, TimeIdentifier = Week20 };
-        var obs3 = new Observation { Year = 2000, TimeIdentifier = Week2 };
-        var obs4 = new Observation { Year = 2000, TimeIdentifier = Week1 };
-        var obs5 = new Observation { Year = 2000, TimeIdentifier = Week10 };
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+                var result = await service.GetTimePeriods(subject.Id);
 
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            await statisticsDbContext.AddRangeAsync(obs1, obs2, obs3, obs4, obs5);
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = new TimePeriodService(statisticsDbContext);
-            var queryableObservations = statisticsDbContext.Observation.AsQueryable();
-            var result = await service.GetTimePeriods(queryableObservations);
-
-            Assert.Equal(5, result.Count);
-            Assert.Equal((2000, Week1), result[0]);
-            Assert.Equal((2000, Week2), result[1]);
-            Assert.Equal((2000, Week10), result[2]);
-            Assert.Equal((2000, Week20), result[3]);
-            Assert.Equal((2001, Week1), result[4]);
-        }
-    }
-
-    [Fact]
-    public async Task GetTimePeriodLabels()
-    {
-        var releaseVersion = new ReleaseVersion();
-
-        var subject = new Subject();
-
-        var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
-
-        var subjectObservation1 = new Observation
-        {
-            Subject = subject,
-            Year = 2030,
-            TimeIdentifier = AcademicYearQ3,
-        };
-
-        var subjectObservation2 = new Observation
-        {
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = AcademicYearQ4,
-        };
-
-        var subjectObservation3 = new Observation
-        {
-            Subject = subject,
-            Year = 2021,
-            TimeIdentifier = AcademicYearQ1,
-        };
-
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            statisticsDbContext.ReleaseVersion.Add(releaseVersion);
-            statisticsDbContext.Subject.Add(subject);
-            statisticsDbContext.ReleaseSubject.Add(releaseSubject);
-            statisticsDbContext.Observation.AddRange(subjectObservation1, subjectObservation2, subjectObservation3);
-            await statisticsDbContext.SaveChangesAsync();
+                Assert.Equal(5, result.Count);
+                Assert.Equal((2000, February), result[0]);
+                Assert.Equal((2000, March), result[1]);
+                Assert.Equal((2000, October), result[2]);
+                Assert.Equal((2000, December), result[3]);
+                Assert.Equal((2001, January), result[4]);
+            }
         }
 
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        [Fact]
+        public async Task ObservationsHaveWeeklyTimeIdentifiers_CorrectlyOrdered()
         {
-            var service = new TimePeriodService(statisticsDbContext);
+            var obs1 = new Observation { Year = 2001, TimeIdentifier = Week1 };
+            var obs2 = new Observation { Year = 2000, TimeIdentifier = Week20 };
+            var obs3 = new Observation { Year = 2000, TimeIdentifier = Week2 };
+            var obs4 = new Observation { Year = 2000, TimeIdentifier = Week1 };
+            var obs5 = new Observation { Year = 2000, TimeIdentifier = Week10 };
 
-            var result = await service.GetTimePeriodLabels(subject.Id);
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                statisticsDbContext.AddRange(obs1, obs2, obs3, obs4, obs5);
+                await statisticsDbContext.SaveChangesAsync();
+            }
 
-            Assert.Equal("2020/21 Q4", result.From);
-            Assert.Equal("2030/31 Q3", result.To);
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+                var queryableObservations = statisticsDbContext.Observation.AsQueryable();
+                var result = await service.GetTimePeriods(queryableObservations);
+
+                Assert.Equal(5, result.Count);
+                Assert.Equal((2000, Week1), result[0]);
+                Assert.Equal((2000, Week2), result[1]);
+                Assert.Equal((2000, Week10), result[2]);
+                Assert.Equal((2000, Week20), result[3]);
+                Assert.Equal((2001, Week1), result[4]);
+            }
         }
     }
 
-    [Fact]
-    public async Task GetTimePeriodLabels_CorrectlyOrderWeeks()
+    public class GetTimePeriodLabelsTests : TimePeriodServiceTests
     {
-        var releaseVersion = new ReleaseVersion();
-
-        var subject = new Subject();
-
-        var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
-
-        var subjectObservation1 = new Observation
+        [Fact]
+        public async Task SubjectHasQuarterlyObservations_ReturnsCorrectFromAndToLabels()
         {
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = Week9,
-        };
+            var releaseVersion = new ReleaseVersion();
 
-        var subjectObservation2 = new Observation
-        {
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = Week37,
-        };
+            var subject = new Subject();
 
-        var subjectObservation3 = new Observation
-        {
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = Week8,
-        };
+            var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
 
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            statisticsDbContext.ReleaseVersion.Add(releaseVersion);
-            statisticsDbContext.Subject.Add(subject);
-            statisticsDbContext.ReleaseSubject.Add(releaseSubject);
-            statisticsDbContext.Observation.AddRange(subjectObservation1, subjectObservation2, subjectObservation3);
-            await statisticsDbContext.SaveChangesAsync();
+            var subjectObservation1 = new Observation
+            {
+                Subject = subject,
+                Year = 2030,
+                TimeIdentifier = AcademicYearQ3,
+            };
+
+            var subjectObservation2 = new Observation
+            {
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = AcademicYearQ4,
+            };
+
+            var subjectObservation3 = new Observation
+            {
+                Subject = subject,
+                Year = 2021,
+                TimeIdentifier = AcademicYearQ1,
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                statisticsDbContext.ReleaseVersion.Add(releaseVersion);
+                statisticsDbContext.Subject.Add(subject);
+                statisticsDbContext.ReleaseSubject.Add(releaseSubject);
+                statisticsDbContext.Observation.AddRange(subjectObservation1, subjectObservation2, subjectObservation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+
+                var result = await service.GetTimePeriodLabels(subject.Id);
+
+                Assert.Equal("2020/21 Q4", result.From);
+                Assert.Equal("2030/31 Q3", result.To);
+            }
         }
 
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        [Fact]
+        public async Task SubjectHasWeeklyObservations_ReturnsCorrectFromAndToLabels()
         {
-            var service = new TimePeriodService(statisticsDbContext);
+            var releaseVersion = new ReleaseVersion();
 
-            var result = await service.GetTimePeriodLabels(subject.Id);
+            var subject = new Subject();
 
-            Assert.Equal("2020 Week 8", result.From);
-            Assert.Equal("2020 Week 37", result.To);
+            var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
+
+            var subjectObservation1 = new Observation
+            {
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = Week9,
+            };
+
+            var subjectObservation2 = new Observation
+            {
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = Week37,
+            };
+
+            var subjectObservation3 = new Observation
+            {
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = Week8,
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                statisticsDbContext.ReleaseVersion.Add(releaseVersion);
+                statisticsDbContext.Subject.Add(subject);
+                statisticsDbContext.ReleaseSubject.Add(releaseSubject);
+                statisticsDbContext.Observation.AddRange(subjectObservation1, subjectObservation2, subjectObservation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+
+                var result = await service.GetTimePeriodLabels(subject.Id);
+
+                Assert.Equal("2020 Week 8", result.From);
+                Assert.Equal("2020 Week 37", result.To);
+            }
         }
-    }
 
-    [Fact]
-    public async Task GetTimePeriodLabels_NoObservations()
-    {
-        var releaseVersion = new ReleaseVersion();
-
-        var subject = new Subject();
-
-        var releaseSubject1 = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
-
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        [Fact]
+        public async Task SubjectHasNoObservations_ReturnsEmptyLabels()
         {
-            statisticsDbContext.ReleaseVersion.Add(releaseVersion);
-            statisticsDbContext.Subject.Add(subject);
-            statisticsDbContext.ReleaseSubject.Add(releaseSubject1);
-            await statisticsDbContext.SaveChangesAsync();
-        }
+            var releaseVersion = new ReleaseVersion();
 
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = new TimePeriodService(statisticsDbContext);
+            var subject = new Subject();
 
-            var result = await service.GetTimePeriodLabels(subject.Id);
+            var releaseSubject1 = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
 
-            Assert.Empty(result.From);
-            Assert.Empty(result.To);
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                statisticsDbContext.ReleaseVersion.Add(releaseVersion);
+                statisticsDbContext.Subject.Add(subject);
+                statisticsDbContext.ReleaseSubject.Add(releaseSubject1);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = new TimePeriodService(statisticsDbContext);
+
+                var result = await service.GetTimePeriodLabels(subject.Id);
+
+                Assert.Empty(result.From);
+                Assert.Empty(result.To);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
 using Microsoft.EntityFrameworkCore;
@@ -41,7 +42,25 @@ public class TimePeriodService : ITimePeriodService
         var start = timePeriods.First();
         var end = timePeriods.Last();
 
-        return TimePeriodUtil.GetTimePeriodRange(start, end);
+        var range = TimePeriodUtil.GetTimePeriodRange(start, end);
+
+        if (!start.TimeIdentifier.IsTerm() || !end.TimeIdentifier.IsTerm())
+        {
+            return range;
+        }
+
+        // For a range of academic terms, only return the terms that are present in the observation data.
+        // This avoids warning users in the 'Explore data' step of Table Tool that
+        // 'Some rows and columns are not shown in this table as the data does not exist in the underlying file'
+        // when the full range of term identifiers is not expected to have data.
+        //
+        // For example, given a range from '2025/26 Autumn term' to '2025/26 Summer term', the generated range is:
+        // '2025/26 Autumn term', '2025/26 Spring term', '2025/26 Autumn and spring term', and '2025/26 Summer term'.
+        //
+        // If observation data only exists for '2025/26 Autumn term' and '2025/26 Summer term', excluding the missing
+        // intermediate terms prevents the unnecessary warning.
+        var timePeriodsSet = timePeriods.ToHashSet();
+        return range.Where(timePeriodsSet.Contains).ToList();
     }
 
     public async Task<TimePeriodLabels> GetTimePeriodLabels(Guid subjectId)


### PR DESCRIPTION
This PR filters the time period range returned in table meta data to exclude non-existent terms in observations data.

This avoids warning users in the 'Explore data' step of Table Tool that **'Some rows and columns are not shown in this table as the data does not exist in the underlying file'**, when the full range of term identifiers is not expected to have data.

For example, given a range from start: '2025/26 Autumn term' to end: '2025/26 Summer term', the generated range is:
'2025/26 Autumn term', '2025/26 Spring term', '2025/26 Autumn and spring term', and '2025/26 Summer term'.

If observations data only exists for '2025/26 Autumn term', '2025/26 Spring term' and '2025/26 Summer term' which is how some teams publish data (as shown in the example below), this would show an unnecessary warning.

### Before

<img width="1342" height="892" alt="image (34)" src="https://github.com/user-attachments/assets/09934528-c9cb-41b6-8bfa-c0da7889efce" />

### After

<img width="677" height="406" alt="image" src="https://github.com/user-attachments/assets/3d2e52c9-8bfc-4dce-a640-034287e5fc6d" />

### Other changes

- Create nested classes on a per-public-method being tested basis in `TimePeriodServiceTests`.
- Remove usages of `AddRangeAsync` / `AddAsync` in `TimePeriodServiceTests`.