### PR TITLE
EES-6901 ARM template tidy-up

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1452,18 +1452,15 @@
         }
       ],
       "properties": {
-        "name": "[variables('dataAppName')]",
         "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('dataPlanName'))]",
-        "hostingEnvironment": "",
         "httpsOnly": true,
         "clientAffinityEnabled": false,
         "siteConfig": {
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -1489,7 +1486,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('dataPlanName'))]",
-        "[resourceId('microsoft.insights/components/', variables('dataAppInsights'))]"
+        "[resourceId('Microsoft.Insights/components', variables('dataAppInsights'))]"
       ]
     },
     {
@@ -1499,11 +1496,11 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('dataAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
         "[variables('ees-storage-public')]"
       ],
       "properties": {
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('dataAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('dataAppInsights')), '2020-02-02').InstrumentationKey]",
         "WEBSITE_NODE_DEFAULT_VERSION": "22.22.0",
         "WEBSITE_CONTENTOVERVNET": "1",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
@@ -1565,8 +1562,7 @@
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
-          "AlwaysOn": false,
+          "alwaysOn": false,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -1596,7 +1592,7 @@
         }
       ],
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('dataAppName'))]"
+        "[resourceId('Microsoft.Web/sites', variables('dataAppName'))]"
       ]
     },
     {
@@ -1692,18 +1688,15 @@
         }
       ],
       "properties": {
-        "name": "[variables('contentAppName')]",
         "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('contentPlanName'))]",
-        "hostingEnvironment": "",
         "httpsOnly": true,
         "clientAffinityEnabled": false,
         "siteConfig": {
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -1729,7 +1722,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('contentPlanName'))]",
-        "[resourceId('microsoft.insights/components/', variables('contentAppInsights'))]"
+        "[resourceId('Microsoft.Insights/components', variables('contentAppInsights'))]"
       ]
     },
     {
@@ -1743,7 +1736,7 @@
         "[variables('ees-storage-public')]"
       ],
       "properties": {
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('contentAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('contentAppInsights')), '2020-02-02').InstrumentationKey]",
         "WEBSITE_NODE_DEFAULT_VERSION": "22.22.0",
         "WEBSITE_CONTENTOVERVNET": "1",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
@@ -1800,8 +1793,7 @@
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
-          "AlwaysOn": false,
+          "alwaysOn": false,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -1831,7 +1823,7 @@
         }
       ],
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('contentAppName'))]"
+        "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
       ]
     },
     {
@@ -1927,20 +1919,15 @@
         }
       ],
       "properties": {
-        "name": "[variables('adminAppName')]",
         "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('adminPlanName'))]",
-        "hostingEnvironment": "",
         "httpsOnly": true,
-        "WEBSITE_SWAP_WARMUP_PING_STATUSES": "200, 202, 204",
-        "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG": 1,
         "clientAffinityEnabled": true,
         "siteConfig": {
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -1968,7 +1955,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('adminPlanName'))]",
-        "[resourceId('microsoft.insights/components/', variables('adminAppInsights'))]"
+        "[resourceId('Microsoft.Insights/components', variables('adminAppInsights'))]"
       ]
     },
     {
@@ -1984,8 +1971,8 @@
         "[variables('ees-storage-publisher')]"
       ],
       "properties": {
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('adminAppInsights')), '2020-02-02').InstrumentationKey]",
-        "AppInsights__InstrumentationKey": "[reference(resourceId('microsoft.insights/components/', variables('adminAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('adminAppInsights')), '2020-02-02').InstrumentationKey]",
+        "AppInsights__InstrumentationKey": "[reference(resourceId('Microsoft.Insights/components', variables('adminAppInsights')), '2020-02-02').InstrumentationKey]",
         "WEBSITE_NODE_DEFAULT_VERSION": "22.22.0",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "WEBSITE_LOAD_CERTIFICATES": "*",
@@ -2066,8 +2053,7 @@
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
-          "AlwaysOn": false,
+          "alwaysOn": false,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -2094,7 +2080,7 @@
         }
       ],
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('adminAppName'))]"
+        "[resourceId('Microsoft.Web/sites', variables('adminAppName'))]"
       ]
     },
     {
@@ -2289,9 +2275,7 @@
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
       "properties": {
-        "name": "[variables('publicAppName')]",
         "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('publicPlanName'))]",
-        "hostingEnvironment": "",
         "httpsOnly": true,
         "clientAffinityEnabled": false,
         "reserved": true,
@@ -2301,9 +2285,8 @@
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
           "preWarmedInstanceCount": 1,
-          "framework": "node",
           "nodeVersion": "16-lts",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -2316,7 +2299,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Web/serverfarms/', variables('publicPlanName'))]",
-        "[resourceId('microsoft.insights/components/', variables('publicAppInsights'))]"
+        "[resourceId('Microsoft.Insights/components', variables('publicAppInsights'))]"
       ]
     },
     {
@@ -2329,7 +2312,7 @@
       ],
       "properties": {
         "APP_ENV": "[parameters('environmentName')]",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('publicAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('publicAppInsights')), '2020-02-02').InstrumentationKey]",
         "AZURE_SEARCH_ENDPOINT": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('apiVersions').searchService).endpoint]",
         "AZURE_SEARCH_INDEX": "[parameters('searchIndexName')]",
         "AZURE_DATASETS_SEARCH_INDEX": "[parameters('datasetsSearchIndexName')]",
@@ -2994,7 +2977,7 @@
       }
     },
     {
-      "name": "[concat(variables('publicSqlserverName'), '/', variables('publicSqlAllowedSubnets')[copyIndex()].name)]",
+      "name": "[concat(variables('publicSqlServerName'), '/', variables('publicSqlAllowedSubnets')[copyIndex()].name)]",
       "type": "Microsoft.Sql/servers/virtualNetworkRules",
       "condition": "[and(equals(parameters('sqlServerPublicNetworkAccess'), 'Enabled'), parameters('useSubnets'))]",
       "apiVersion": "2015-05-01-preview",
@@ -3381,7 +3364,7 @@
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "requestTracingEnabled": true,
           "remoteDebuggingEnabled": false,
@@ -3416,7 +3399,7 @@
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('notificationsAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('notificationsAppInsights')), '2020-02-02').InstrumentationKey]",
         "App__EmailEnabled": "true",
         "App__SuppressExceptionsForTeamOnlyApiKeyErrors": "[parameters('notifierSuppressExceptionsForTeamOnlyApiKeyErrors')]",
         "App__Url": "[concat(concat('https://', variables('notificationsAppName')), '.azurewebsites.net/api')]",
@@ -3532,9 +3515,8 @@
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -3572,7 +3554,7 @@
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('importerAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('importerAppInsights')), '2020-02-02').InstrumentationKey]",
         "App__RowsPerBatch": "3000",
         "App__PrivateStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-core')).secretUriWithVersion, ')')]"
       }
@@ -3685,9 +3667,8 @@
           "http20Enabled": true,
           "minTlsVersion": "[parameters('minTlsVersion')]",
           "ftpsState": "FtpsOnly",
-          "phpVersion": "off",
           "netFrameworkVersion": "v8.0",
-          "AlwaysOn": true,
+          "alwaysOn": true,
           "webSocketsEnabled": false,
           "remoteDebuggingEnabled": false,
           "httpLoggingEnabled": true,
@@ -3736,7 +3717,7 @@
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('publisherAppInsights')), '2020-02-02').InstrumentationKey]",
+        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('publisherAppInsights')), '2020-02-02').InstrumentationKey]",
         "App__PrepareScheduledReleaseVersionsFunctionCronSchedule": "[parameters('prepareScheduledReleaseVersionsFunctionCronSchedule')]",
         "App__PublishScheduledReleaseVersionsFunctionCronSchedule": "[parameters('publishScheduledReleaseVersionsFunctionCronSchedule')]",
         "App__PrivateStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-core')).secretUriWithVersion, ')')]",
@@ -4274,7 +4255,7 @@
         "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
         "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
         "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
-        "[resourceId('microsoft.insights/actionGroups', variables('actionGroupAlerts'))]"
+        "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupAlerts'))]"
       ]
     },
     {
@@ -4721,7 +4702,7 @@
       ]
     },
     {
-      "type": "microsoft.insights/actionGroups",
+      "type": "Microsoft.Insights/actionGroups",
       "apiVersion": "2019-06-01",
       "name": "[variables('actionGroupAlerts')]",
       "location": "global",
@@ -4739,13 +4720,13 @@
       }
     },
     {
-      "type": "microsoft.insights/metricAlerts",
+      "type": "Microsoft.Insights/metricAlerts",
       "apiVersion": "2018-03-01",
       "name": "[variables('metricAlerts')[copyIndex()].name]",
       "location": "global",
       "dependsOn": [
         "[variables('metricAlerts')[copyIndex()].resourceId]",
-        "[resourceId('microsoft.insights/actionGroups', variables('actionGroupAlerts'))]"
+        "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupAlerts'))]"
       ],
       "copy": {
         "name": "metricAlertsCopy",
@@ -4778,7 +4759,7 @@
         "targetResourceType": "[variables('metricAlerts')[copyIndex()].resourceType]",
         "actions": [
           {
-            "actionGroupId": "[resourceId('microsoft.insights/actionGroups', variables('actionGroupAlerts'))]"
+            "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupAlerts'))]"
           }
         ]
       }


### PR DESCRIPTION
While not strictly related to the .NET 10 upgrade work, this PR contains a tidy up of the ARM template, separating these changes out from those which will be strictly required for the .NET 10 upgrade and will be raised in a later change.

This PR:

* Renames the `AlwaysOn` property to `alwaysOn` throughout all `siteConfig` sections to match the schema.
* Removes invalid properties such as `name`, `hostingEnvironment`, and `framework` which don't exist in the schema, from various web app resource definitions.
* Removes other invalid properties `WEBSITE_SWAP_WARMUP_PING_STATUSES`, and `WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG` which look like they should have been made app settings and were probably added to the wrong place by trial and error.
* Removes redundant property `phpVersion` from resource definitions.
* Updates all resource type references and `resourceId` function calls to use the correct casing (e.g. `Microsoft.Insights/components` instead of `microsoft.insights/components`) .
* Fixes casing in usage of the variable name `publicSqlserverName`, renaming it to `publicSqlServerName` so that it matches the variable name definition.
* Updates all `Microsoft.Web/Sites` references to `Microsoft.Web/sites` for consistency.