### PR TITLE
EES-7323 table tool search result completion

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -9,8 +9,10 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import tableBuilderService, {
   FastTrackTable,
   FeaturedTable,
+  ReleaseTableDataQuery,
   Subject,
   SubjectMeta,
+  TableDataResponse,
 } from '@common/services/tableBuilderService';
 import publicationService, {
   PublicationMethodologiesList,
@@ -20,11 +22,14 @@ import { Dictionary } from '@common/types';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import TableToolInfoWrapper from '@frontend/modules/table-tool/components/TableToolInfoWrapper';
+import { decodeParamsToFullTableQuery } from '@frontend/modules/table-tool/utils/fullTableQueryTranscode';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { GetServerSideProps, NextPage } from 'next';
 import dynamic from 'next/dynamic';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
+import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
+import logger from '@common/services/logger';
 
 const defaultPageTitle = 'Create your own tables';
 
@@ -35,6 +40,8 @@ const TableToolFinalStep = dynamic(
 export interface TableToolPageProps {
   fastTrack?: FastTrackTable;
   featuredTables?: FeaturedTable[];
+  initialQuery?: ReleaseTableDataQuery;
+  initialTableData?: TableDataResponse;
   selectedPublication?: SelectedPublication;
   publicationMethodologies?: PublicationMethodologiesList;
   selectedSubjectId?: string;
@@ -46,6 +53,8 @@ export interface TableToolPageProps {
 const TableToolPage: NextPage<TableToolPageProps> = ({
   fastTrack,
   featuredTables = [],
+  initialQuery,
+  initialTableData,
   selectedPublication,
   publicationMethodologies,
   selectedSubjectId,
@@ -120,6 +129,23 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       };
     }
 
+    if (initialQuery && initialTableData && subjectMeta) {
+      const fullTable = mapFullTable(initialTableData);
+      const tableHeaders = getDefaultTableHeaderConfig(fullTable);
+      return {
+        initialStep: 6,
+        subjects,
+        featuredTables,
+        query: initialQuery,
+        selectedPublication,
+        subjectMeta,
+        response: {
+          table: fullTable,
+          tableHeaders,
+        },
+      };
+    }
+
     if (selectedSubjectId && subjectMeta) {
       return {
         initialStep: 3,
@@ -157,11 +183,13 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   }, [
     subjects,
     fastTrack,
-    publicationMethodologies,
     subjectMeta,
+    initialQuery,
+    initialTableData,
     selectedSubjectId,
     featuredTables,
     selectedPublication,
+    publicationMethodologies,
   ]);
 
   return (
@@ -317,7 +345,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
 
 export const getServerSideProps: GetServerSideProps<
   TableToolPageProps
-> = async ({ query }) => {
+> = async ({ query, req }) => {
   const {
     publicationSlug = '',
     releaseSlug = '',
@@ -357,39 +385,46 @@ export const getServerSideProps: GetServerSideProps<
       publicationService.getPublicationMethodologies(publicationSlug),
     ]);
 
-  if (subjectId && subjects.some(subject => subject.id === subjectId)) {
-    const subjectMeta = await tableBuilderService.getSubjectMeta(
+  let initialQuery: ReleaseTableDataQuery | undefined;
+  let initialTableData: TableDataResponse | undefined;
+  let subjectMeta: SubjectMeta | undefined;
+  let selectedSubjectId: string | undefined;
+
+  const urlObj = new URL(req.url || '', process.env.PUBLIC_URL);
+
+  // Check if the user has come from table tool search (with compressed query string)
+  const hasCompressedQuery = urlObj.searchParams.has('fromSearch');
+  if (hasCompressedQuery) {
+    try {
+      const decodedQuery = decodeParamsToFullTableQuery(urlObj.searchParams);
+      initialQuery = {
+        ...decodedQuery,
+        releaseVersionId: selectedReleaseVersion.id,
+        publicationId: selectedPublication.id,
+      };
+      const [fetchedSubjectMeta, fetchedTableData] = await Promise.all([
+        tableBuilderService.getSubjectMeta(
+          decodedQuery.subjectId,
+          selectedReleaseVersion.id,
+        ),
+        tableBuilderService.getTableData(
+          decodedQuery,
+          selectedReleaseVersion.id,
+        ),
+      ]);
+      subjectMeta = fetchedSubjectMeta;
+      initialTableData = fetchedTableData;
+      selectedSubjectId = decodedQuery.subjectId;
+    } catch (e) {
+      logger.error(e);
+    }
+  } else if (subjectId && subjects.some(subject => subject.id === subjectId)) {
+    // Fallback/standard path (initialStep: 3)
+    subjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
       selectedReleaseVersion.id,
     );
-
-    return {
-      props: {
-        featuredTables,
-        publicationMethodologies,
-        selectedPublication: {
-          ...selectedPublication,
-          contact: publicationSummary.contact,
-          selectedRelease: {
-            id: selectedReleaseVersion.id,
-            latestData: selectedReleaseVersion.isLatestRelease,
-            publishingOrganisations:
-              selectedReleaseVersion.publishingOrganisations,
-            slug: selectedReleaseVersion.slug,
-            title: selectedReleaseVersion.title,
-            type: selectedReleaseVersion.type,
-          },
-          latestRelease: {
-            title: latestRelease.title,
-            slug: latestRelease.slug,
-          },
-        },
-        selectedSubjectId: subjectId,
-        subjects,
-        subjectMeta,
-        themeMeta,
-      },
-    };
+    selectedSubjectId = subjectId;
   }
 
   return {
@@ -415,6 +450,10 @@ export const getServerSideProps: GetServerSideProps<
       },
       subjects,
       featuredTables,
+      ...(subjectMeta ? { subjectMeta } : {}),
+      ...(selectedSubjectId ? { selectedSubjectId } : {}),
+      ...(initialQuery ? { initialQuery } : {}),
+      ...(initialTableData ? { initialTableData } : {}),
     },
   };
 };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
@@ -293,7 +293,7 @@ const TableToolSearchPage: NextPage<TableToolSearchPageProps> = ({
                             <TableToolSearchFinalResult
                               key={dataset.fileId}
                               dataset={dataset}
-                              releaseVersionId={latestReleaseVersion.id}
+                              releaseVersionSummary={latestReleaseVersion}
                             />
                           ))}
                         </ul>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
@@ -78,8 +78,7 @@ const TableToolSearchPage: NextPage<TableToolSearchPageProps> = ({
       await tableToolSearchService.postSearchStream(
         {
           userQuery: searchTerm.trim(),
-          publicationId:
-            'a91d9e05-be82-474c-85ae-4913158406d0' || publicationSummary.id, // hardcoding for now
+          publicationId: publicationSummary.id,
         },
         {
           signal: abortControllerRef.current.signal,
@@ -105,6 +104,8 @@ const TableToolSearchPage: NextPage<TableToolSearchPageProps> = ({
 
               return updatedState;
             });
+
+            setError(null);
 
             // Abort early if there are no results.
             if (

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -467,6 +467,22 @@ describe('TableToolPage', () => {
     expect(screen.getByLabelText('Great Britain')).toBeInTheDocument();
   });
 
+  test('renders the page correctly when initialQuery and initialTableData are provided', async () => {
+    render(
+      <TableToolPage
+        selectedPublication={testSelectedPublicationWithLatestRelease}
+        selectedSubjectId="1"
+        subjects={testSubjects}
+        themeMeta={testThemeMeta}
+        subjectMeta={testSubjectMeta}
+        initialQuery={testFastTrack.query}
+        initialTableData={testFastTrack.fullTable}
+      />,
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
   test('renders the page correctly with pre-built table when a fast track is provided', async () => {
     render(
       <TableToolPage

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolSearchPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolSearchPage.test.tsx
@@ -93,7 +93,7 @@ describe('TableToolSearchPage', () => {
     expect(mockPostSearchStream).toHaveBeenCalledWith(
       {
         userQuery: 'test search term',
-        publicationId: 'a91d9e05-be82-474c-85ae-4913158406d0',
+        publicationId: 'publication-summary-1',
       },
       expect.anything(),
     );
@@ -112,11 +112,33 @@ describe('TableToolSearchPage', () => {
         stage: PipelineStage.RETRIEVED,
         data: {
           datasets: [
-            { title: 'Dataset A', relevanceScore: 10, rawRelevanceScore: 0.1 },
+            {
+              title: 'Dataset A',
+              relevanceScore: 10,
+              rawRelevanceScore: 0.1,
+              publicationId: 'test-publication-id',
+              publicationSlug: 'test-publication-slug',
+              publicationTitle: 'Test publication title',
+              releaseSlug: 'test-release-slug',
+              releaseVersionId: 'test-release-version-id',
+              dataSetFileId: '',
+              description: '',
+              fileId: 'file-id-a',
+              subjectId: '',
+            },
             {
               title: 'Dataset B',
               relevanceScore: 85.5,
               rawRelevanceScore: 0.5,
+              publicationId: 'test-publication-id',
+              publicationSlug: 'test-publication-slug',
+              publicationTitle: 'Test publication title',
+              releaseSlug: 'test-release-slug',
+              releaseVersionId: 'test-release-version-id',
+              dataSetFileId: '',
+              description: '',
+              fileId: 'file-id-b',
+              subjectId: '',
             },
           ],
         },

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.module.scss
@@ -1,0 +1,14 @@
+@use '~govuk-frontend/dist/govuk/base' as *;
+
+.previewNotice {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: govuk-spacing(4);
+  flex-wrap: wrap;
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(6);
+  border: 1px solid govuk-functional-colour('surface-border');
+  background-color: govuk-functional-colour('surface-background');
+  color: govuk-functional-colour('surface-text');
+}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
@@ -20,7 +20,7 @@ interface TableToolSearchFinalResultProps {
 
 const generateQueryFromResult = (dataset: FinalDataset): FullTableQuery => {
   const {
-    timePeriod: { start, end },
+    timePeriod: { start, end } = {},
     filters,
     indicators,
     geographicLevels,
@@ -32,7 +32,7 @@ const generateQueryFromResult = (dataset: FinalDataset): FullTableQuery => {
       locations.map(location => location.id),
     ),
     timePeriod:
-      start.year && end.year
+      start?.year && end?.year
         ? {
             startYear: parseInt(start.year, 10),
             startCode: start.code,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
@@ -24,9 +24,10 @@ const generateQueryFromResult = (dataset: FinalDataset): FullTableQuery => {
     filters,
     indicators,
     geographicLevels,
+    subjectId,
   } = dataset;
   return {
-    subjectId: '2dc0f701-dbe6-44bc-4772-08debbdc36fb', // TODO replace with subjectId when available
+    subjectId,
     locationIds: Object.values(geographicLevels).flatMap(locations =>
       locations.map(location => location.id),
     ),
@@ -75,11 +76,11 @@ const TableToolSearchFinalResult = ({
       <h2 className="govuk-heading-m govuk-!-margin-bottom-2">
         {dataset.title}
       </h2>
-      <Link to={`/data-catalogue/data-set/${dataset.fileId}`}>
+      <Link to={`/data-catalogue/data-set/${dataset.dataSetFileId}`}>
         View this data set <VisuallyHidden> - {dataset.title}</VisuallyHidden>
       </Link>
       <h3 className="govuk-heading-s govuk-!-margin-top-4">Relevance</h3>
-      <p className="govuk-body">{dataset.aiSummary}</p>
+      <p className="govuk-body">{dataset.relevanceReason}</p>
 
       <LoadingSpinner loading={isLoading} className="govuk-!-margin-top-4">
         {isError && <ErrorMessage>Error loading table preview.</ErrorMessage>}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
@@ -1,20 +1,24 @@
+import ErrorMessage from '@common/components/ErrorMessage';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import generateTableTitle from '@common/modules/table-tool/utils/generateTableTitle';
 import tableBuilderQueries from '@common/queries/tableBuilderQueries';
+import { ReleaseVersionSummary } from '@common/services/publicationService';
 import Link from '@frontend/components/Link';
+import styles from '@frontend/modules/table-tool/components/TableToolSearchFinalResult.module.scss';
+import { encodeFullTableQueryToParams } from '@frontend/modules/table-tool/utils/fullTableQueryTranscode';
 import { FinalDataset } from '@frontend/services/tableToolSearchService';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 interface TableToolSearchFinalResultProps {
   dataset: FinalDataset;
-  releaseVersionId: string;
+  releaseVersionSummary: ReleaseVersionSummary;
 }
 
 const TableToolSearchFinalResult = ({
   dataset,
-  releaseVersionId,
+  releaseVersionSummary,
 }: TableToolSearchFinalResultProps) => {
   // Use test data for now, implement when backend provides required data
   const fullTableQuery =
@@ -41,36 +45,31 @@ const TableToolSearchFinalResult = ({
           ],
         }
       : {
-          subjectId: '10308fbb-da53-4eae-20d2-08dec542d092',
-          locationIds: [
-            'dd13fe4c-d79d-4412-778c-08dec542d100',
-            '3bbe6385-e5fc-4867-77d7-08dec542d100',
-            'bd0133ed-6e3a-4f15-77ce-08dec542d100',
-            '01c13f50-725d-4e33-77ca-08dec542d100',
-          ],
+          subjectId: '2dc0f701-dbe6-44bc-4772-08debbdc36fb',
+          locationIds: ['376f9a26-dc39-4db3-bb19-0549e59d322a'],
           timePeriod: {
-            startYear: 2014,
+            startYear: 2024,
             startCode: 'AY',
-            endYear: 2016,
+            endYear: 2024,
             endCode: 'AY',
           },
           filters: [
-            '04739429-a265-4f28-80a5-4a6fc96bc29e',
-            'f6968c07-3256-41e9-a420-c6a35d78eaa9',
-            'e5936411-6c33-46e4-b247-5d0a8059835f',
-            '24b99a48-5448-4aba-a7c4-a1408cbbc1af',
+            '9d5df94e-67b1-4535-a753-4fc7ba0e589b',
+            '373dad8a-a916-464e-8824-c2c68691a4b3',
+            '24784681-ee31-4cf9-a38e-096d679747b4',
+            '82a5fc83-99f5-494e-b7be-97559cfa2c1c',
           ],
+          filterHierarchiesOptions: {},
           indicators: [
-            '6543f18b-c9fd-4866-776e-08dec542d100',
-            'dfbc7a76-1a0a-4649-7775-08dec542d100',
-            '32a616ef-6ade-4514-7781-08dec542d100',
-            'f2bab6fb-38c5-47f2-776d-08dec542d100',
-            'd5034dd2-8b52-4a84-777d-08dec542d100',
-            '370436e9-5880-444d-777f-08dec542d100',
+            '1a01f5af-049b-4877-2fc6-08debbdc383d',
+            '1ca177aa-4fca-4493-2fc3-08debbdc383d',
           ],
         };
   const { data, isError, isLoading } = useQuery({
-    ...tableBuilderQueries.getFullTable(fullTableQuery, releaseVersionId),
+    ...tableBuilderQueries.getFullTable(
+      fullTableQuery,
+      releaseVersionSummary.id,
+    ),
     refetchOnWindowFocus: false,
     staleTime: Infinity,
   });
@@ -91,23 +90,41 @@ const TableToolSearchFinalResult = ({
       <h2 className="govuk-heading-m govuk-!-margin-bottom-2">
         {dataset.title}
       </h2>
-      <Link to={`/data-catalogue/${dataset.fileId}`}>View this data set</Link>
+      <Link to={`/data-catalogue/data-set/${dataset.fileId}`}>
+        View this data set
+      </Link>
       <h3 className="govuk-heading-s govuk-!-margin-top-4">Relevance</h3>
       <p className="govuk-body">{dataset.aiSummary}</p>
 
       <LoadingSpinner loading={isLoading} className="govuk-!-margin-top-4">
-        {isError && <p>Error loading table.</p>}
+        {isError && <ErrorMessage>Error loading table preview.</ErrorMessage>}
         {table && tableHeaders && (
-          <TimePeriodDataTable
-            capMaxHeight
-            captionTitle={generatedCaption}
-            defaultCaptionId={`dataTableCaption-${dataset.fileId}`}
-            defaultFootnotesId={`dataTableFootnotes-${dataset.fileId}`}
-            fullTable={table}
-            query={fullTableQuery}
-            releaseVersionId={releaseVersionId}
-            tableHeadersConfig={tableHeaders}
-          />
+          <>
+            <div className={styles.previewNotice}>
+              <p className="govuk-body govuk-!-margin-bottom-0">
+                Table showing a preview from:
+                <br />
+                {dataset.title}
+              </p>
+              <Link
+                to={`/data-tables/${releaseVersionSummary.publication.slug}/${
+                  releaseVersionSummary.slug
+                }?fromSearch&${encodeFullTableQueryToParams(fullTableQuery)}`}
+              >
+                View and edit this table
+              </Link>
+            </div>
+            <TimePeriodDataTable
+              capMaxHeight
+              captionTitle={generatedCaption}
+              defaultCaptionId={`dataTableCaption-${dataset.fileId}`}
+              defaultFootnotesId={`dataTableFootnotes-${dataset.fileId}`}
+              fullTable={table}
+              query={fullTableQuery}
+              releaseVersionId={releaseVersionSummary.id}
+              tableHeadersConfig={tableHeaders}
+            />
+          </>
         )}
       </LoadingSpinner>
     </li>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolSearchFinalResult.tsx
@@ -1,9 +1,11 @@
 import ErrorMessage from '@common/components/ErrorMessage';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import generateTableTitle from '@common/modules/table-tool/utils/generateTableTitle';
 import tableBuilderQueries from '@common/queries/tableBuilderQueries';
 import { ReleaseVersionSummary } from '@common/services/publicationService';
+import { FullTableQuery } from '@common/services/tableBuilderService';
 import Link from '@frontend/components/Link';
 import styles from '@frontend/modules/table-tool/components/TableToolSearchFinalResult.module.scss';
 import { encodeFullTableQueryToParams } from '@frontend/modules/table-tool/utils/fullTableQueryTranscode';
@@ -16,55 +18,38 @@ interface TableToolSearchFinalResultProps {
   releaseVersionSummary: ReleaseVersionSummary;
 }
 
+const generateQueryFromResult = (dataset: FinalDataset): FullTableQuery => {
+  const {
+    timePeriod: { start, end },
+    filters,
+    indicators,
+    geographicLevels,
+  } = dataset;
+  return {
+    subjectId: '2dc0f701-dbe6-44bc-4772-08debbdc36fb', // TODO replace with subjectId when available
+    locationIds: Object.values(geographicLevels).flatMap(locations =>
+      locations.map(location => location.id),
+    ),
+    timePeriod:
+      start.year && end.year
+        ? {
+            startYear: parseInt(start.year, 10),
+            startCode: start.code,
+            endYear: parseInt(end.year, 10),
+            endCode: end.code,
+          }
+        : undefined,
+    filters: filters.map(filter => filter.id),
+    indicators: indicators.map(indicator => indicator.id),
+  };
+};
+
 const TableToolSearchFinalResult = ({
   dataset,
   releaseVersionSummary,
 }: TableToolSearchFinalResultProps) => {
-  // Use test data for now, implement when backend provides required data
-  const fullTableQuery =
-    dataset.title === 'Test final result'
-      ? {
-          subjectId: '821750f6-939f-4f60-20d4-08dec542d092',
-          locationIds: [
-            'a455a027-e635-4e90-a0b8-08dec542d106',
-            'a2857282-154f-44cb-a0bb-08dec542d106',
-          ],
-          timePeriod: {
-            startYear: 2014,
-            startCode: 'AY',
-            endYear: 2016,
-            endCode: 'AY',
-          },
-          filters: [],
-          filterHierarchiesOptions: {},
-          indicators: [
-            '4f9f7d79-c3a5-459c-a0b5-08dec542d106',
-            '1bd72149-5230-40ab-a0ac-08dec542d106',
-            '0e74dcb9-9c90-4747-a0a4-08dec542d106',
-            '922db259-ddcc-4a64-a09d-08dec542d106',
-          ],
-        }
-      : {
-          subjectId: '2dc0f701-dbe6-44bc-4772-08debbdc36fb',
-          locationIds: ['376f9a26-dc39-4db3-bb19-0549e59d322a'],
-          timePeriod: {
-            startYear: 2024,
-            startCode: 'AY',
-            endYear: 2024,
-            endCode: 'AY',
-          },
-          filters: [
-            '9d5df94e-67b1-4535-a753-4fc7ba0e589b',
-            '373dad8a-a916-464e-8824-c2c68691a4b3',
-            '24784681-ee31-4cf9-a38e-096d679747b4',
-            '82a5fc83-99f5-494e-b7be-97559cfa2c1c',
-          ],
-          filterHierarchiesOptions: {},
-          indicators: [
-            '1a01f5af-049b-4877-2fc6-08debbdc383d',
-            '1ca177aa-4fca-4493-2fc3-08debbdc383d',
-          ],
-        };
+  const fullTableQuery = generateQueryFromResult(dataset);
+
   const { data, isError, isLoading } = useQuery({
     ...tableBuilderQueries.getFullTable(
       fullTableQuery,
@@ -91,7 +76,7 @@ const TableToolSearchFinalResult = ({
         {dataset.title}
       </h2>
       <Link to={`/data-catalogue/data-set/${dataset.fileId}`}>
-        View this data set
+        View this data set <VisuallyHidden> - {dataset.title}</VisuallyHidden>
       </Link>
       <h3 className="govuk-heading-s govuk-!-margin-top-4">Relevance</h3>
       <p className="govuk-body">{dataset.aiSummary}</p>
@@ -111,7 +96,8 @@ const TableToolSearchFinalResult = ({
                   releaseVersionSummary.slug
                 }?fromSearch&${encodeFullTableQueryToParams(fullTableQuery)}`}
               >
-                View and edit this table
+                View and edit this table{' '}
+                <VisuallyHidden> - {dataset.title}</VisuallyHidden>
               </Link>
             </div>
             <TimePeriodDataTable

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
@@ -26,7 +26,7 @@ describe('TableToolSearchFinalResult', () => {
 
     expect(
       screen.getByRole('link', { name: /View this data set/ }),
-    ).toHaveAttribute('href', '/data-catalogue/data-set/test-file-id');
+    ).toHaveAttribute('href', '/data-catalogue/data-set/test-data-set-file-id');
 
     expect(
       screen.getByRole('heading', { name: 'Relevance' }),
@@ -56,7 +56,7 @@ describe('TableToolSearchFinalResult', () => {
       screen.getByRole('link', { name: /View and edit this table/ }),
     ).toHaveAttribute(
       'href',
-      '/data-tables/publication-slug/release-slug?fromSearch&sub=2dc0f701dbe644bc477208debbdc36fb&tp=2014%7CAY%7C2016%7CAY',
+      '/data-tables/publication-slug/release-slug?fromSearch&sub=testsubjectid&tp=2014%7CAY%7C2016%7CAY',
     );
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
@@ -25,7 +25,7 @@ describe('TableToolSearchFinalResult', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', { name: 'View this data set' }),
+      screen.getByRole('link', { name: /View this data set/ }),
     ).toHaveAttribute('href', '/data-catalogue/data-set/test-file-id');
 
     expect(
@@ -51,6 +51,13 @@ describe('TableToolSearchFinalResult', () => {
     expect(screen.getByTestId('dataTableCaption')).toHaveTextContent(
       /Number of applications received/,
     );
+
+    expect(
+      screen.getByRole('link', { name: /View and edit this table/ }),
+    ).toHaveAttribute(
+      'href',
+      '/data-tables/publication-slug/release-slug?fromSearch&sub=2dc0f701dbe644bc477208debbdc36fb&tp=2014%7CAY%7C2016%7CAY',
+    );
   });
 
   test('renders error message when table query fails', async () => {
@@ -63,7 +70,9 @@ describe('TableToolSearchFinalResult', () => {
       />,
     );
 
-    expect(await screen.findByText('Error loading table.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Error loading table preview.'),
+    ).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolSearchFinalResult.test.tsx
@@ -1,8 +1,8 @@
 import render from '@common-test/render';
 import _tableBuilderService from '@common/services/tableBuilderService';
+import { testReleaseVersionSummary } from '@frontend/modules/find-statistics/__tests__/__data__/testReleaseData';
 import TableToolSearchFinalResult from '@frontend/modules/table-tool/components/TableToolSearchFinalResult';
 import { screen } from '@testing-library/react';
-import React from 'react';
 import { testFinalResult, testTableDataResponse } from './__data__/tableData';
 
 jest.mock('@common/services/tableBuilderService');
@@ -15,7 +15,7 @@ describe('TableToolSearchFinalResult', () => {
 
     render(
       <TableToolSearchFinalResult
-        releaseVersionId="test-release-version-id"
+        releaseVersionSummary={testReleaseVersionSummary}
         dataset={testFinalResult}
       />,
     );
@@ -26,7 +26,7 @@ describe('TableToolSearchFinalResult', () => {
 
     expect(
       screen.getByRole('link', { name: 'View this data set' }),
-    ).toHaveAttribute('href', '/data-catalogue/test-file-id');
+    ).toHaveAttribute('href', '/data-catalogue/data-set/test-file-id');
 
     expect(
       screen.getByRole('heading', { name: 'Relevance' }),
@@ -42,7 +42,7 @@ describe('TableToolSearchFinalResult', () => {
 
     render(
       <TableToolSearchFinalResult
-        releaseVersionId="test-release-version-id"
+        releaseVersionSummary={testReleaseVersionSummary}
         dataset={testFinalResult}
       />,
     );
@@ -58,7 +58,7 @@ describe('TableToolSearchFinalResult', () => {
 
     render(
       <TableToolSearchFinalResult
-        releaseVersionId="test-release-version-id"
+        releaseVersionSummary={testReleaseVersionSummary}
         dataset={testFinalResult}
       />,
     );

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -269,8 +269,16 @@ export const testPublicationMethodologyList = {
 
 export const testFinalResult: FinalDataset = {
   fileId: 'test-file-id',
+  subjectId: 'test-subject-id',
+  dataSetFileId: 'test-data-set-file-id',
+  description: 'Test dataset description',
+  publicationId: 'test-publication-id',
+  publicationSlug: 'test-publication-slug',
+  publicationTitle: 'Test publication title',
+  relevanceReason: 'Test AI relevance summary explanation.',
+  releaseSlug: 'test-release-slug',
+  releaseVersionId: 'test-release-version-id',
   title: 'Test dataset title',
-  aiSummary: 'Test AI relevance summary explanation.',
   filters: [],
   geographicLevels: {},
   timePeriod: {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/utils/__tests__/fullTableQueryTranscode.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/utils/__tests__/fullTableQueryTranscode.test.ts
@@ -1,0 +1,110 @@
+import {
+  encodeFullTableQueryToParams,
+  decodeParamsToFullTableQuery,
+} from '../fullTableQueryTranscode';
+
+const testSubjectId = '12345678-abcd-ef01-2345-6789abcdef01';
+const testSubjectIdEncoded = '12345678abcdef0123456789abcdef01';
+
+const testFilter1 = 'abcdef01-2345-6789-abcd-ef0123456789';
+const testFilter1Encoded = 'abcdef0123456789abcdef0123456789';
+const testFilter2 = '23456789-abcd-ef01-2345-6789abcdef01';
+const testFilter2Encoded = '23456789abcdef0123456789abcdef01';
+
+const testIndicator1 = 'ef012345-6789-abcd-ef01-23456789abcd';
+const testIndicator1Encoded = 'ef0123456789abcdef0123456789abcd';
+const testIndicator2 = '6789abcd-ef01-2345-6789-abcdef012345';
+const testIndicator2Encoded = '6789abcdef0123456789abcdef012345';
+
+const testLocationId1 = '3456789a-bcde-f012-3456-789abcdef012';
+const testLocationId1Encoded = '3456789abcdef0123456789abcdef012';
+const testLocationId2 = 'bcdef012-3456-789a-bcde-f0123456789a';
+const testLocationId2Encoded = 'bcdef0123456789abcdef0123456789a';
+
+const testTimePeriod = {
+  startYear: 2020,
+  startCode: 'AY',
+  endYear: 2021,
+  endCode: 'AY',
+};
+const testTimePeriodEncoded = '2020|AY|2021|AY';
+
+describe('fullTableQueryTranscode', () => {
+  describe('encodeFullTableQueryToParams', () => {
+    test('encodes a minimal query containing only subjectId', () => {
+      const query = {
+        subjectId: testSubjectId,
+        filters: [],
+        indicators: [],
+        locationIds: [],
+      };
+      const result = encodeFullTableQueryToParams(query);
+      expect(result).toBe(`sub=${testSubjectIdEncoded}`);
+    });
+
+    test('encodes a complete query containing all parameters', () => {
+      const query = {
+        subjectId: testSubjectId,
+        timePeriod: testTimePeriod,
+        filters: [testFilter1, testFilter2],
+        indicators: [testIndicator1, testIndicator2],
+        locationIds: [testLocationId1, testLocationId2],
+      };
+      const result = encodeFullTableQueryToParams(query);
+      const expectedParams = new URLSearchParams({
+        sub: testSubjectIdEncoded,
+        tp: testTimePeriodEncoded,
+        f: `${testFilter1Encoded},${testFilter2Encoded}`,
+        ind: `${testIndicator1Encoded},${testIndicator2Encoded}`,
+        loc: `${testLocationId1Encoded},${testLocationId2Encoded}`,
+      }).toString();
+      expect(result).toBe(expectedParams);
+    });
+  });
+
+  describe('decodeParamsToFullTableQuery', () => {
+    test('decodes minimal parameters containing only sub', () => {
+      const params = new URLSearchParams({
+        sub: testSubjectIdEncoded,
+      });
+      const result = decodeParamsToFullTableQuery(params);
+      expect(result).toEqual({
+        subjectId: testSubjectId,
+        timePeriod: undefined,
+        filters: [],
+        indicators: [],
+        locationIds: [],
+      });
+    });
+
+    test('decodes complete parameters', () => {
+      const params = new URLSearchParams({
+        sub: testSubjectIdEncoded,
+        tp: testTimePeriodEncoded,
+        f: `${testFilter1Encoded},${testFilter2Encoded}`,
+        ind: `${testIndicator1Encoded},${testIndicator2Encoded}`,
+        loc: `${testLocationId1Encoded},${testLocationId2Encoded}`,
+      });
+      const result = decodeParamsToFullTableQuery(params);
+      expect(result).toEqual({
+        subjectId: testSubjectId,
+        timePeriod: testTimePeriod,
+        filters: [testFilter1, testFilter2],
+        indicators: [testIndicator1, testIndicator2],
+        locationIds: [testLocationId1, testLocationId2],
+      });
+    });
+
+    test('handles missing parameters gracefully by providing empty arrays for list fields and undefined for timePeriod', () => {
+      const params = new URLSearchParams();
+      const result = decodeParamsToFullTableQuery(params);
+      expect(result).toEqual({
+        subjectId: '',
+        timePeriod: undefined,
+        filters: [],
+        indicators: [],
+        locationIds: [],
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/utils/createMockSseStream.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/utils/createMockSseStream.ts
@@ -48,14 +48,34 @@ export default function createMockSseStream({
               data: {
                 datasets: [
                   {
+                    dataSetFileId: '52d98825-1e90-4752-acb9-e751d03d0d1d',
+                    fileId: '9a0aa599-fdfd-40ad-b73a-08dec0963904',
+                    publicationId: '96f418e7-3ddb-4a8c-60dc-08deb7f1c424',
+                    publicationSlug: 'pupil-attendance-in-schools-in-england',
+                    publicationTitle: 'Pupil attendance in schools in England',
+                    releaseSlug: '2026-week-20',
+                    releaseVersionId: 'db7aad55-30b2-4d7e-bb45-08dec09602df',
+                    rawRelevanceScore: 0.024358974769711494,
+                    relevanceScore: 74.3,
+                    subjectId: '6806855d-79e6-4abd-ed1f-08dec09638f8',
                     title: 'Persistent absence in schools',
-                    relevanceScore: 50.8,
-                    rawRelevanceScore: 0.01666666753590107,
+                    description:
+                      'Persistent absence measures, year to date only, updated each publication week. Figures are provided at the local authority, regional and national level for state-funded primary, secondary and special schools.',
                   },
                   {
+                    dataSetFileId: '9e2601f1-2ff5-43a2-b892-502a7dec9ecf',
+                    fileId: '688db31c-66bd-4dbd-b73c-08dec0963904',
+                    publicationId: '96f418e7-3ddb-4a8c-60dc-08deb7f1c424',
+                    publicationSlug: 'pupil-attendance-in-schools-in-england',
+                    publicationTitle: 'Pupil attendance in schools in England',
+                    releaseSlug: '2026-week-20',
+                    releaseVersionId: 'db7aad55-30b2-4d7e-bb45-08dec09602df',
+                    rawRelevanceScore: 0.024462364614009857,
+                    relevanceScore: 74.6,
+                    subjectId: '10ea4c1e-2124-4da4-ed21-08dec09638f8',
                     title: 'Reasons for absence and attendance',
-                    relevanceScore: 73.1,
-                    rawRelevanceScore: 0.02395833283662796,
+                    description:
+                      'Daily and weekly local authority, regional and national reasons for pupil attendance and absence. Figures are provided for state-funded primary, secondary and special schools.',
                   },
                 ],
               },
@@ -102,70 +122,45 @@ export default function createMockSseStream({
               data: {
                 datasets: [
                   {
+                    dataSetFileId: '9e2601f1-2ff5-43a2-b892-502a7dec9ecf',
                     fileId: '688db31c-66bd-4dbd-b73c-08dec0963904',
-                    filters: [
-                      {
-                        id: '6fe1e32e-ec17-478b-904d-11c121f6817b',
-                        label: 'State-funded AP school',
-                      },
-                      {
-                        id: '1736fa44-d7af-421c-91a1-69c3b3aed8d9',
-                        label: 'State-funded secondary',
-                      },
-                    ],
-                    indicators: [
-                      {
-                        id: 'ad93c0c6-6485-4817-2fc5-08debbdc383d',
-                        label: 'Headcount',
-                      },
-                    ],
-                    geographicLevels: {
-                      'Local authority': [
-                        {
-                          id: 'bbe3cafc-2c62-42d6-4919-08d93bbc8641',
-                          label: 'Sheffield',
-                          value: 'E08000019',
-                        },
-                      ],
-                    },
-                    aiSummary:
-                      'This data is relevant because This dataset provides local authority level data on reasons for pupil absence, including holidays, with weekly time frames that cover the last 4 weeks, making it directly relevant to the query for Sheffield.\n It contains information about Daily and weekly local authority, regional and national reasons for pupil attendance and absence. Figures are provided for state-funded primary, secondary and special schools.',
-                    timePeriod: {
-                      start: {
-                        code: 'W17',
-                        year: '2026',
-                      },
-                      end: {
-                        code: 'W20',
-                        year: '2026',
-                      },
-                    },
+                    publicationId: '96f418e7-3ddb-4a8c-60dc-08deb7f1c424',
+                    publicationSlug: 'pupil-attendance-in-schools-in-england',
+                    publicationTitle: 'Pupil attendance in schools in England',
+                    releaseSlug: '2026-week-20',
+                    releaseVersionId: 'db7aad55-30b2-4d7e-bb45-08dec09602df',
+                    subjectId: '10ea4c1e-2124-4da4-ed21-08dec09638f8',
                     title: 'Reasons for absence and attendance',
-                  },
-                  {
-                    fileId: '10308fbb-da53-4eae-20d2-08dec542d092',
+                    description:
+                      'Daily and weekly local authority, regional and national reasons for pupil attendance and absence. Figures are provided for state-funded primary, secondary and special schools.',
                     filters: [
                       {
-                        id: 'filter-id',
-                        label: 'filter label',
+                        id: '45eff781-6dbe-4c06-8c90-795cc17bbf38',
+                        label: 'Week',
+                      },
+                      {
+                        id: '6b3e255f-3f19-4609-8167-246beb16706d',
+                        label: 'Legacy family holiday (f)',
+                      },
+                      {
+                        id: 'b36a0689-f2c6-4464-95be-d82921199721',
+                        label: 'Unauthorised holiday (g)',
+                      },
+                      {
+                        id: '62e7150f-29ae-44d7-be9b-85aca0636094',
+                        label: 'Authorised holiday (h)',
                       },
                     ],
                     indicators: [
                       {
-                        id: 'indicator-id',
-                        label: 'indicator label',
+                        id: 'ccb4341c-3fbe-47ec-087b-08dec0963a29',
+                        label: 'Percent of sessions',
+                      },
+                      {
+                        id: 'eb2ea071-0f13-438c-0879-08dec0963a29',
+                        label: 'Reference date',
                       },
                     ],
-                    geographicLevels: {
-                      'Local authority': [
-                        {
-                          id: 'bbe3cafc-2c62-42d6-4919-08d93bbc8641',
-                          label: 'Sheffield',
-                          value: 'E08000019',
-                        },
-                      ],
-                    },
-                    aiSummary: 'Mock AI summary',
                     timePeriod: {
                       start: {
                         code: 'W17',
@@ -176,7 +171,19 @@ export default function createMockSseStream({
                         year: '2026',
                       },
                     },
-                    title: 'Test final result',
+                    geographicLevels: {
+                      'Local authority': [
+                        {
+                          id: 'bbe3cafc-2c62-42d6-4919-08d93bbc8641',
+                          label: 'Sheffield',
+                          value: 'E08000019',
+                        },
+                      ],
+                      National: [],
+                      Regional: [],
+                    },
+                    relevanceReason:
+                      'This dataset provides daily and weekly local authority level data on reasons for pupil absence, including holidays, and covers the relevant recent time period including the last 4 weeks.',
                   },
                 ],
                 token_usage: {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/utils/createMockSseStream.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/utils/createMockSseStream.ts
@@ -103,8 +103,22 @@ export default function createMockSseStream({
                 datasets: [
                   {
                     fileId: '688db31c-66bd-4dbd-b73c-08dec0963904',
-                    filters: ['Legacy family holiday (f)'],
-                    indicators: ['Percent of sessions'],
+                    filters: [
+                      {
+                        id: '6fe1e32e-ec17-478b-904d-11c121f6817b',
+                        label: 'State-funded AP school',
+                      },
+                      {
+                        id: '1736fa44-d7af-421c-91a1-69c3b3aed8d9',
+                        label: 'State-funded secondary',
+                      },
+                    ],
+                    indicators: [
+                      {
+                        id: 'ad93c0c6-6485-4817-2fc5-08debbdc383d',
+                        label: 'Headcount',
+                      },
+                    ],
                     geographicLevels: {
                       'Local authority': [
                         {
@@ -130,8 +144,18 @@ export default function createMockSseStream({
                   },
                   {
                     fileId: '10308fbb-da53-4eae-20d2-08dec542d092',
-                    filters: ['lorem'],
-                    indicators: ['lorem'],
+                    filters: [
+                      {
+                        id: 'filter-id',
+                        label: 'filter label',
+                      },
+                    ],
+                    indicators: [
+                      {
+                        id: 'indicator-id',
+                        label: 'indicator label',
+                      },
+                    ],
                     geographicLevels: {
                       'Local authority': [
                         {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/utils/fullTableQueryTranscode.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/utils/fullTableQueryTranscode.ts
@@ -1,0 +1,63 @@
+import {
+  FullTableQuery,
+  TimePeriodQuery,
+} from '@common/services/tableBuilderService';
+
+// Encodes a FullTableQuery into a compact query string
+export function encodeFullTableQueryToParams(query: FullTableQuery): string {
+  const stripDashes = (uuid: string) => uuid.replace(/-/g, '');
+  const params: Record<string, string> = {
+    sub: stripDashes(query.subjectId),
+  };
+
+  if (query.timePeriod) {
+    const { startYear, startCode, endYear, endCode } = query.timePeriod;
+    params.tp = `${startYear}|${startCode}|${endYear}|${endCode}`;
+  }
+  if (query.filters && query.filters.length) {
+    params.f = query.filters.map(stripDashes).join(',');
+  }
+  if (query.indicators && query.indicators.length) {
+    params.ind = query.indicators.map(stripDashes).join(',');
+  }
+  if (query.locationIds && query.locationIds.length) {
+    params.loc = query.locationIds.map(stripDashes).join(',');
+  }
+
+  return new URLSearchParams(params).toString();
+}
+
+// Decodes the URL query parameters back into a FullTableQuery
+export function decodeParamsToFullTableQuery(
+  searchParams: URLSearchParams,
+): FullTableQuery {
+  const restoreDashes = (hex: string) =>
+    hex.replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '$1-$2-$3-$4-$5');
+
+  const subjectId = restoreDashes(searchParams.get('sub') || '');
+  const timePeriodRaw = searchParams.get('tp');
+  let timePeriod: TimePeriodQuery | undefined;
+
+  if (timePeriodRaw) {
+    const [startYear, startCode, endYear, endCode] = timePeriodRaw.split('|');
+    timePeriod = {
+      startYear: parseInt(startYear, 10),
+      startCode,
+      endYear: parseInt(endYear, 10),
+      endCode,
+    };
+  }
+
+  const parseUuids = (paramName: string) => {
+    const value = searchParams.get(paramName);
+    return value ? value.split(',').map(restoreDashes) : [];
+  };
+
+  return {
+    subjectId,
+    timePeriod,
+    filters: parseUuids('f'),
+    indicators: parseUuids('ind'),
+    locationIds: parseUuids('loc'),
+  };
+}

--- a/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
+++ b/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
@@ -67,7 +67,7 @@ export interface FinalDataset extends DatasetResultBase {
   geographicLevels: Dictionary<GeographicLevelItem[]>;
   indicators: FilterIndicatorItem[];
   relevanceReason: string;
-  timePeriod: {
+  timePeriod?: {
     start: {
       code: string;
       year: string;

--- a/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
+++ b/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
@@ -25,10 +25,22 @@ export const PipelineStageLabels: Record<PipelineStageType, string> = {
   [PipelineStage.COMPLETE]: 'Results',
 };
 
-export interface RetrievedDataset {
+interface DatasetResultBase {
+  dataSetFileId: string;
+  description: string;
+  fileId: string;
+  publicationId: string;
+  publicationSlug: string;
+  publicationTitle: string;
+  releaseSlug: string;
+  releaseVersionId: string;
+  subjectId: string;
+  title: string;
+}
+
+export interface RetrievedDataset extends DatasetResultBase {
   rawRelevanceScore: number;
   relevanceScore: number;
-  title: string;
 }
 
 export interface ShortlistedDataset {
@@ -50,12 +62,11 @@ export interface FilterIndicatorItem {
   label: string;
 }
 
-export interface FinalDataset {
-  aiSummary: string;
-  fileId: string;
+export interface FinalDataset extends DatasetResultBase {
   filters: FilterIndicatorItem[];
   geographicLevels: Dictionary<GeographicLevelItem[]>;
   indicators: FilterIndicatorItem[];
+  relevanceReason: string;
   timePeriod: {
     start: {
       code: string;
@@ -66,7 +77,6 @@ export interface FinalDataset {
       year: string;
     };
   };
-  title: string;
 }
 
 export interface StageStarting {

--- a/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
+++ b/src/explore-education-statistics-frontend/src/services/tableToolSearchService.ts
@@ -45,11 +45,17 @@ export interface GeographicLevelItem {
   value: string;
 }
 
+export interface FilterIndicatorItem {
+  id: string;
+  label: string;
+}
+
 export interface FinalDataset {
   aiSummary: string;
   fileId: string;
-  filters: string[];
+  filters: FilterIndicatorItem[];
   geographicLevels: Dictionary<GeographicLevelItem[]>;
+  indicators: FilterIndicatorItem[];
   timePeriod: {
     start: {
       code: string;
@@ -60,7 +66,6 @@ export interface FinalDataset {
       year: string;
     };
   };
-  indicators: string[];
   title: string;
 }
 


### PR DESCRIPTION
This PR adds in the remaining functionality for the final result items of the table tool natural language search. Specifically, it adds:
- a link back to the table tool with 'compressed/encoded' query params, which are detected on the table tool page to fetch the required data to be on step 6 (with a table already visible, and filters etc from earlier steps prepopulated)
  - the query is compressed to be able to store all of the query items in a valid query string. Modern browsers support a very long query string so maybe the compression doesn't need to be so much (e.g. removing UUID dashes) but I thought better to be safe than sorry. If it's a problem we can look to change.
  - you should be able to visit the table tool url with an encoded filter e.g. `http://localhost:3000/data-tables/school-pupils-and-their-characteristics/2024-25?fromSearch&sub=2dc0f701dbe644bc477208debbdc36fb&tp=2024%7CAY%7C2024%7CAY&f=f5c9ed3bd1c24cc6affb08446c762787%2C9d5df94e67b14535a7534fc7ba0e589b%2Ce438213b287f4eb29f46638e3096e002%2C82a5fc8399f5494eb7be97559cfa2c1c%2Cb42d3732addd4aa4b7d0f686744c6173%2C373dad8aa916464e8824c2c68691a4b3&ind=1ca177aa4fca44932fc308debbdc383d%2Cad93c0c6648548172fc508debbdc383d&loc=376f9a26dc394db3bb190549e59d322a` to load a table and query similar to a fast track
- fixes for rendering the table on the results page
- fix for the link to the dataset details within data catalogue

We are now able to generate a query based on the final result data as it contains indicator/location/filter ids. I've removed any hardcoded values from the search pages, so the search will only return results on the publications we have data indexed for (see a separate spreadsheet or ask in the channel). 
Example publication to search on: **school-pupils-and-their-characteristics**.

### Running locally
If you point to the dev environment when running the frontend (change env vars) then you should be able to get back results which work when going back to the table tool.

### Other changes:
- Update the interface for the results to match backend changes.

### Screenshot:
<img width="957" height="1155" alt="Screenshot 2026-07-10 113335" src="https://github.com/user-attachments/assets/205e8a9c-eccd-4f7f-a1aa-01fb9e681278" />
