### PR TITLE
EES-7347 - Using a query param for the `email` in a couple of endpoints instead of a path param

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserInvitesController.cs
@@ -26,8 +26,8 @@ public class UserInvitesController(IUserManagementService userManagementService)
         return await userManagementService.InviteUser(request).HandleFailuresOrOk();
     }
 
-    [HttpDelete("user-invites/{email}")]
-    public async Task<ActionResult> CancelUserInvite(string email)
+    [HttpDelete("user-invites")]
+    public async Task<ActionResult> CancelUserInvite([FromQuery] string email)
     {
         return await userManagementService.CancelInvite(email).HandleFailuresOrNoContent();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UsersController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UsersController.cs
@@ -35,8 +35,8 @@ public class UsersController(IUserManagementService userManagementService) : Con
     /// <summary>
     /// A BAU-only endpoint for deleting test users.
     /// </summary>
-    [HttpDelete("users/{email}")]
-    public async Task<ActionResult> DeleteUser(string email)
+    [HttpDelete("users")]
+    public async Task<ActionResult> DeleteUser([FromQuery] string email)
     {
         return await userManagementService.DeleteUser(email).HandleFailuresOrNoContent();
     }

--- a/src/explore-education-statistics-admin/src/services/user-management/userInvitesService.ts
+++ b/src/explore-education-statistics-admin/src/services/user-management/userInvitesService.ts
@@ -38,7 +38,9 @@ const userInvitesService: UserInvitesService = {
   },
 
   cancelInvite(email: string): Promise<boolean> {
-    return client.delete(`/user-invites/${email}`);
+    return client.delete(`/user-invites`, {
+      params: { email },
+    });
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/user-management/usersService.ts
+++ b/src/explore-education-statistics-admin/src/services/user-management/usersService.ts
@@ -36,7 +36,9 @@ const userService: UsersService = {
   },
 
   deleteUser(email: string): Promise<RemoveUser> {
-    return client.delete(`users/${email}`);
+    return client.delete(`users`, {
+      params: { email },
+    });
   },
 };
 


### PR DESCRIPTION
This was an edge-case bug, which probably wasn't being encountered in production, but whenever you send an invite to a user with an email address which contained a `+` special character, and then tried to **cancel that invite**, you would receive a `404` because the resource (the endpoint) could not be found.

It worked completely fine locally, and after some digging it appears that something sat in front of the application on the Azure environment was filtering these requests out due to the `+`. Maybe Azure Front Door, or something similar? So the request was never reaching the application.

The fix was to change the API URL such that the `email` was no longer part of the path, and is now a query parameter. We're hoping this should fix the issue.

I also applied the same fix to a BAU only endpoint for deleting users whilst I was in the area.