### PR TITLE
EES-7067 - added core SQL Server private endpoint and VNet integrated runtime creation to Data Factory

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -146,7 +146,7 @@
       "value": "nl-search-dataset-index"
     },
     "sqlServerPublicNetworkAccess": {
-      "value": "Enabled"
+      "value": "Disabled"
     },
     "tableToolSearchEndpoint": {
       "value": "https://s101d01-ees-fa-nlsearch.azurewebsites.net/api/natural_language_search_function"

--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -14,6 +14,12 @@
         "description": "The name of the key vault"
       }
     },
+    "coreSqlServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Core Azure SQL server name"
+      }
+    },
     "slackAlertsChannel": {
       "type": "string",
       "metadata": {
@@ -29,12 +35,59 @@
   },
   "variables": {
     "factoryId": "[concat('Microsoft.DataFactory/factories/', parameters('factoryName'))]",
+    "coreSqlServerPrivateEndpointName": "[concat(parameters('coreSqlServerName'), '-pep')]",
+    "coreSqlServerPrivateEndpointId": "[concat('Microsoft.DataFactory/factories/', variables('coreSqlServerPrivateEndpointName'))]",
     "fragmentationTables": "Observation,ObservationFilterItem",
     "removeSoftDeletedSubjectsObservationLimit": "20000000",
     "removeSoftDeletedSubjectsObservationCommitBatchSize": "500000",
     "removeSoftDeletedSubjectsObservationFilterItemCommitBatchSize": "500000"
   },
   "resources": [
+    {
+      "name": "[concat(parameters('factoryName'), '/default')]",
+      "type": "Microsoft.DataFactory/factories/managedVirtualNetworks",
+      "apiVersion": "2018-06-01",
+      "properties": {}
+    },
+    {
+      "name": "[concat(parameters('factoryName'), '/vnetIntegrationRuntime')]",
+      "type": "Microsoft.DataFactory/factories/integrationRuntimes",
+      "apiVersion": "2018-06-01",
+      "properties": {
+        "type": "Managed",
+        "typeProperties": {
+          "computeProperties": {
+            "location": "[resourceGroup().location]",
+            "dataFlowProperties": {
+              "computeType": "General",
+              "coreCount": 8,
+              "timeToLive": 10,
+              "cleanup": false
+            }
+          }
+        },
+        "managedVirtualNetwork": {
+          "type": "ManagedVirtualNetworkReference",
+          "referenceName": "default"
+        }
+      },
+      "dependsOn": [
+        "[concat(variables('factoryId'), '/managedVirtualNetworks/default')]"
+      ]
+    },
+    {
+      "name": "[concat(parameters('factoryName'), '/default/', variables('coreSqlServerPrivateEndpointName'))]",
+      "type": "Microsoft.DataFactory/factories/managedVirtualNetworks/managedPrivateEndpoints",
+      "apiVersion": "2018-06-01",
+      "properties": {
+        "privateLinkResourceId": "[resourceId('Microsoft.Sql/servers', parameters('coreSqlServerName'))]",
+        "groupId": "sqlServer",
+        "fqdns": "[createArray(concat(parameters('coreSqlServerName'), '.database.windows.net'))]"
+      },
+      "dependsOn": [
+        "[concat(variables('factoryId'), '/managedVirtualNetworks/default')]"
+      ]
+    },
     {
       "name": "[concat(parameters('factoryName'), '/ls_sql_statistics')]",
       "type": "Microsoft.DataFactory/factories/linkedServices",
@@ -51,10 +104,43 @@
             },
             "secretName": "ees-sql-admin-datafactory-connectionstring"
           }
+        },
+        "connectVia": {
+          "referenceName": "vnetIntegrationRuntime",
+          "type": "IntegrationRuntimeReference"
         }
       },
       "dependsOn": [
         "[concat(variables('factoryId'), '/linkedServices/AzureKeyVault')]"
+      ]
+    },
+    {
+      "name": "[concat(parameters('factoryName'), '/ds_sql_statistics')]",
+      "type": "Microsoft.DataFactory/factories/datasets",
+      "apiVersion": "2018-06-01",
+      "properties": {
+        "linkedServiceName": {
+          "referenceName": "ls_sql_statistics",
+          "type": "LinkedServiceReference"
+        },
+        "parameters": {
+          "cw_table": {
+            "type": "String"
+          }
+        },
+        "annotations": [],
+        "type": "AzureSqlTable",
+        "schema": [],
+        "typeProperties": {
+          "schema": "dbo",
+          "table": {
+            "value": "@dataset().cw_table",
+            "type": "Expression"
+          }
+        }
+      },
+      "dependsOn": [
+        "[concat(variables('factoryId'), '/linkedServices/ls_sql_statistics')]"
       ]
     },
     {

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -15,7 +15,7 @@
         "description": "Data Hub Environment Name e.g. ees. Used as a prefix for created resources"
       }
     },
-    "publisherAppName": {
+    "coreSqlServerName": {
       "type": "string"
     },
     "dataFactoryName": {
@@ -86,6 +86,9 @@
           },
           "keyVaultName": {
             "value": "[parameters('keyVaultName')]"
+          },
+          "coreSqlServerName": {
+            "value": "[parameters('coreSqlServerName')]"
           },
           "slackAlertsChannel": {
             "value": "[parameters('slackAlertsChannel')]"

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -4227,8 +4227,8 @@
           "environment": {
             "value": "[parameters('environment')]"
           },
-          "publisherAppName": {
-            "value": "[variables('publisherAppName')]"
+          "coreSqlServerName": {
+            "value": "[variables('coreSqlServerName')]"
           },
           "dataFactoryName": {
             "value": "[variables('dataFactoryName')]"
@@ -4252,8 +4252,6 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
-        "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
-        "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
         "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupAlerts'))]"
       ]


### PR DESCRIPTION
This PR:
- makes the core SQL server non-public.
- allows Data Factory to access non-public core SQL server via private endpoint and integration runtime that is connected to out VNet. 

As part of this PR, I added some previously manually-added resources into the ARM template control e.g. managed network, data sources and linked services. 

Also as part of this PR, I also manually cleaned up a bunch of private endpoints and test integration runtimes that had built up in Dev over time.

:warning: This work includes a manual step to visit each environment's core SQL server after deploy, to go to Networking > Private access and to approve the newly-created private endpoint.