### PR TITLE
EES-7338 - switching back to using reorganizations now all indexes ba…

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -1081,11 +1081,11 @@
           },
           "FragmentationThresholdReorganize": {
             "type": "string",
-            "defaultValue": "10"
+            "defaultValue": "5"
           },
           "FragmentationThresholdRebuild": {
             "type": "string",
-            "defaultValue": "10"
+            "defaultValue": "30"
           },
           "RunMode": {
             "type": "string",


### PR DESCRIPTION
This PR:
- reintroduces reorganizations now that the indexes are under control in all environments.
- lowers the threshold of reorganizations now that we have much longer to tackle them with extended evening and weekend schedules.

We need to try to move away from rebuilds now where we can, as the resumeable rebuilds are close to making the db run out of space. 