### PR TITLE
EES-7346 - Fixing robot tests on Invite Users page

### DIFF
--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -11,17 +11,21 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    Invite new users %{RUN_IDENTIFIER}
-${RELEASE1_NAME}=       ${PUBLICATION_NAME} - Academic year 2000/01
-${RELEASE2_NAME}=       ${PUBLICATION_NAME} - Academic year 2001/02
-${EMAIL}=               ees-ui-test-%{RUN_IDENTIFIER}@education.gov.uk
+${PUBLICATION1_NAME}=               Invite new users 1 %{RUN_IDENTIFIER}
+${PUBLICATION2_NAME}=               Invite new users 2 %{RUN_IDENTIFIER}
+${PUBLICATION1_RELEASE1_NAME}=      ${PUBLICATION1_NAME} - Academic year 2000/01
+${PUBLICATION1_RELEASE2_NAME}=      ${PUBLICATION1_NAME} - Academic year 2001/02
+${PUBLICATION2_RELEASE1_NAME}=      ${PUBLICATION2_NAME} - Academic year 2000/01
+${EMAIL}=                           ees-ui-test-%{RUN_IDENTIFIER}@education.gov.uk
 
 
 *** Test Cases ***
 Create Publication as bau1
-    ${publication_id}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${publication_id}    AY    2000
-    user creates test release via api    ${publication_id}    AY    2001
+    ${publication1_id}=    user creates test publication via api    ${PUBLICATION1_NAME}
+    ${publication2_id}=    user creates test publication via api    ${PUBLICATION2_NAME}
+    user creates test release via api    ${publication1_id}    AY    2000
+    user creates test release via api    ${publication1_id}    AY    2001
+    user creates test release via api    ${publication2_id}    AY    2000
 
 Navigate to Platform administration, Invite new users page
     user clicks link    Platform administration
@@ -50,50 +54,105 @@ Cancel invite
     user waits until page does not contain    ${EMAIL}
     user waits until h1 is visible    Pending invites
 
-Invite a new user with pre-release and publication roles
+Invite a new user with pre-release and publication roles within the same publication
     user clicks link    Invite a new user
     user waits until h1 is visible    Invite user
 
     user enters text into element    name:userEmail    ${EMAIL}
 
-    user chooses select option    name:releaseId    ${RELEASE1_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION1_RELEASE1_NAME}
     user clicks button    Add pre-release role
 
     user checks table body has x rows    1    testid:pre-release-role-table
-    user gets table row    ${RELEASE1_NAME}    testid:pre-release-role-table
+    user gets table row    ${PUBLICATION1_RELEASE1_NAME}    testid:pre-release-role-table
 
-    user chooses select option    name:releaseId    ${RELEASE2_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION1_RELEASE2_NAME}
     user clicks button    Add pre-release role
 
     user checks table body has x rows    2    testid:pre-release-role-table
-    user gets table row    ${RELEASE1_NAME}    testid:pre-release-role-table
-    ${ROW}=    user gets table row    ${RELEASE2_NAME}    testid:pre-release-role-table
+    user gets table row    ${PUBLICATION1_RELEASE1_NAME}    testid:pre-release-role-table
+    ${ROW}=    user gets table row    ${PUBLICATION1_RELEASE2_NAME}    testid:pre-release-role-table
 
     user clicks button    Remove    ${ROW}
     user checks table body has x rows    1    testid:pre-release-role-table
-    user checks element does not contain    testid:pre-release-role-table    ${RELEASE2_NAME}
+    user checks element does not contain    testid:pre-release-role-table    ${PUBLICATION1_RELEASE2_NAME}
 
-    user chooses select option    name:publicationId    ${PUBLICATION_NAME}
+    # Because we're adding a more powerful publication-level role to the same publication as the pre-release
+    # role above, the pre-release role will be rendered redundant and should therefore be silently
+    # ignored on the BE and not added to the user's list of pre-release roles (current implementation).
+    # Therefore, we would not expect for this pre-release role to appear on the Pending Invites page
+    # after we send the invite.
+    user chooses select option    name:publicationId    ${PUBLICATION1_NAME}
     user chooses select option    name:publicationRole    Approver
     user clicks button    Add publication role
 
     user checks table body has x rows    1    testid:publication-role-table
-    ${ROW}=    user gets table row    ${PUBLICATION_NAME}    testid:publication-role-table
+    ${ROW}=    user gets table row    ${PUBLICATION1_NAME}    testid:publication-role-table
     user checks element contains    ${ROW}    Approver
 
     user clicks button    Send invite
     user waits until h1 is visible    Pending invites
 
-Validate newly invited user with roles appears on Pending invites page
+Validate newly invited user with roles appears on Pending invites page but the redundant pre-release role was not added
     ${ROW}=    user gets table row    ${EMAIL}
     set suite variable    ${ROW}
     user checks element contains    ${ROW}    Analyst
-    user checks element contains    ${ROW}    ${PUBLICATION_NAME}
+    user checks element does not contain    ${ROW}    Academic year 2000/01
+    user checks element does not contain    ${ROW}    Academic year 2001/02
+    user checks element contains    ${ROW}    No user pre-release roles
+    user checks element contains    ${ROW}    ${PUBLICATION1_NAME} - Approver
 
+Cancel invite with roles
+    user clicks button    Cancel invite    ${ROW}
+    user waits until page does not contain    ${EMAIL}
+    user waits until h1 is visible    Pending invites
+
+Invite a new user with pre-release and publication roles within different publications
+    user clicks link    Invite a new user
+    user waits until h1 is visible    Invite user
+
+    user enters text into element    name:userEmail    ${EMAIL}
+
+    user chooses select option    name:releaseId    ${PUBLICATION1_RELEASE1_NAME}
+    user clicks button    Add pre-release role
+
+    user checks table body has x rows    1    testid:pre-release-role-table
+    user gets table row    ${PUBLICATION1_RELEASE1_NAME}    testid:pre-release-role-table
+
+    user chooses select option    name:releaseId    ${PUBLICATION1_RELEASE2_NAME}
+    user clicks button    Add pre-release role
+
+    user checks table body has x rows    2    testid:pre-release-role-table
+    user gets table row    ${PUBLICATION1_RELEASE1_NAME}    testid:pre-release-role-table
+    ${ROW}=    user gets table row    ${PUBLICATION1_RELEASE2_NAME}    testid:pre-release-role-table
+
+    user clicks button    Remove    ${ROW}
+    user checks table body has x rows    1    testid:pre-release-role-table
+    user checks element does not contain    testid:pre-release-role-table    ${PUBLICATION1_RELEASE2_NAME}
+
+    # In this case, because we're adding a publication-level role to a DIFFERENT publication to the pre-release
+    # role above, the pre-release role will still be useful, and therefore should not be silently
+    # ignored on the BE and will be added to the user's list of pre-release roles.
+    # Therefore, we WOULD expect for this pre-release role to appear on the Pending Invites page
+    # after we send the invite.
+    user chooses select option    name:publicationId    ${PUBLICATION2_NAME}
+    user chooses select option    name:publicationRole    Approver
+    user clicks button    Add publication role
+
+    user checks table body has x rows    1    testid:publication-role-table
+    ${ROW}=    user gets table row    ${PUBLICATION2_NAME}    testid:publication-role-table
+    user checks element contains    ${ROW}    Approver
+
+    user clicks button    Send invite
+    user waits until h1 is visible    Pending invites
+
+Validate newly invited user with roles appears on Pending invites page and the pre-release role appears this time
+    ${ROW}=    user gets table row    ${EMAIL}
+    set suite variable    ${ROW}
+    user checks element contains    ${ROW}    Analyst
     user checks element contains    ${ROW}    Academic year 2000/01
     user checks element does not contain    ${ROW}    Academic year 2001/02
-
-    user checks element contains    ${ROW}    ${PUBLICATION_NAME} - Approver
+    user checks element contains    ${ROW}    ${PUBLICATION2_NAME} - Approver
 
 Cancel invite with roles
     user clicks button    Cancel invite    ${ROW}


### PR DESCRIPTION
There is a new Ui test failure in:
`robot-tests/tests/admin/bau/invite_new_users.robot` due to the changes in https://github.com/dfe-analytical-services/explore-education-statistics/pull/7106

This is because we now automatically (and silently) remove any redundant pre-release roles from the user invite request on the BE before adding the new user invite to the database. If there is a more powerful publication-level role in place for the same publication as a pre-release role which is being added, then the pre-release role has no use as it is effectively superseded by the publication-level role. Therefore, we do not add those redundant pre-release roles to the user, and they do not appear on the Pending Invites page after the invite has been sent.

This is now expected behaviour, but our current UI tests were still checking for the old behaviour.

They have now been changed to test for the scenario where you add pre-release roles to the same publication as a publication-level role, and the other situation where you add them to different publications