### PR TITLE
EES-7279 Add Filters to DataSetMapping

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -55,7 +55,7 @@ public abstract class DataReplacementControllerTests
                                                 id: Guid.NewGuid(),
                                                 label: "filter group replacement label",
                                                 target: Guid.NewGuid(),
-                                                filters:
+                                                items:
                                                 [
                                                     new FilterItemReplacementViewModel(
                                                         id: Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Moq;
 using Newtonsoft.Json;
@@ -107,7 +108,7 @@ public abstract class DataReplacementControllerTests
                                         Name = "filter_original_name",
                                         Label = "filter original label",
                                     },
-                                    Type = "ManuallySet",
+                                    Type = MapStatus.ManuallySet,
                                     CandidateKey = replacementFilterId,
                                     FilterGroups = new ReplacementPlanFilterGroupMappingsViewModel
                                     {
@@ -122,7 +123,7 @@ public abstract class DataReplacementControllerTests
                                                         Id = originalFilterGroupId,
                                                         Label = "filter group original label",
                                                     },
-                                                    Type = "AutoSet",
+                                                    Type = MapStatus.AutoSet,
                                                     CandidateKey = replacementFilterGroupId,
                                                     FilterItems = new ReplacementPlanFilterItemMappingsViewModel
                                                     {
@@ -140,7 +141,7 @@ public abstract class DataReplacementControllerTests
                                                                         Id = originalFilterItemId,
                                                                         Label = "filter item original label",
                                                                     },
-                                                                    Type = "AutoSet",
+                                                                    Type = MapStatus.AutoSet,
                                                                     CandidateKey = replacementFilterItemId,
                                                                 }
                                                             },
@@ -205,7 +206,7 @@ public abstract class DataReplacementControllerTests
                                         Name = "original_indicator",
                                         Label = "Original indicator",
                                     },
-                                    Type = "ManuallySet",
+                                    Type = MapStatus.ManuallySet,
                                     CandidateKey = replacementIndicatorId,
                                 }
                             },
@@ -237,7 +238,7 @@ public abstract class DataReplacementControllerTests
                                         Code = "E9000",
                                         Name = "OriginalLocation",
                                     },
-                                    Type = "ManuallySet",
+                                    Type = MapStatus.ManuallySet,
                                     CandidateKey = replacementLocationId,
                                 }
                             },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -31,6 +31,15 @@ public abstract class DataReplacementControllerTests
             var originalLocationId = Guid.NewGuid();
             var replacementLocationId = Guid.NewGuid();
 
+            var originalFilterId = Guid.NewGuid();
+            var replacementFilterId = Guid.NewGuid();
+
+            var originalFilterGroupId = Guid.NewGuid();
+            var replacementFilterGroupId = Guid.NewGuid();
+
+            var originalFilterItemId = Guid.NewGuid();
+            var replacementFilterItemId = Guid.NewGuid();
+
             var dataReplacementPlan = new DataReplacementPlanViewModel
             {
                 DataBlocks =
@@ -41,26 +50,26 @@ public abstract class DataReplacementControllerTests
                         filters: new Dictionary<Guid, FilterReplacementViewModel>
                         {
                             {
-                                Guid.NewGuid(),
+                                originalFilterId,
                                 new FilterReplacementViewModel(
-                                    id: Guid.NewGuid(), // original filterId
-                                    target: Guid.NewGuid(), // replacement filterId
-                                    label: "filter replacement lebel",
-                                    name: "filter replacement name",
+                                    id: originalFilterId,
+                                    target: replacementFilterId,
+                                    label: "filter original label",
+                                    name: "filter_original_name",
                                     groups: new Dictionary<Guid, FilterGroupReplacementViewModel>
                                     {
                                         {
-                                            Guid.NewGuid(),
+                                            originalFilterGroupId,
                                             new FilterGroupReplacementViewModel(
-                                                id: Guid.NewGuid(),
-                                                label: "filter group replacement label",
-                                                target: Guid.NewGuid(),
+                                                id: originalFilterGroupId,
+                                                label: "filter group original label",
+                                                target: replacementFilterGroupId,
                                                 items:
                                                 [
                                                     new FilterItemReplacementViewModel(
-                                                        id: Guid.NewGuid(),
-                                                        label: "filter item replacement label",
-                                                        target: Guid.NewGuid()
+                                                        id: originalFilterItemId,
+                                                        label: "filter item original label",
+                                                        target: replacementFilterItemId
                                                     ),
                                                 ]
                                             )
@@ -84,6 +93,104 @@ public abstract class DataReplacementControllerTests
                 ReplacementSubjectId = Guid.NewGuid(),
                 Mapping = new ReplacementPlanMappingViewModel
                 {
+                    Filters = new ReplacementPlanFilterMappingsViewModel
+                    {
+                        Mappings = new Dictionary<Guid, ReplacementPlanFilterMappingViewModel>
+                        {
+                            {
+                                originalFilterId,
+                                new ReplacementPlanFilterMappingViewModel
+                                {
+                                    Source = new ReplacementPlanFilterViewModel
+                                    {
+                                        Id = originalFilterId,
+                                        Name = "filter_original_label",
+                                        Label = "filter original label",
+                                    },
+                                    Type = "ManuallySet",
+                                    CandidateKey = replacementFilterId,
+                                    FilterGroups = new ReplacementPlanFilterGroupMappingsViewModel
+                                    {
+                                        Mappings = new Dictionary<Guid, ReplacementPlanFilterGroupMappingViewModel>
+                                        {
+                                            {
+                                                originalFilterGroupId,
+                                                new ReplacementPlanFilterGroupMappingViewModel
+                                                {
+                                                    Source = new ReplacementPlanFilterGroupViewModel
+                                                    {
+                                                        Id = originalFilterGroupId,
+                                                        Label = "filter group original label",
+                                                    },
+                                                    Type = "AutoSet",
+                                                    CandidateKey = replacementFilterGroupId,
+                                                    FilterItems = new ReplacementPlanFilterItemMappingsViewModel
+                                                    {
+                                                        Mappings = new Dictionary<
+                                                            Guid,
+                                                            ReplacementPlanFilterItemMappingViewModel
+                                                        >
+                                                        {
+                                                            {
+                                                                originalFilterItemId,
+                                                                new ReplacementPlanFilterItemMappingViewModel
+                                                                {
+                                                                    Source = new ReplacementPlanFilterItemViewModel
+                                                                    {
+                                                                        Id = originalFilterItemId,
+                                                                        Label = "filter item original label",
+                                                                    },
+                                                                    Type = "AutoSet",
+                                                                    CandidateKey = replacementFilterItemId,
+                                                                }
+                                                            },
+                                                        },
+                                                        Candidates = new Dictionary<
+                                                            Guid,
+                                                            ReplacementPlanFilterItemViewModel
+                                                        >
+                                                        {
+                                                            {
+                                                                replacementFilterItemId,
+                                                                new ReplacementPlanFilterItemViewModel
+                                                                {
+                                                                    Id = replacementFilterItemId,
+                                                                    Label = "filter item replacement label",
+                                                                }
+                                                            },
+                                                        },
+                                                    },
+                                                }
+                                            },
+                                        },
+                                        Candidates = new Dictionary<Guid, ReplacementPlanFilterGroupViewModel>
+                                        {
+                                            {
+                                                replacementFilterGroupId,
+                                                new ReplacementPlanFilterGroupViewModel
+                                                {
+                                                    Id = replacementFilterGroupId,
+                                                    Label = "filter group replacement label",
+                                                }
+                                            },
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                        Candidates = new Dictionary<Guid, ReplacementPlanFilterViewModel>
+                        {
+                            {
+                                replacementFilterId,
+                                new ReplacementPlanFilterViewModel
+                                {
+                                    Id = replacementFilterId,
+                                    Name = "filter_replacement_name",
+                                    Label = "filter replacement label",
+                                }
+                            },
+                        },
+                    },
                     Indicators = new ReplacementPlanIndicatorMappingsViewModel
                     {
                         Mappings = new Dictionary<Guid, ReplacementPlanIndicatorMappingViewModel>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -38,7 +38,7 @@ public abstract class DataReplacementControllerTests
                     new DataBlockReplacementPlanViewModel(
                         id: Guid.NewGuid(),
                         name: "my data block",
-                        originalFilters: new Dictionary<Guid, FilterReplacementViewModel>
+                        filters: new Dictionary<Guid, FilterReplacementViewModel>
                         {
                             {
                                 Guid.NewGuid(),
@@ -54,6 +54,7 @@ public abstract class DataReplacementControllerTests
                                             new FilterGroupReplacementViewModel(
                                                 id: Guid.NewGuid(),
                                                 label: "filter group replacement label",
+                                                target: Guid.NewGuid(),
                                                 filters:
                                                 [
                                                     new FilterItemReplacementViewModel(
@@ -83,7 +84,7 @@ public abstract class DataReplacementControllerTests
                 ReplacementSubjectId = Guid.NewGuid(),
                 Mapping = new ReplacementPlanMappingViewModel
                 {
-                    Indicators = new ReplacementPlanIndicatorsMappingViewModel
+                    Indicators = new ReplacementPlanIndicatorMappingsViewModel
                     {
                         Mappings = new Dictionary<Guid, ReplacementPlanIndicatorMappingViewModel>
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -104,7 +104,7 @@ public abstract class DataReplacementControllerTests
                                     Source = new ReplacementPlanFilterViewModel
                                     {
                                         Id = originalFilterId,
-                                        Name = "filter_original_label",
+                                        Name = "filter_original_name",
                                         Label = "filter original label",
                                     },
                                     Type = "ManuallySet",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -19,6 +19,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Public.Data.DataSetVersionMappingControllerTestsHelpers;
+using FilterMapping = GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMapping;
 
 #pragma warning disable CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well.
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -2659,7 +2659,7 @@ public class ReplacementPlanServiceTests
             Assert.False(footnoteForIndicatorPlan.Valid);
 
             var indicatorMappingPlan = replacementPlan.Mapping.Indicators;
-            Assert.Equivalent(new[] { originalIndicatorA.Id }, indicatorMappingPlan.Mappings.Keys); // @MarkFix add this test elsewhere
+            Assert.Equivalent(new[] { originalIndicatorA.Id }, indicatorMappingPlan.Mappings.Keys);
             var indicatorMapping = Assert.Single(indicatorMappingPlan.Mappings.Values);
             Assert.Equal(
                 new ReplacementPlanIndicatorMappingViewModel
@@ -3341,8 +3341,6 @@ public class ReplacementPlanServiceTests
         var userService = AlwaysTrueUserService().Object;
         return new ReplacementPlanService(
             contentDbContext,
-            statisticsDbContext,
-            new FilterRepository(statisticsDbContext),
             new FootnoteRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -28,6 +28,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
 using static Moq.MockBehavior;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+using FilterMapping = GovUk.Education.ExploreEducationStatistics.Content.Model.FilterMapping;
 using IndicatorMapping = GovUk.Education.ExploreEducationStatistics.Content.Model.IndicatorMapping;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Data.Model.ReleaseVersion;
 
@@ -252,22 +253,25 @@ public class ReplacementPlanServiceTests
 
         var originalFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Original Test filter item" };
 
-        var replacementFilterItem = new FilterItem { Label = "Replacement Test filter item" };
+        var replacementFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Replacement Test filter item" };
 
         var originalFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Original Default group",
             FilterItems = new List<FilterItem> { originalFilterItem },
         };
 
         var replacementFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Replacement Default group",
             FilterItems = new List<FilterItem> { replacementFilterItem },
         };
 
         var originalFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Original Test filter",
             Name = "original_test_filter",
             Subject = originalReleaseSubject.Subject,
@@ -276,6 +280,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Replacement Test filter",
             Name = "replacement_test_filter",
             Subject = replacementReleaseSubject.Subject,
@@ -380,6 +385,61 @@ public class ReplacementPlanServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFileId(originalReleaseFile.FileId)
             .WithReplacementDataFileId(replacementReleaseFile.FileId)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter.Id,
+                        CreateFilterMapping(
+                            original: originalFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem.Id,
+                                                    OriginalLabel = originalFilterItem.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
+            .WithUnmappedReplacementFilters([
+                new UnmappedFilter
+                {
+                    Id = replacementFilter.Id,
+                    ColumnName = replacementFilter.Name,
+                    Label = replacementFilter.Label,
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = replacementFilterGroup.Id,
+                            Label = replacementFilterGroup.Label,
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem
+                                {
+                                    Id = replacementFilterItem.Id,
+                                    Label = replacementFilterItem.Label,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ])
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -731,22 +791,25 @@ public class ReplacementPlanServiceTests
 
         var originalDefaultFilterItem2 = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item 2" };
 
-        var replacementDefaultFilterItem = new FilterItem { Label = "Test filter item" };
+        var replacementDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
 
         var originalDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalDefaultFilterItem, originalDefaultFilterItem2 },
         };
 
         var replacementDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementDefaultFilterItem },
         };
 
         var originalDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -755,6 +818,7 @@ public class ReplacementPlanServiceTests
 
         var replacementDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -770,12 +834,14 @@ public class ReplacementPlanServiceTests
 
         var replacementIndicator = new Indicator
         {
+            Id = Guid.NewGuid(),
             Label = "Indicator - not changing",
             Name = "indicator_not_changing",
         };
 
         var originalIndicatorGroup = new IndicatorGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             Subject = originalReleaseSubject.Subject,
             Indicators = new List<Indicator> { originalIndicator },
@@ -783,6 +849,7 @@ public class ReplacementPlanServiceTests
 
         var replacementIndicatorGroup = new IndicatorGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             Subject = replacementReleaseSubject.Subject,
             Indicators = new List<Indicator> { replacementIndicator },
@@ -823,6 +890,73 @@ public class ReplacementPlanServiceTests
             ReleaseVersion = releaseVersion,
         };
 
+        var mapping = _fixture
+            .DefaultDataSetMapping()
+            .WithOriginalDataFile(originalFile)
+            .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalDefaultFilter.Id,
+                        CreateFilterMapping(
+                            original: originalDefaultFilter,
+                            replacement: replacementDefaultFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalDefaultFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalDefaultFilterGroup,
+                                        replacement: replacementDefaultFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalDefaultFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalDefaultFilterItem.Id,
+                                                    OriginalLabel = originalDefaultFilterItem.Label,
+                                                    ReplacementId = replacementDefaultFilterItem.Id,
+                                                    ReplacementLabel = replacementDefaultFilterItem.Label,
+                                                    Status = MapStatus.AutoSet,
+                                                }
+                                            },
+                                            {
+                                                originalDefaultFilterItem2.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalDefaultFilterItem2.Id,
+                                                    OriginalLabel = originalDefaultFilterItem2.Label,
+                                                    Status = MapStatus.Unset,
+                                                }
+                                            },
+                                        },
+                                        status: MapStatus.AutoSet
+                                    )
+                                },
+                            },
+                            status: MapStatus.AutoSet
+                        )
+                    },
+                }
+            )
+            .WithIndicatorMappings(
+                new Dictionary<Guid, IndicatorMapping>
+                {
+                    {
+                        originalIndicator.Id,
+                        CreateIndicatorMapping(
+                            original: originalIndicator,
+                            originalGroup: originalIndicatorGroup,
+                            replacement: replacementIndicator,
+                            replacementGroup: replacementIndicatorGroup,
+                            status: MapStatus.AutoSet
+                        )
+                    },
+                }
+            );
+
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
         timePeriodService
             .Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
@@ -843,12 +977,7 @@ public class ReplacementPlanServiceTests
             contentDbContext.ReleaseVersions.AddRange(releaseVersion);
             contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
             contentDbContext.DataBlocks.AddRange(dataBlock);
-            contentDbContext.DataSetMappings.Add(
-                _fixture
-                    .DefaultDataSetMapping()
-                    .WithOriginalDataFile(originalFile)
-                    .WithReplacementDataFile(replacementFile)
-            );
+            contentDbContext.DataSetMappings.Add(mapping);
             await contentDbContext.SaveChangesAsync();
         }
 
@@ -911,6 +1040,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFile = new File
         {
+            Id = Guid.NewGuid(),
             Type = FileType.Data,
             SubjectId = replacementReleaseSubject.SubjectId,
             Replacing = originalFile,
@@ -918,28 +1048,45 @@ public class ReplacementPlanServiceTests
 
         originalFile.ReplacedBy = replacementFile;
 
-        var originalReleaseFile = new ReleaseFile { ReleaseVersion = releaseVersion, File = originalFile };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = originalFile,
+            FileId = originalFile.Id,
+        };
 
-        var replacementReleaseFile = new ReleaseFile { ReleaseVersion = releaseVersion, File = replacementFile };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = replacementFile,
+            FileId = replacementFile.Id,
+        };
 
         var originalDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
 
-        var replacementDefaultFilterItem = new FilterItem { Label = "Test filter item - changing!" };
+        var replacementDefaultFilterItem = new FilterItem
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter item - changing!",
+        };
 
         var originalDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalDefaultFilterItem },
         };
 
         var replacementDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementDefaultFilterItem },
         };
 
         var originalDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -948,6 +1095,7 @@ public class ReplacementPlanServiceTests
 
         var replacementDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -963,12 +1111,14 @@ public class ReplacementPlanServiceTests
 
         var replacementIndicator = new Indicator
         {
+            Id = Guid.NewGuid(),
             Label = "Indicator - not changing",
             Name = "indicator_not_changing",
         };
 
         var originalIndicatorGroup = new IndicatorGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             Subject = originalReleaseSubject.Subject,
             Indicators = new List<Indicator> { originalIndicator },
@@ -976,10 +1126,65 @@ public class ReplacementPlanServiceTests
 
         var replacementIndicatorGroup = new IndicatorGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             Subject = replacementReleaseSubject.Subject,
             Indicators = new List<Indicator> { replacementIndicator },
         };
+
+        var mapping = _fixture
+            .DefaultDataSetMapping()
+            .WithOriginalDataFileId(originalReleaseFile.FileId)
+            .WithReplacementDataFileId(replacementReleaseFile.FileId)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalDefaultFilter.Id,
+                        CreateFilterMapping(
+                            original: originalDefaultFilter,
+                            replacement: replacementDefaultFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalDefaultFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalDefaultFilterGroup,
+                                        replacement: replacementDefaultFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalDefaultFilterItem.Id,
+                                                new FilterItemMapping { OriginalId = originalDefaultFilterItem.Id }
+                                            },
+                                        },
+                                        unmappedReplacementFilterItems:
+                                        [
+                                            new UnmappedFilterItem { Id = replacementDefaultFilterItem.Id },
+                                        ]
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
+            .WithIndicatorMappings(
+                new Dictionary<Guid, IndicatorMapping>
+                {
+                    {
+                        originalIndicator.Id,
+                        new IndicatorMapping
+                        {
+                            OriginalId = originalIndicator.Id,
+                            OriginalGroupId = originalIndicatorGroup.Id,
+                            ReplacementId = replacementIndicator.Id,
+                            ReplacementGroupId = replacementIndicatorGroup.Id,
+                        }
+                    },
+                }
+            )
+            .Generate();
 
         var location = new Location
         {
@@ -1036,12 +1241,7 @@ public class ReplacementPlanServiceTests
             contentDbContext.ReleaseVersions.AddRange(releaseVersion);
             contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
             contentDbContext.DataBlocks.AddRange(dataBlock);
-            contentDbContext.DataSetMappings.Add(
-                _fixture
-                    .DefaultDataSetMapping()
-                    .WithOriginalDataFileId(originalReleaseFile.FileId)
-                    .WithReplacementDataFileId(replacementReleaseFile.FileId)
-            );
+            contentDbContext.DataSetMappings.Add(mapping);
             await contentDbContext.SaveChangesAsync();
         }
 
@@ -1050,222 +1250,6 @@ public class ReplacementPlanServiceTests
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.Filter.AddRange(originalDefaultFilter, replacementDefaultFilter);
-            statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
-            statisticsDbContext.Location.AddRange(location);
-            statisticsDbContext.Observation.AddRange(observationForLocation);
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var replacementPlanService = BuildReplacementPlanService(
-                contentDbContext,
-                statisticsDbContext,
-                timePeriodService: timePeriodService.Object,
-                releaseFileRepository: releaseFileRepository.Object
-            );
-
-            var result = await replacementPlanService.GetReplacementPlan(
-                releaseVersionId: releaseVersion.Id,
-                originalFileId: originalFile.Id
-            );
-
-            VerifyAllMocks(timePeriodService, releaseFileRepository);
-
-            var replacementPlan = result.AssertRight();
-            Assert.False(replacementPlan.Valid);
-
-            Assert.Single(replacementPlan.DataBlocks);
-            var dataBlockPlan = replacementPlan.DataBlocks.First();
-            Assert.False(dataBlockPlan.Valid);
-        }
-    }
-
-    [Fact]
-    public async Task GetReplacementPlan_NewFiltersIntroduced_ReplacementInvalid()
-    {
-        var releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease()).Generate();
-
-        var statsReleaseVersion = _fixture.DefaultStatsReleaseVersion().WithId(releaseVersion.Id).Generate();
-
-        var (originalReleaseSubject, replacementReleaseSubject) = _fixture
-            .DefaultReleaseSubject()
-            .WithReleaseVersion(statsReleaseVersion)
-            .WithSubjects(_fixture.DefaultSubject().Generate(2))
-            .GenerateTuple2();
-
-        var originalFile = new File
-        {
-            Id = Guid.NewGuid(),
-            Type = FileType.Data,
-            SubjectId = originalReleaseSubject.SubjectId,
-        };
-
-        var replacementFile = new File
-        {
-            Type = FileType.Data,
-            SubjectId = replacementReleaseSubject.SubjectId,
-            Replacing = originalFile,
-        };
-
-        originalFile.ReplacedBy = replacementFile;
-
-        var originalReleaseFile = new ReleaseFile { ReleaseVersion = releaseVersion, File = originalFile };
-
-        var replacementReleaseFile = new ReleaseFile { ReleaseVersion = releaseVersion, File = replacementFile };
-
-        var originalDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
-
-        var replacementDefaultFilterItem = new FilterItem { Label = "Test filter item" };
-
-        var replacementNewlyIntroducedFiltersFilterItem = new FilterItem
-        {
-            Label = "Filter item for newly introduced Filter",
-        };
-
-        var originalDefaultFilterGroup = new FilterGroup
-        {
-            Label = "Default group - not changing",
-            FilterItems = new List<FilterItem> { originalDefaultFilterItem },
-        };
-
-        var replacementDefaultFilterGroup = new FilterGroup
-        {
-            Label = "Default group - not changing",
-            FilterItems = new List<FilterItem> { replacementDefaultFilterItem },
-        };
-
-        var replacementNewlyIntroducedFilterGroup = new FilterGroup
-        {
-            Label = "Newly introduced filter group",
-            FilterItems = new List<FilterItem> { replacementNewlyIntroducedFiltersFilterItem },
-        };
-
-        var originalDefaultFilter = new Filter
-        {
-            Label = "Test filter 1 - not changing",
-            Name = "test_filter_1_not_changing",
-            Subject = originalReleaseSubject.Subject,
-            FilterGroups = new List<FilterGroup> { originalDefaultFilterGroup },
-        };
-
-        var replacementDefaultFilter = new Filter
-        {
-            Label = "Test filter 1 - not changing",
-            Name = "test_filter_1_not_changing",
-            Subject = replacementReleaseSubject.Subject,
-            FilterGroups = new List<FilterGroup> { replacementDefaultFilterGroup },
-        };
-
-        var replacementNewlyIntroducedFilter = new Filter
-        {
-            Label = "Newly introduced filter",
-            Name = "newly_introduced_filter",
-            Subject = replacementReleaseSubject.Subject,
-            FilterGroups = new List<FilterGroup> { replacementNewlyIntroducedFilterGroup },
-        };
-
-        var originalIndicator = new Indicator
-        {
-            Id = Guid.NewGuid(),
-            Label = "Indicator - not changing",
-            Name = "indicator_not_changing",
-        };
-
-        var replacementIndicator = new Indicator
-        {
-            Label = "Indicator - not changing",
-            Name = "indicator_not_changing",
-        };
-
-        var originalIndicatorGroup = new IndicatorGroup
-        {
-            Label = "Default group - not changing",
-            Subject = originalReleaseSubject.Subject,
-            Indicators = new List<Indicator> { originalIndicator },
-        };
-
-        var replacementIndicatorGroup = new IndicatorGroup
-        {
-            Label = "Default group - not changing",
-            Subject = replacementReleaseSubject.Subject,
-            Indicators = new List<Indicator> { replacementIndicator },
-        };
-
-        var location = new Location
-        {
-            Id = Guid.NewGuid(),
-            GeographicLevel = GeographicLevel.Country,
-            Country = _england,
-        };
-        var observationForLocation = new Observation
-        {
-            Id = Guid.NewGuid(),
-            SubjectId = originalReleaseSubject.SubjectId,
-            Location = location,
-        };
-
-        var timePeriod = new TimePeriodQuery
-        {
-            StartYear = 2019,
-            StartCode = CalendarYear,
-            EndYear = 2020,
-            EndCode = CalendarYear,
-        };
-
-        var dataBlock = new DataBlock
-        {
-            Name = "Test DataBlock",
-            Query = new FullTableQuery
-            {
-                SubjectId = originalReleaseSubject.SubjectId,
-                Filters = new[] { originalDefaultFilterItem.Id },
-                Indicators = new[] { originalIndicator.Id },
-                LocationIds = ListOf(location.Id),
-                TimePeriod = timePeriod,
-            },
-            ReleaseVersion = releaseVersion,
-        };
-
-        var timePeriodService = new Mock<ITimePeriodService>(Strict);
-        timePeriodService
-            .Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
-            .ReturnsAsync(
-                new List<(int Year, TimeIdentifier TimeIdentifier)> { (2019, CalendarYear), (2020, CalendarYear) }
-            );
-
-        var releaseFileRepository = new Mock<IReleaseFileRepository>(Strict);
-        releaseFileRepository
-            .Setup(mock => mock.CheckLinkedOriginalAndReplacementReleaseFilesExist(releaseVersion.Id, originalFile.Id))
-            .ReturnsAsync((originalReleaseFile, replacementReleaseFile));
-
-        var contentDbContextId = Guid.NewGuid().ToString();
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-        {
-            contentDbContext.ReleaseVersions.AddRange(releaseVersion);
-            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
-            contentDbContext.DataBlocks.AddRange(dataBlock);
-            contentDbContext.DataSetMappings.Add(
-                _fixture
-                    .DefaultDataSetMapping()
-                    .WithOriginalDataFileId(originalReleaseFile.FileId)
-                    .WithReplacementDataFileId(replacementReleaseFile.FileId)
-            );
-            await contentDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
-            statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
-            statisticsDbContext.Filter.AddRange(
-                originalDefaultFilter,
-                replacementDefaultFilter,
-                replacementNewlyIntroducedFilter
-            );
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
             statisticsDbContext.Location.AddRange(location);
             statisticsDbContext.Observation.AddRange(observationForLocation);
@@ -1515,53 +1499,65 @@ public class ReplacementPlanServiceTests
             Label = "Primary and secondary schools",
         };
 
-        var replacementDefaultFilterItem = new FilterItem { Label = "Test filter item - not changing" };
+        var replacementDefaultFilterItem = new FilterItem
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter item - not changing",
+        };
 
-        var replacementPrimarySchoolsFilterItem = new FilterItem { Label = "Primary schools" };
+        var replacementPrimarySchoolsFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Primary schools" };
 
         var replacementPrimaryAndSecondarySchoolsFilterItem = new FilterItem
         {
+            Id = Guid.NewGuid(),
             Label = "Primary and secondary schools",
         };
 
         var originalDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalDefaultFilterItem },
         };
 
         var originalIndividualSchoolTypeFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Individual",
             FilterItems = new List<FilterItem> { originalPrimarySchoolsFilterItem },
         };
 
         var originalCombinedSchoolTypeFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Combined",
             FilterItems = new List<FilterItem> { originalPrimaryAndSecondarySchoolsFilterItem },
         };
 
         var replacementDefaultFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementDefaultFilterItem },
         };
 
         var replacementIndividualSchoolTypeFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Individual",
             FilterItems = new List<FilterItem> { replacementPrimarySchoolsFilterItem },
         };
 
         var replacementCombinedSchoolTypeFilterGroup = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Combined",
             FilterItems = new List<FilterItem> { replacementPrimaryAndSecondarySchoolsFilterItem },
         };
 
         var originalDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -1570,6 +1566,7 @@ public class ReplacementPlanServiceTests
 
         var originalSchoolTypeFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "School type",
             Name = "school_type",
             Subject = originalReleaseSubject.Subject,
@@ -1582,6 +1579,7 @@ public class ReplacementPlanServiceTests
 
         var replacementDefaultFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1590,6 +1588,7 @@ public class ReplacementPlanServiceTests
 
         var replacementSchoolTypeFilter = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "School type",
             Name = "school_type",
             Subject = replacementReleaseSubject.Subject,
@@ -1720,6 +1719,88 @@ public class ReplacementPlanServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFileId(originalReleaseFile.FileId)
             .WithReplacementDataFileId(replacementReleaseFile.FileId)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalDefaultFilter.Id,
+                        CreateFilterMapping(
+                            original: originalDefaultFilter,
+                            replacement: replacementDefaultFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalDefaultFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalDefaultFilterGroup,
+                                        replacement: replacementDefaultFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalDefaultFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalDefaultFilterItem.Id,
+                                                    OriginalLabel = originalDefaultFilterItem.Label,
+                                                    ReplacementId = replacementDefaultFilterItem.Id,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                    {
+                        originalSchoolTypeFilter.Id,
+                        CreateFilterMapping(
+                            original: originalSchoolTypeFilter,
+                            replacement: replacementSchoolTypeFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalIndividualSchoolTypeFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalIndividualSchoolTypeFilterGroup,
+                                        replacement: originalIndividualSchoolTypeFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalPrimarySchoolsFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalPrimarySchoolsFilterItem.Id,
+                                                    OriginalLabel = originalPrimarySchoolsFilterItem.Label,
+                                                    ReplacementId = replacementPrimarySchoolsFilterItem.Id,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                                {
+                                    originalCombinedSchoolTypeFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalCombinedSchoolTypeFilterGroup,
+                                        replacement: replacementCombinedSchoolTypeFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalPrimaryAndSecondarySchoolsFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalPrimaryAndSecondarySchoolsFilterItem.Id,
+                                                    OriginalLabel = originalPrimaryAndSecondarySchoolsFilterItem.Label,
+                                                    ReplacementId = replacementPrimaryAndSecondarySchoolsFilterItem.Id,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -3350,12 +3431,54 @@ public class ReplacementPlanServiceTests
         );
     }
 
+    private static FilterMapping CreateFilterMapping(
+        Filter original,
+        Filter? replacement = null,
+        Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
+        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterMapping
+        {
+            OriginalId = original.Id,
+            OriginalColumnName = original.Name,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementColumnName = replacement?.Name,
+            ReplacementLabel = replacement?.Label,
+            FilterGroupMappings = filterGroupMappings ?? [],
+            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
+            Status = status,
+        };
+    }
+
+    private static FilterGroupMapping CreateFilterGroupMapping(
+        FilterGroup original,
+        FilterGroup? replacement = null,
+        Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
+        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterGroupMapping
+        {
+            OriginalId = original.Id,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementLabel = replacement?.Label,
+            FilterItemMappings = filterItemMappings ?? [],
+            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
+            Status = status,
+        };
+    }
+
     private static IndicatorMapping CreateIndicatorMapping(
         Indicator original,
         IndicatorGroup originalGroup,
         Indicator? replacement = null,
         IndicatorGroup? replacementGroup = null,
-        MapStatus mapStatus = MapStatus.Unset
+        MapStatus status = MapStatus.Unset
     )
     {
         return new IndicatorMapping
@@ -3370,7 +3493,7 @@ public class ReplacementPlanServiceTests
             ReplacementLabel = replacement?.Label,
             ReplacementGroupId = replacementGroup?.Id,
             ReplacementGroupLabel = replacementGroup?.Label,
-            Status = mapStatus,
+            Status = status,
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -1282,6 +1282,453 @@ public class ReplacementPlanServiceTests
         }
     }
 
+    [Fact]
+    public async Task GetReplacementPlan_AdditionalFilterWithDataBlock_ReplacementInvalid()
+    {
+        var releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease()).Generate();
+        var statsReleaseVersion = _fixture.DefaultStatsReleaseVersion().WithId(releaseVersion.Id).Generate();
+
+        var (originalReleaseSubject, replacementReleaseSubject) = _fixture
+            .DefaultReleaseSubject()
+            .WithReleaseVersion(statsReleaseVersion)
+            .WithSubjects(_fixture.DefaultSubject().Generate(2))
+            .GenerateTuple2();
+
+        var originalFile = new File
+        {
+            Id = Guid.NewGuid(),
+            Type = FileType.Data,
+            SubjectId = originalReleaseSubject.SubjectId,
+        };
+
+        var replacementFile = new File
+        {
+            Id = Guid.NewGuid(),
+            Type = FileType.Data,
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Replacing = originalFile,
+        };
+
+        originalFile.ReplacedBy = replacementFile;
+
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = originalFile,
+            FileId = originalFile.Id,
+        };
+
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = replacementFile,
+            FileId = replacementFile.Id,
+        };
+
+        var originalDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
+        var originalDefaultFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Default group - not changing",
+            FilterItems = [originalDefaultFilterItem],
+        };
+        var originalDefaultFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter 1 - not changing",
+            Name = "test_filter_1_not_changing",
+            Subject = originalReleaseSubject.Subject,
+            FilterGroups = [originalDefaultFilterGroup],
+        };
+
+        var replacementDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
+        var replacementDefaultFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Default group - not changing",
+            FilterItems = [replacementDefaultFilterItem],
+        };
+        var replacementDefaultFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter 1 - not changing",
+            Name = "test_filter_1_not_changing",
+            Subject = replacementReleaseSubject.Subject,
+            FilterGroups = [replacementDefaultFilterGroup],
+        };
+
+        var replacementNewlyIntroducedFiltersFilterItem = new FilterItem
+        {
+            Id = Guid.NewGuid(),
+            Label = "Filter item for newly introduced Filter",
+        };
+        var replacementNewlyIntroducedFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Newly introduced filter group",
+            FilterItems = [replacementNewlyIntroducedFiltersFilterItem],
+        };
+        var replacementNewlyIntroducedFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Newly introduced filter",
+            Name = "newly_introduced_filter",
+            Subject = replacementReleaseSubject.Subject,
+            FilterGroups = [replacementNewlyIntroducedFilterGroup],
+        };
+
+        var timePeriod = new TimePeriodQuery
+        {
+            StartYear = 2019,
+            StartCode = CalendarYear,
+            EndYear = 2020,
+            EndCode = CalendarYear,
+        };
+        var dataBlock = new DataBlock
+        {
+            Name = "Test DataBlock",
+            Query = new FullTableQuery
+            {
+                SubjectId = originalReleaseSubject.SubjectId,
+                Filters = [originalDefaultFilterItem.Id],
+                Indicators = [],
+                LocationIds = [],
+                TimePeriod = timePeriod,
+            },
+            ReleaseVersion = releaseVersion,
+        };
+
+        var mapping = _fixture
+            .DefaultDataSetMapping()
+            .WithOriginalDataFileId(originalReleaseFile.FileId)
+            .WithReplacementDataFileId(replacementReleaseFile.FileId)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalDefaultFilter.Id,
+                        CreateFilterMapping(
+                            original: originalDefaultFilter,
+                            replacement: replacementDefaultFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalDefaultFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalDefaultFilterGroup,
+                                        replacement: replacementDefaultFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalDefaultFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalDefaultFilterItem.Id,
+                                                    OriginalLabel = originalDefaultFilterItem.Label,
+                                                    ReplacementId = replacementDefaultFilterItem.Id,
+                                                    ReplacementLabel = replacementDefaultFilterItem.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
+            .WithUnmappedReplacementFilters([
+                new UnmappedFilter
+                {
+                    Id = replacementNewlyIntroducedFilter.Id,
+                    ColumnName = replacementNewlyIntroducedFilter.Name,
+                    Label = replacementNewlyIntroducedFilter.Label,
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = replacementNewlyIntroducedFilterGroup.Id,
+                            Label = replacementNewlyIntroducedFilterGroup.Label,
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem
+                                {
+                                    Id = replacementNewlyIntroducedFiltersFilterItem.Id,
+                                    Label = replacementNewlyIntroducedFiltersFilterItem.Label,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+        var timePeriodService = new Mock<ITimePeriodService>(Strict);
+        timePeriodService
+            .Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
+            .ReturnsAsync(
+                new List<(int Year, TimeIdentifier TimeIdentifier)> { (2019, CalendarYear), (2020, CalendarYear) }
+            );
+        var releaseFileRepository = new Mock<IReleaseFileRepository>(Strict);
+        releaseFileRepository
+            .Setup(mock => mock.CheckLinkedOriginalAndReplacementReleaseFilesExist(releaseVersion.Id, originalFile.Id))
+            .ReturnsAsync((originalReleaseFile, replacementReleaseFile));
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.AddRange(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataBlocks.AddRange(dataBlock);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
+            statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
+            statisticsDbContext.Filter.AddRange(
+                originalDefaultFilter,
+                replacementDefaultFilter,
+                replacementNewlyIntroducedFilter
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var replacementPlanService = BuildReplacementPlanService(
+                contentDbContext,
+                statisticsDbContext,
+                timePeriodService: timePeriodService.Object,
+                releaseFileRepository: releaseFileRepository.Object
+            );
+            var result = await replacementPlanService.GetReplacementPlan(
+                releaseVersionId: releaseVersion.Id,
+                originalFileId: originalFile.Id
+            );
+            VerifyAllMocks(timePeriodService, releaseFileRepository);
+            var replacementPlan = result.AssertRight();
+            Assert.False(replacementPlan.Valid);
+            Assert.True(replacementPlan.HasDataBlockAndReplacementHasAdditionalFilter);
+            Assert.Single(replacementPlan.DataBlocks);
+            var dataBlockPlan = replacementPlan.DataBlocks.First();
+            Assert.True(dataBlockPlan.Valid);
+        }
+    }
+
+    [Fact]
+    public async Task GetReplacementPlan_AdditionalFilterButNoDataBlocks_Success()
+    {
+        var releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease()).Generate();
+        var statsReleaseVersion = _fixture.DefaultStatsReleaseVersion().WithId(releaseVersion.Id).Generate();
+
+        var (originalReleaseSubject, replacementReleaseSubject) = _fixture
+            .DefaultReleaseSubject()
+            .WithReleaseVersion(statsReleaseVersion)
+            .WithSubjects(_fixture.DefaultSubject().Generate(2))
+            .GenerateTuple2();
+
+        var originalFile = new File
+        {
+            Id = Guid.NewGuid(),
+            Type = FileType.Data,
+            SubjectId = originalReleaseSubject.SubjectId,
+        };
+
+        var replacementFile = new File
+        {
+            Id = Guid.NewGuid(),
+            Type = FileType.Data,
+            SubjectId = replacementReleaseSubject.SubjectId,
+            Replacing = originalFile,
+        };
+
+        originalFile.ReplacedBy = replacementFile;
+
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = originalFile,
+            FileId = originalFile.Id,
+        };
+
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersion = releaseVersion,
+            File = replacementFile,
+            FileId = replacementFile.Id,
+        };
+
+        var originalDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
+        var originalDefaultFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Default group - not changing",
+            FilterItems = [originalDefaultFilterItem],
+        };
+        var originalDefaultFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter 1 - not changing",
+            Name = "test_filter_1_not_changing",
+            Subject = originalReleaseSubject.Subject,
+            FilterGroups = [originalDefaultFilterGroup],
+        };
+
+        var replacementDefaultFilterItem = new FilterItem { Id = Guid.NewGuid(), Label = "Test filter item" };
+        var replacementDefaultFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Default group - not changing",
+            FilterItems = [replacementDefaultFilterItem],
+        };
+        var replacementDefaultFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Test filter 1 - not changing",
+            Name = "test_filter_1_not_changing",
+            Subject = replacementReleaseSubject.Subject,
+            FilterGroups = [replacementDefaultFilterGroup],
+        };
+
+        var replacementNewlyIntroducedFiltersFilterItem = new FilterItem
+        {
+            Id = Guid.NewGuid(),
+            Label = "Filter item for newly introduced Filter",
+        };
+        var replacementNewlyIntroducedFilterGroup = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Newly introduced filter group",
+            FilterItems = [replacementNewlyIntroducedFiltersFilterItem],
+        };
+        var replacementNewlyIntroducedFilter = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Label = "Newly introduced filter",
+            Name = "newly_introduced_filter",
+            Subject = replacementReleaseSubject.Subject,
+            FilterGroups = [replacementNewlyIntroducedFilterGroup],
+        };
+
+        var mapping = _fixture
+            .DefaultDataSetMapping()
+            .WithOriginalDataFileId(originalReleaseFile.FileId)
+            .WithReplacementDataFileId(replacementReleaseFile.FileId)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalDefaultFilter.Id,
+                        CreateFilterMapping(
+                            original: originalDefaultFilter,
+                            replacement: replacementDefaultFilter,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalDefaultFilterGroup.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalDefaultFilterGroup,
+                                        replacement: replacementDefaultFilterGroup,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalDefaultFilterItem.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalDefaultFilterItem.Id,
+                                                    OriginalLabel = originalDefaultFilterItem.Label,
+                                                    ReplacementId = replacementDefaultFilterItem.Id,
+                                                    ReplacementLabel = replacementDefaultFilterItem.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
+            .WithUnmappedReplacementFilters([
+                new UnmappedFilter
+                {
+                    Id = replacementNewlyIntroducedFilter.Id,
+                    ColumnName = replacementNewlyIntroducedFilter.Name,
+                    Label = replacementNewlyIntroducedFilter.Label,
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = replacementNewlyIntroducedFilterGroup.Id,
+                            Label = replacementNewlyIntroducedFilterGroup.Label,
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem
+                                {
+                                    Id = replacementNewlyIntroducedFiltersFilterItem.Id,
+                                    Label = replacementNewlyIntroducedFiltersFilterItem.Label,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]);
+
+        var timePeriodService = new Mock<ITimePeriodService>(Strict);
+        timePeriodService
+            .Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
+            .ReturnsAsync(
+                new List<(int Year, TimeIdentifier TimeIdentifier)> { (2019, CalendarYear), (2020, CalendarYear) }
+            );
+        var releaseFileRepository = new Mock<IReleaseFileRepository>(Strict);
+        releaseFileRepository
+            .Setup(mock => mock.CheckLinkedOriginalAndReplacementReleaseFilesExist(releaseVersion.Id, originalFile.Id))
+            .ReturnsAsync((originalReleaseFile, replacementReleaseFile));
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.AddRange(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
+            statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
+            statisticsDbContext.Filter.AddRange(
+                originalDefaultFilter,
+                replacementDefaultFilter,
+                replacementNewlyIntroducedFilter
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var replacementPlanService = BuildReplacementPlanService(
+                contentDbContext,
+                statisticsDbContext,
+                timePeriodService: timePeriodService.Object,
+                releaseFileRepository: releaseFileRepository.Object
+            );
+            var result = await replacementPlanService.GetReplacementPlan(
+                releaseVersionId: releaseVersion.Id,
+                originalFileId: originalFile.Id
+            );
+            VerifyAllMocks(timePeriodService, releaseFileRepository);
+            var replacementPlan = result.AssertRight();
+            Assert.True(replacementPlan.Valid);
+            Assert.False(replacementPlan.HasDataBlockAndReplacementHasAdditionalFilter);
+        }
+    }
+
     /// <summary>
     /// Please note this test will reduce in the number of cases when the feature flag has been removed from it.
     /// </summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -711,7 +711,7 @@ public class ReplacementPlanServiceTests
                 new ReplacementPlanIndicatorMappingViewModel
                 {
                     CandidateKey = null,
-                    Type = nameof(MapStatus.Unset),
+                    Type = MapStatus.Unset,
                     Source = new ReplacementPlanIndicatorViewModel
                     {
                         Id = originalIndicator.Id,
@@ -738,7 +738,7 @@ public class ReplacementPlanServiceTests
                 new ReplacementPlanLocationMappingViewModel
                 {
                     CandidateKey = null,
-                    Type = nameof(MapStatus.Unset),
+                    Type = MapStatus.Unset,
                     Source = new ReplacementPlanLocationViewModel
                     {
                         Id = originalLocation.Id,
@@ -2578,7 +2578,7 @@ public class ReplacementPlanServiceTests
                 new ReplacementPlanIndicatorMappingViewModel
                 {
                     CandidateKey = replacementIndicator.Id,
-                    Type = nameof(MapStatus.AutoSet),
+                    Type = MapStatus.AutoSet,
                     Source = new ReplacementPlanIndicatorViewModel
                     {
                         Id = originalIndicator.Id,
@@ -2609,7 +2609,7 @@ public class ReplacementPlanServiceTests
                 new ReplacementPlanLocationMappingViewModel
                 {
                     CandidateKey = replacementLocation.Id,
-                    Type = nameof(MapStatus.AutoSet),
+                    Type = MapStatus.AutoSet,
                     Source = new ReplacementPlanLocationViewModel
                     {
                         Id = originalLocation.Id,
@@ -2907,7 +2907,7 @@ public class ReplacementPlanServiceTests
                         Label = originalIndicatorA.Label,
                         Name = originalIndicatorA.Name,
                     },
-                    Type = nameof(MapStatus.ManuallySet),
+                    Type = MapStatus.ManuallySet,
                 },
                 indicatorMappingPlan.Mappings.Values
             );
@@ -2921,7 +2921,7 @@ public class ReplacementPlanServiceTests
                         Label = originalIndicatorToBeRemoved.Label,
                         Name = originalIndicatorToBeRemoved.Name,
                     },
-                    Type = nameof(MapStatus.Unset),
+                    Type = MapStatus.Unset,
                 },
                 indicatorMappingPlan.Mappings.Values
             );
@@ -3193,7 +3193,7 @@ public class ReplacementPlanServiceTests
                 new ReplacementPlanIndicatorMappingViewModel
                 {
                     CandidateKey = null,
-                    Type = nameof(MapStatus.Unset),
+                    Type = MapStatus.Unset,
                     Source = new ReplacementPlanIndicatorViewModel
                     {
                         Id = originalIndicatorA.Id,
@@ -3503,7 +3503,7 @@ public class ReplacementPlanServiceTests
                         Code = locationEng.ToLocationAttribute().Code!,
                         Name = locationEng.ToLocationAttribute().Name!,
                     },
-                    Type = nameof(MapStatus.AutoSet),
+                    Type = MapStatus.AutoSet,
                 },
                 locationMappingPlan.Mappings.Values
             );
@@ -3517,7 +3517,7 @@ public class ReplacementPlanServiceTests
                         Code = originalLocationDerby.ToLocationAttribute().Code!,
                         Name = originalLocationDerby.ToLocationAttribute().Name!,
                     },
-                    Type = nameof(MapStatus.ManuallySet),
+                    Type = MapStatus.ManuallySet,
                 },
                 locationMappingPlan.Mappings.Values
             );
@@ -3531,7 +3531,7 @@ public class ReplacementPlanServiceTests
                         Code = locationLeicester.ToLocationAttribute().Code!,
                         Name = locationLeicester.ToLocationAttribute().Name!,
                     },
-                    Type = nameof(MapStatus.AutoSet),
+                    Type = MapStatus.AutoSet,
                 },
                 locationMappingPlan.Mappings.Values
             );
@@ -3545,7 +3545,7 @@ public class ReplacementPlanServiceTests
                         Code = originalLocationBirmingham.ToLocationAttribute().Code!,
                         Name = originalLocationBirmingham.ToLocationAttribute().Name!,
                     },
-                    Type = nameof(MapStatus.Unset),
+                    Type = MapStatus.Unset,
                 },
                 locationMappingPlan.Mappings.Values
             );
@@ -3814,7 +3814,7 @@ public class ReplacementPlanServiceTests
                     Code = originalLocationDerby.ToLocationAttribute().Code!,
                     Name = originalLocationDerby.ToLocationAttribute().Name!,
                 },
-                Type = nameof(MapStatus.Unset),
+                Type = MapStatus.Unset,
             };
             Assert.Equal(expectedLocationMapping, locationMapping.Value);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -507,9 +507,9 @@ public class ReplacementPlanServiceTests
             Assert.Equal(originalFilterGroup.Label, dataBlockFilterGroupPlan.Value.Label);
             Assert.False(dataBlockFilterGroupPlan.Value.Valid);
 
-            Assert.Single(dataBlockFilterGroupPlan.Value.Filters);
+            Assert.Single(dataBlockFilterGroupPlan.Value.Items);
 
-            var dataBlockFilterItemPlan = dataBlockFilterGroupPlan.Value.Filters.First();
+            var dataBlockFilterItemPlan = dataBlockFilterGroupPlan.Value.Items.First();
 
             Assert.Equal(originalFilterItem.Id, dataBlockFilterItemPlan.Id);
             Assert.Equal(originalFilterItem.Label, dataBlockFilterItemPlan.Label);
@@ -1852,10 +1852,10 @@ public class ReplacementPlanServiceTests
             Assert.Equal(originalDefaultFilterGroup.Id, dataBlockDefaultFilterGroupPlan.Key);
             Assert.Equal(originalDefaultFilterGroup.Id, dataBlockDefaultFilterGroupPlan.Value.Id);
             Assert.Equal(originalDefaultFilterGroup.Label, dataBlockDefaultFilterGroupPlan.Value.Label);
-            Assert.Single(dataBlockDefaultFilterGroupPlan.Value.Filters);
+            Assert.Single(dataBlockDefaultFilterGroupPlan.Value.Items);
             Assert.True(dataBlockDefaultFilterGroupPlan.Value.Valid);
 
-            var dataBlockDefaultFilterItemPlan = dataBlockDefaultFilterGroupPlan.Value.Filters.First();
+            var dataBlockDefaultFilterItemPlan = dataBlockDefaultFilterGroupPlan.Value.Items.First();
 
             Assert.Equal(originalDefaultFilterItem.Id, dataBlockDefaultFilterItemPlan.Id);
             Assert.Equal(originalDefaultFilterItem.Label, dataBlockDefaultFilterItemPlan.Label);
@@ -1885,7 +1885,7 @@ public class ReplacementPlanServiceTests
                 originalIndividualSchoolTypeFilterGroup.Label,
                 dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Label
             );
-            Assert.Single(dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Filters);
+            Assert.Single(dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Items);
             Assert.True(dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Valid);
 
             var dataBlockCombinedSchoolTypeFilterGroupPlan = dataBlockSchoolTypeFilterPlan.Value.Groups.First(g =>
@@ -1897,11 +1897,11 @@ public class ReplacementPlanServiceTests
                 originalCombinedSchoolTypeFilterGroup.Label,
                 dataBlockCombinedSchoolTypeFilterGroupPlan.Value.Label
             );
-            Assert.Single(dataBlockCombinedSchoolTypeFilterGroupPlan.Value.Filters);
+            Assert.Single(dataBlockCombinedSchoolTypeFilterGroupPlan.Value.Items);
             Assert.True(dataBlockCombinedSchoolTypeFilterGroupPlan.Value.Valid);
 
             var dataBlockPrimarySchoolsFilterItemPlan =
-                dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Filters.First();
+                dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Items.First();
 
             Assert.Equal(originalPrimarySchoolsFilterItem.Id, dataBlockPrimarySchoolsFilterItemPlan.Id);
             Assert.Equal(originalPrimarySchoolsFilterItem.Label, dataBlockPrimarySchoolsFilterItemPlan.Label);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -89,7 +89,7 @@ public class ReplacementServiceHelperTests
                                         new UnmappedFilterItem
                                         {
                                             Id = replacementIndicatorA1CId,
-                                            Label = "Indicator A1c",
+                                            Label = "Indicator A1C",
                                         },
                                     ],
                                 }
@@ -199,7 +199,7 @@ public class ReplacementServiceHelperTests
                             Label = "Group C1",
                             UnmappedReplacementFilterItems =
                             [
-                                new UnmappedFilterItem { Id = replacementIndicatorC1AId, Label = "Indicator C1a" },
+                                new UnmappedFilterItem { Id = replacementIndicatorC1AId, Label = "Indicator C1A" },
                             ],
                         },
                     ],
@@ -1194,6 +1194,48 @@ public class ReplacementServiceHelperTests
             ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = indicatorsMappings,
             UnmappedReplacementIndicators = unmappedReplacementIndicators,
+        };
+    }
+
+    private static FilterMapping CreateFilterMapping(
+        Filter original,
+        Filter? replacement = null,
+        Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
+        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterMapping
+        {
+            OriginalId = original.Id,
+            OriginalColumnName = original.Name,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementColumnName = replacement?.Name,
+            ReplacementLabel = replacement?.Label,
+            FilterGroupMappings = filterGroupMappings ?? [],
+            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
+            Status = status,
+        };
+    }
+
+    private static FilterGroupMapping CreateFilterGroupMapping(
+        FilterGroup original,
+        FilterGroup? replacement = null,
+        Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
+        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterGroupMapping
+        {
+            OriginalId = original.Id,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementLabel = replacement?.Label,
+            FilterItemMappings = filterItemMappings ?? [],
+            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
+            Status = status,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -1,348 +1,275 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
-using LinqToDB;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
 public class ReplacementServiceHelperTests
 {
     [Fact]
-    public void ReplaceFilterSequence()
+    public void ReplaceFilterSequence_Success()
     {
-        // Define a set of filters, filter groups and filter items belonging to the original subject
-        var originalFilters = new List<Filter>
-        {
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter a",
-                Name = "filter_a",
-                FilterGroups = new List<FilterGroup>
-                {
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group a",
-                        FilterItems = new List<FilterItem>
-                        {
-                            new() { Id = Guid.NewGuid(), Label = "Item a" },
-                            new() { Id = Guid.NewGuid(), Label = "Item b" },
-                            new() { Id = Guid.NewGuid(), Label = "Item c" },
-                        },
-                    },
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group b",
-                        FilterItems = new List<FilterItem>
-                        {
-                            new() { Id = Guid.NewGuid(), Label = "Item d" },
-                            new() { Id = Guid.NewGuid(), Label = "Item e" },
-                            new() { Id = Guid.NewGuid(), Label = "Item f" },
-                        },
-                    },
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group c",
-                        FilterItems = new List<FilterItem>
-                        {
-                            new() { Id = Guid.NewGuid(), Label = "Item g" },
-                            new() { Id = Guid.NewGuid(), Label = "Item h" },
-                            new() { Id = Guid.NewGuid(), Label = "Item i" },
-                        },
-                    },
-                },
-            },
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter b",
-                Name = "filter_b",
-                FilterGroups = new List<FilterGroup>(),
-            },
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter c",
-                Name = "filter_c",
-                FilterGroups = new List<FilterGroup>(),
-            },
-        };
+        var originalFilterAId = Guid.NewGuid();
+        var originalGroupA1Id = Guid.NewGuid();
+        var originalIndicatorA1AId = Guid.NewGuid(); // mapped to replacement IA1A
+        var originalIndicatorA1BId = Guid.NewGuid(); // mapped to replacement IA1B
 
-        // Define a sequence for the original subject which is expected to be updated after the replacement
-        var originalReleaseFile = new ReleaseFile
+        var originalFilterBId = Guid.NewGuid();
+        var originalGroupB1Id = Guid.NewGuid();
+        var originalIndicatorB1AId = Guid.NewGuid(); // mapped to replacement IB1A
+        var originalIndicatorB1BId = Guid.NewGuid(); // not in replacement
+
+        var originalGroupB2Id = Guid.NewGuid(); // not in replacement
+        var originalIndicatorB2AId = Guid.NewGuid();
+
+        var originalFilterDId = Guid.NewGuid(); // not in replacement
+        var originalGroupD1Id = Guid.NewGuid();
+        var originalIndicatorD1AId = Guid.NewGuid();
+
+        var replacementFilterAId = Guid.NewGuid();
+        var replacementGroupA1Id = Guid.NewGuid();
+        var replacementIndicatorA1AId = Guid.NewGuid();
+        var replacementIndicatorA1BId = Guid.NewGuid();
+        var replacementIndicatorA1CId = Guid.NewGuid(); // new to replacement
+
+        var replacementFilterBId = Guid.NewGuid();
+        var replacementGroupB1Id = Guid.NewGuid();
+        var replacementIndicatorB1AId = Guid.NewGuid();
+
+        var replacementGroupB3Id = Guid.NewGuid(); // new to replacement
+        var replacementIndicatorB3AId = Guid.NewGuid();
+
+        var replacementFilterCId = Guid.NewGuid(); // new to replacement
+        var replacementGroupC1Id = Guid.NewGuid();
+        var replacementIndicatorC1AId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
         {
-            FilterSequence = new List<FilterSequenceEntry>
+            FilterMappings = new Dictionary<Guid, FilterMapping>()
             {
-                // Filter c
-                new(originalFilters[2].Id, new List<FilterGroupSequenceEntry>()),
-                // Filter a
-                new(
-                    originalFilters[0].Id,
-                    new List<FilterGroupSequenceEntry>
+                {
+                    originalFilterAId,
+                    new FilterMapping
                     {
-                        // Group c
-                        new(
-                            originalFilters[0].FilterGroups[2].Id,
-                            new List<Guid>
+                        OriginalId = originalFilterAId,
+
+                        ReplacementId = replacementFilterAId,
+
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
                             {
-                                // Item i, Item g, Item h
-                                originalFilters[0].FilterGroups[2].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[2].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[2].FilterItems[1].Id,
-                            }
-                        ),
-                        // Group a
-                        new(
-                            originalFilters[0].FilterGroups[0].Id,
-                            new List<Guid>
-                            {
-                                // Item c, Indicator a, Indicator b
-                                originalFilters[0].FilterGroups[0].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[0].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[0].FilterItems[1].Id,
-                            }
-                        ),
-                        // Group b
-                        new(
-                            originalFilters[0].FilterGroups[1].Id,
-                            new List<Guid>
-                            {
-                                // Item f, Item d, Item e
-                                originalFilters[0].FilterGroups[1].FilterItems[2].Id,
-                                originalFilters[0].FilterGroups[1].FilterItems[0].Id,
-                                originalFilters[0].FilterGroups[1].FilterItems[1].Id,
-                            }
-                        ),
+                                originalGroupA1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupA1Id,
+
+                                    ReplacementId = replacementGroupA1Id,
+
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalIndicatorA1AId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalIndicatorA1AId,
+                                                ReplacementId = replacementIndicatorA1AId,
+                                            }
+                                        },
+                                        {
+                                            originalIndicatorA1BId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalIndicatorA1BId,
+                                                ReplacementId = replacementIndicatorA1BId,
+                                            }
+                                        },
+                                    },
+                                    UnmappedReplacementFilterItems =
+                                    [
+                                        new UnmappedFilterItem
+                                        {
+                                            Id = replacementIndicatorA1CId,
+                                            Label = "Indicator A1c",
+                                        },
+                                    ],
+                                }
+                            },
+                        },
                     }
-                ),
-                // Filter b
-                new(originalFilters[1].Id, new List<FilterGroupSequenceEntry>()),
-            },
-        };
-
-        // Define the set of filters, filter groups and filter items belonging to the replacement subject
-        var replacementFilters = new List<Filter>
-        {
-            // 'Filter a' is updated
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter a",
-                Name = "filter_a",
-                FilterGroups = new List<FilterGroup>
+                },
                 {
-                    // 'Group a' is removed
-                    // 'Group e' is added
-                    new()
+                    originalFilterBId,
+                    new FilterMapping
                     {
-                        Id = Guid.NewGuid(),
-                        Label = "Group e",
-                        FilterItems = new List<FilterItem>(),
-                    },
-                    // Group 'Total' is added
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Total",
-                        FilterItems = new List<FilterItem>
+                        OriginalId = originalFilterBId,
+                        ReplacementId = replacementFilterBId,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
                         {
-                            new() { Id = Guid.NewGuid(), Label = "Item m" },
-                            new() { Id = Guid.NewGuid(), Label = "Total" },
-                            new() { Id = Guid.NewGuid(), Label = "Item l" },
+                            {
+                                originalGroupB1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupB1Id,
+                                    ReplacementId = replacementGroupB1Id,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalIndicatorB1AId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalIndicatorB1AId,
+                                                ReplacementId = replacementIndicatorB1AId,
+                                            }
+                                        },
+                                        {
+                                            originalIndicatorB1BId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalIndicatorB1BId,
+                                                ReplacementId = null,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                            {
+                                originalGroupB2Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupB2Id,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalIndicatorB2AId,
+                                            new FilterItemMapping { OriginalId = originalIndicatorB2AId }
+                                        },
+                                    },
+                                }
+                            },
                         },
-                    },
-                    // 'Group d' is added
-                    new()
+                        UnmappedReplacementFilterGroups =
+                        [
+                            new UnmappedFilterGroup
+                            {
+                                Id = replacementGroupB3Id,
+                                UnmappedReplacementFilterItems =
+                                [
+                                    new UnmappedFilterItem { Id = replacementIndicatorB3AId },
+                                ],
+                            },
+                        ],
+                    }
+                },
+                {
+                    originalFilterDId,
+                    new FilterMapping
                     {
-                        Id = Guid.NewGuid(),
-                        Label = "Group d",
-                        FilterItems = new List<FilterItem>(),
-                    },
-                    // 'Group b' is updated
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group b",
-                        FilterItems = new List<FilterItem>
+                        OriginalId = originalFilterDId,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
                         {
-                            new() { Id = Guid.NewGuid(), Label = "Item d" },
-                            // 'Item e' is removed
-                            // 'Item k' is added
-                            new() { Id = Guid.NewGuid(), Label = "Item k" },
-                            // 'Item j' is added
-                            new() { Id = Guid.NewGuid(), Label = "Item j" },
-                            new() { Id = Guid.NewGuid(), Label = "Item f" },
+                            {
+                                originalGroupD1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupD1Id,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalIndicatorD1AId,
+                                            new FilterItemMapping { OriginalId = originalIndicatorD1AId }
+                                        },
+                                    },
+                                }
+                            },
                         },
-                    },
-                    // 'Group c' remains identical
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group c",
-                        FilterItems = new List<FilterItem>
-                        {
-                            new() { Id = Guid.NewGuid(), Label = "Item g" },
-                            new() { Id = Guid.NewGuid(), Label = "Item h" },
-                            new() { Id = Guid.NewGuid(), Label = "Item i" },
-                        },
-                    },
+                    }
                 },
             },
-            // 'Filter b' is removed
-            // 'Filter e' is added
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter e",
-                Name = "filter_e",
-                FilterGroups = new List<FilterGroup>(),
-            },
-            // 'Filter d' is added
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter d",
-                Name = "filter_d",
-                FilterGroups = new List<FilterGroup>
+            UnmappedReplacementFilters =
+            [
+                new UnmappedFilter
                 {
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group g",
-                        FilterItems = new List<FilterItem>(),
-                    },
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Total",
-                        FilterItems = new List<FilterItem>
+                    Id = replacementFilterCId,
+                    Label = "Filter C",
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
                         {
-                            new() { Id = Guid.NewGuid(), Label = "Item o" },
-                            new() { Id = Guid.NewGuid(), Label = "Total" },
-                            new() { Id = Guid.NewGuid(), Label = "Item n" },
+                            Id = replacementGroupC1Id,
+                            Label = "Group C1",
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem { Id = replacementIndicatorC1AId, Label = "Indicator C1a" },
+                            ],
                         },
-                    },
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Label = "Group f",
-                        FilterItems = new List<FilterItem>(),
-                    },
+                    ],
                 },
-            },
-            // 'Filter c' remains identical
-            new()
-            {
-                Id = Guid.NewGuid(),
-                Label = "Filter c",
-                Name = "filter_c",
-                FilterGroups = new List<FilterGroup>(),
-            },
+            ],
         };
 
-        var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(
-            originalReleaseFile.FilterSequence,
-            new DataSetMapping() // @MarkFix
-        );
+        List<FilterSequenceEntry> indicatorSequence =
+        [
+            new(
+                Id: originalFilterAId,
+                FilterGroupSequence:
+                [
+                    new FilterGroupSequenceEntry(
+                        Id: originalGroupA1Id,
+                        FilterItemSequence: [originalIndicatorA1AId, originalIndicatorA1BId]
+                    ),
+                ]
+            ),
+            new(
+                Id: originalFilterBId,
+                FilterGroupSequence:
+                [
+                    new FilterGroupSequenceEntry(
+                        Id: originalGroupB1Id,
+                        FilterItemSequence: [originalIndicatorB1AId, originalIndicatorB1BId]
+                    ),
+                ]
+            ),
+        ];
 
-        // Verify the updated sequence of filters
+        var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(indicatorSequence, mapping);
+
         Assert.NotNull(updatedSequence);
+        Assert.Equal(3, updatedSequence.Count);
 
-        Assert.Equal(4, updatedSequence!.Count);
+        var filterA = updatedSequence[0];
+        Assert.Equal(replacementFilterAId, filterA.Id);
 
-        // 'Filter c' was first in the original sequence and is identical in the replacement subject so it should be first
-        var filterC = updatedSequence[0];
-        Assert.Equal(replacementFilters[3].Id, filterC.Id);
-        Assert.Empty(filterC.FilterGroupSequence);
+        var groupA1 = Assert.Single(filterA.FilterGroupSequence);
+        Assert.Equal(replacementGroupA1Id, groupA1.Id);
 
-        // 'Filter a' should be next in the sequence
-        var filterA = updatedSequence[1];
-        Assert.Equal(replacementFilters[0].Id, filterA.Id);
+        Assert.Equal(3, groupA1.FilterItemSequence.Count);
+        Assert.Equal(replacementIndicatorA1AId, groupA1.FilterItemSequence[0]);
+        Assert.Equal(replacementIndicatorA1BId, groupA1.FilterItemSequence[1]);
+        Assert.Equal(replacementIndicatorA1CId, groupA1.FilterItemSequence[2]);
 
-        var filterAGroups = filterA.FilterGroupSequence;
-        Assert.Equal(5, filterAGroups.Count);
+        var filterB = updatedSequence[1];
+        Assert.Equal(replacementFilterBId, filterB.Id);
+        Assert.Equal(2, filterB.FilterGroupSequence.Count);
 
-        // 'Group c' was first in the original sequence and is untouched in the replacement subject so it should be first
-        var filterAGroupC = filterAGroups[0];
-        Assert.Equal(replacementFilters[0].FilterGroups[4].Id, filterAGroupC.Id);
-        Assert.Equal(3, filterAGroupC.FilterItemSequence.Count);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.FilterItemSequence[0]);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.FilterItemSequence[1]);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.FilterItemSequence[2]);
+        var groupB1 = filterB.FilterGroupSequence[0];
+        Assert.Equal(replacementGroupB1Id, groupB1.Id);
+        var indicatorB1AId = Assert.Single(groupB1.FilterItemSequence);
+        Assert.Equal(replacementIndicatorB1AId, indicatorB1AId);
 
-        // 'Group a' would've been the next group but has been removed
+        // groupB2 is not in the replacement
 
-        // 'Group b' should be second based on the original sequence
-        // Check 'Item e' was removed and both 'Item j' and 'Item k' have been appended in order
-        var filterAGroupB = filterAGroups[1];
-        Assert.Equal(replacementFilters[0].FilterGroups[3].Id, filterAGroupB.Id);
-        Assert.Equal(4, filterAGroupB.FilterItemSequence.Count);
-        // 'Item f' is first from the original sequence
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.FilterItemSequence[0]);
-        // 'Item d' is second from the original sequence
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.FilterItemSequence[1]);
-        // 'Item j' is appended first alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.FilterItemSequence[2]);
-        // 'Item k' is appended second alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.FilterItemSequence[3]);
+        var groupB3 = filterB.FilterGroupSequence[1];
+        Assert.Equal(replacementGroupB3Id, groupB3.Id);
+        var indicatorB3AId = Assert.Single(groupB3.FilterItemSequence);
+        Assert.Equal(replacementIndicatorB3AId, indicatorB3AId);
 
-        // Group 'Total' is new so it should be appended first and its filter items should be ordered by label
-        var filterAGroupTotal = filterAGroups[2];
-        Assert.Equal(replacementFilters[0].FilterGroups[1].Id, filterAGroupTotal.Id);
-        // Item 'Total' should be first
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.FilterItemSequence[0]);
-        // 'Item l' should be second alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.FilterItemSequence[1]);
-        // 'Item m' should be third alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.FilterItemSequence[2]);
+        var filterC = updatedSequence[2];
+        Assert.Equal(replacementFilterCId, filterC.Id);
 
-        // 'Group d' is new so it should be appended in order and its filter items should be ordered by label
-        var filterAGroupD = filterAGroups[3];
-        Assert.Equal(replacementFilters[0].FilterGroups[2].Id, filterAGroupD.Id);
-        Assert.Empty(filterAGroupD.FilterItemSequence);
-
-        // 'Group e' is new so it should be appended in order
-        var filterAGroupE = filterAGroups[4];
-        Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupE.Id);
-        Assert.Empty(filterAGroupE.FilterItemSequence);
-
-        // 'Filter b' would've been the next filter but has been removed
-
-        // 'Filter d' is new so it should be appended in order and its filter groups and filter items should be ordered by label
-        var filterD = updatedSequence[2];
-        Assert.Equal(replacementFilters[2].Id, filterD.Id);
-
-        var filterDGroups = filterD.FilterGroupSequence;
-        Assert.Equal(3, filterDGroups.Count);
-
-        // Group 'Total' should be first and its filter items should be ordered by label
-        var filterDGroupTotal = filterDGroups[0];
-        Assert.Equal(replacementFilters[2].FilterGroups[1].Id, filterDGroupTotal.Id);
-        Assert.Equal(3, filterDGroupTotal.FilterItemSequence.Count);
-        // Item 'Total' should be first
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.FilterItemSequence[0]);
-        // 'Item n' should be second alphabetically
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.FilterItemSequence[1]);
-        // 'Item o' should be third alphabetically
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.FilterItemSequence[2]);
-
-        // 'Group f' should be second alphabetically
-        var filterDGroupF = filterDGroups[1];
-        Assert.Equal(replacementFilters[2].FilterGroups[2].Id, filterDGroupF.Id);
-        Assert.Empty(filterDGroupF.FilterItemSequence);
-
-        // 'Group g' should be third alphabetically
-        var filterDGroupG = filterDGroups[2];
-        Assert.Equal(replacementFilters[2].FilterGroups[0].Id, filterDGroupG.Id);
-        Assert.Empty(filterDGroupG.FilterItemSequence);
-
-        // 'Filter e' is new so it should be appended in order
-        var filterE = updatedSequence[3];
-        Assert.Equal(replacementFilters[1].Id, filterE.Id);
-        Assert.Empty(filterE.FilterGroupSequence);
+        var groupC = Assert.Single(filterC.FilterGroupSequence);
+        Assert.Equal(replacementGroupC1Id, groupC.Id);
+        var indicatorC1A = Assert.Single(groupC.FilterItemSequence);
+        Assert.Equal(replacementIndicatorC1AId, indicatorC1A);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using LinqToDB;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
@@ -243,9 +244,8 @@ public class ReplacementServiceHelperTests
         };
 
         var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(
-            originalFilters: originalFilters,
-            replacementFilters: replacementFilters,
-            originalReleaseFile
+            originalReleaseFile.FilterSequence,
+            new DataSetMapping() // @MarkFix
         );
 
         // Verify the updated sequence of filters
@@ -256,22 +256,22 @@ public class ReplacementServiceHelperTests
         // 'Filter c' was first in the original sequence and is identical in the replacement subject so it should be first
         var filterC = updatedSequence[0];
         Assert.Equal(replacementFilters[3].Id, filterC.Id);
-        Assert.Empty(filterC.ChildSequence);
+        Assert.Empty(filterC.FilterGroupSequence);
 
         // 'Filter a' should be next in the sequence
         var filterA = updatedSequence[1];
         Assert.Equal(replacementFilters[0].Id, filterA.Id);
 
-        var filterAGroups = filterA.ChildSequence;
+        var filterAGroups = filterA.FilterGroupSequence;
         Assert.Equal(5, filterAGroups.Count);
 
         // 'Group c' was first in the original sequence and is untouched in the replacement subject so it should be first
         var filterAGroupC = filterAGroups[0];
         Assert.Equal(replacementFilters[0].FilterGroups[4].Id, filterAGroupC.Id);
-        Assert.Equal(3, filterAGroupC.ChildSequence.Count);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.ChildSequence[0]);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.ChildSequence[1]);
-        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.ChildSequence[2]);
+        Assert.Equal(3, filterAGroupC.FilterItemSequence.Count);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[2].Id, filterAGroupC.FilterItemSequence[0]);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[0].Id, filterAGroupC.FilterItemSequence[1]);
+        Assert.Equal(replacementFilters[0].FilterGroups[4].FilterItems[1].Id, filterAGroupC.FilterItemSequence[2]);
 
         // 'Group a' would've been the next group but has been removed
 
@@ -279,35 +279,35 @@ public class ReplacementServiceHelperTests
         // Check 'Item e' was removed and both 'Item j' and 'Item k' have been appended in order
         var filterAGroupB = filterAGroups[1];
         Assert.Equal(replacementFilters[0].FilterGroups[3].Id, filterAGroupB.Id);
-        Assert.Equal(4, filterAGroupB.ChildSequence.Count);
+        Assert.Equal(4, filterAGroupB.FilterItemSequence.Count);
         // 'Item f' is first from the original sequence
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.ChildSequence[0]);
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[3].Id, filterAGroupB.FilterItemSequence[0]);
         // 'Item d' is second from the original sequence
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.ChildSequence[1]);
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[0].Id, filterAGroupB.FilterItemSequence[1]);
         // 'Item j' is appended first alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.ChildSequence[2]);
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[2].Id, filterAGroupB.FilterItemSequence[2]);
         // 'Item k' is appended second alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.ChildSequence[3]);
+        Assert.Equal(replacementFilters[0].FilterGroups[3].FilterItems[1].Id, filterAGroupB.FilterItemSequence[3]);
 
         // Group 'Total' is new so it should be appended first and its filter items should be ordered by label
         var filterAGroupTotal = filterAGroups[2];
         Assert.Equal(replacementFilters[0].FilterGroups[1].Id, filterAGroupTotal.Id);
         // Item 'Total' should be first
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.ChildSequence[0]);
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[1].Id, filterAGroupTotal.FilterItemSequence[0]);
         // 'Item l' should be second alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.ChildSequence[1]);
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[2].Id, filterAGroupTotal.FilterItemSequence[1]);
         // 'Item m' should be third alphabetically
-        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.ChildSequence[2]);
+        Assert.Equal(replacementFilters[0].FilterGroups[1].FilterItems[0].Id, filterAGroupTotal.FilterItemSequence[2]);
 
         // 'Group d' is new so it should be appended in order and its filter items should be ordered by label
         var filterAGroupD = filterAGroups[3];
         Assert.Equal(replacementFilters[0].FilterGroups[2].Id, filterAGroupD.Id);
-        Assert.Empty(filterAGroupD.ChildSequence);
+        Assert.Empty(filterAGroupD.FilterItemSequence);
 
         // 'Group e' is new so it should be appended in order
         var filterAGroupE = filterAGroups[4];
         Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupE.Id);
-        Assert.Empty(filterAGroupE.ChildSequence);
+        Assert.Empty(filterAGroupE.FilterItemSequence);
 
         // 'Filter b' would've been the next filter but has been removed
 
@@ -315,34 +315,34 @@ public class ReplacementServiceHelperTests
         var filterD = updatedSequence[2];
         Assert.Equal(replacementFilters[2].Id, filterD.Id);
 
-        var filterDGroups = filterD.ChildSequence;
+        var filterDGroups = filterD.FilterGroupSequence;
         Assert.Equal(3, filterDGroups.Count);
 
         // Group 'Total' should be first and its filter items should be ordered by label
         var filterDGroupTotal = filterDGroups[0];
         Assert.Equal(replacementFilters[2].FilterGroups[1].Id, filterDGroupTotal.Id);
-        Assert.Equal(3, filterDGroupTotal.ChildSequence.Count);
+        Assert.Equal(3, filterDGroupTotal.FilterItemSequence.Count);
         // Item 'Total' should be first
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.ChildSequence[0]);
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[1].Id, filterDGroupTotal.FilterItemSequence[0]);
         // 'Item n' should be second alphabetically
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.ChildSequence[1]);
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[2].Id, filterDGroupTotal.FilterItemSequence[1]);
         // 'Item o' should be third alphabetically
-        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.ChildSequence[2]);
+        Assert.Equal(replacementFilters[2].FilterGroups[1].FilterItems[0].Id, filterDGroupTotal.FilterItemSequence[2]);
 
         // 'Group f' should be second alphabetically
         var filterDGroupF = filterDGroups[1];
         Assert.Equal(replacementFilters[2].FilterGroups[2].Id, filterDGroupF.Id);
-        Assert.Empty(filterDGroupF.ChildSequence);
+        Assert.Empty(filterDGroupF.FilterItemSequence);
 
         // 'Group g' should be third alphabetically
         var filterDGroupG = filterDGroups[2];
         Assert.Equal(replacementFilters[2].FilterGroups[0].Id, filterDGroupG.Id);
-        Assert.Empty(filterDGroupG.ChildSequence);
+        Assert.Empty(filterDGroupG.FilterItemSequence);
 
         // 'Filter e' is new so it should be appended in order
         var filterE = updatedSequence[3];
         Assert.Equal(replacementFilters[1].Id, filterE.Id);
-        Assert.Empty(filterE.ChildSequence);
+        Assert.Empty(filterE.FilterGroupSequence);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -180,7 +180,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -543,7 +542,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -726,7 +724,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object,
                     dataSetVersionService: dataSetVersionService.Object,
                     apiDataSetVersionMappingService: apiDataSetVersionMappingService.Object
@@ -1143,7 +1140,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object,
                     releaseFileRepository: releaseFileRepository.Object
                 )
@@ -1675,7 +1671,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -2038,7 +2033,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -2304,7 +2298,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -2506,7 +2499,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -2733,7 +2725,6 @@ public class ReplacementServiceTests
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
                     statisticsDbContext,
-                    filterRepository: filterRepository,
                     timePeriodService: timePeriodService.Object
                 )
             );
@@ -2814,7 +2805,6 @@ public class ReplacementServiceTests
     private static ReplacementPlanService BuildReplacementPlanService(
         ContentDbContext contentDbContext,
         StatisticsDbContext statisticsDbContext,
-        IFilterRepository? filterRepository = null,
         IDataSetVersionService? dataSetVersionService = null,
         ITimePeriodService? timePeriodService = null,
         IDataSetVersionMappingService? apiDataSetVersionMappingService = null,
@@ -2824,8 +2814,6 @@ public class ReplacementServiceTests
         var userService = AlwaysTrueUserService().Object;
         return new ReplacementPlanService(
             contentDbContext,
-            statisticsDbContext,
-            filterRepository ?? Mock.Of<IFilterRepository>(Strict),
             new FootnoteRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -172,11 +172,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFIx
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
@@ -534,11 +532,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
@@ -715,11 +711,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //'filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
@@ -2551,11 +2545,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -3041,11 +3033,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -38,6 +38,7 @@ using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Util
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
 using static Moq.MockBehavior;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+using FilterMapping = GovUk.Education.ExploreEducationStatistics.Content.Model.FilterMapping;
 using IndicatorMapping = GovUk.Education.ExploreEducationStatistics.Content.Model.IndicatorMapping;
 using IReleaseVersionService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseVersionService;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Data.Model.ReleaseVersion;
@@ -794,30 +795,35 @@ public class ReplacementServiceTests
 
         var originalFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem1 },
         };
 
         var originalFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem2 },
         };
 
         var replacementFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem1 },
         };
 
         var replacementFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem2 },
         };
 
         var originalFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -826,6 +832,7 @@ public class ReplacementServiceTests
 
         var originalFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -834,6 +841,7 @@ public class ReplacementServiceTests
 
         var replacementFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -842,6 +850,7 @@ public class ReplacementServiceTests
 
         var replacementFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1053,6 +1062,71 @@ public class ReplacementServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFile(originalFile)
             .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter1.Id,
+                        CreateFilterMapping(
+                            original: originalFilter1,
+                            replacement: replacementFilter1,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup1.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup1,
+                                        replacement: replacementFilterGroup1,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1.Id,
+                                                    OriginalLabel = originalFilterItem1.Label,
+                                                    ReplacementId = replacementFilterItem1.Id,
+                                                    ReplacementLabel = replacementFilterItem1.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                    {
+                        originalFilter2.Id,
+                        CreateFilterMapping(
+                            original: originalFilter2,
+                            replacement: replacementFilter2,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup2.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup2,
+                                        replacement: replacementFilterGroup2,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem2.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem2.Id,
+                                                    OriginalLabel = originalFilterItem2.Label,
+                                                    ReplacementId = replacementFilterItem2.Id,
+                                                    ReplacementLabel = replacementFilterItem2.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -1128,11 +1202,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -1385,6 +1457,7 @@ public class ReplacementServiceTests
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     Label = "Default group - not changing",
                     FilterItems = new List<FilterItem>
                     {
@@ -1404,6 +1477,7 @@ public class ReplacementServiceTests
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     Label = "Default group - not changing",
                     FilterItems = new List<FilterItem>
                     {
@@ -1415,6 +1489,7 @@ public class ReplacementServiceTests
 
         var replacementFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1422,6 +1497,7 @@ public class ReplacementServiceTests
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     Label = "Default group - not changing",
                     FilterItems = new List<FilterItem>
                     {
@@ -1433,6 +1509,7 @@ public class ReplacementServiceTests
 
         var replacementFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1440,6 +1517,7 @@ public class ReplacementServiceTests
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     Label = "Default group - not changing",
                     FilterItems = new List<FilterItem>
                     {
@@ -1578,6 +1656,89 @@ public class ReplacementServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFile(originalFile)
             .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter1.Id,
+                        CreateFilterMapping(
+                            original: originalFilter1,
+                            replacementFilter1,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilter1.FilterGroups[0].Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilter1.FilterGroups[0],
+                                        replacement: replacementFilter1.FilterGroups[0],
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilter1.FilterGroups[0].FilterItems[0].Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilter1.FilterGroups[0].FilterItems[0].Id,
+                                                    OriginalLabel = originalFilter1
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                    ReplacementId = replacementFilter1
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Id,
+                                                    ReplacementLabel = replacementFilter1
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                    {
+                        originalFilter2.Id,
+                        CreateFilterMapping(
+                            original: originalFilter2,
+                            replacementFilter2,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilter2.FilterGroups[0].Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilter2.FilterGroups[0],
+                                        replacement: replacementFilter2.FilterGroups[0],
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilter2.FilterGroups[0].FilterItems[0].Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilter2.FilterGroups[0].FilterItems[0].Id,
+                                                    OriginalLabel = originalFilter2
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                    ReplacementId = replacementFilter2
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Id,
+                                                    ReplacementLabel = replacementFilter2
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -1659,11 +1820,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -1774,30 +1933,35 @@ public class ReplacementServiceTests
 
         var originalFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem1 },
         };
 
         var originalFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem2 },
         };
 
         var replacementFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem1 },
         };
 
         var replacementFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem2 },
         };
 
         var originalFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -1806,6 +1970,7 @@ public class ReplacementServiceTests
 
         var originalFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -1814,6 +1979,7 @@ public class ReplacementServiceTests
 
         var replacementFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1822,6 +1988,7 @@ public class ReplacementServiceTests
 
         var replacementFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -1940,6 +2107,71 @@ public class ReplacementServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFile(originalFile)
             .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter1.Id,
+                        CreateFilterMapping(
+                            original: originalFilter1,
+                            replacement: replacementFilter1,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup1.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup1,
+                                        replacement: replacementFilterGroup1,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1.Id,
+                                                    OriginalLabel = originalFilterItem1.Label,
+                                                    ReplacementId = replacementFilterItem1.Id,
+                                                    ReplacementLabel = replacementFilterItem1.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                    {
+                        originalFilter2.Id,
+                        CreateFilterMapping(
+                            original: originalFilter2,
+                            replacement: replacementFilter2,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup2.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup2,
+                                        replacement: replacementFilterGroup2,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem2.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem2.Id,
+                                                    OriginalLabel = originalFilterItem2.Label,
+                                                    ReplacementId = replacementFilterItem2.Id,
+                                                    ReplacementLabel = replacementFilterItem2.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -2021,11 +2253,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -2217,6 +2447,41 @@ public class ReplacementServiceTests
             .DefaultDataSetMapping()
             .WithOriginalDataFile(originalFile)
             .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter1.Id,
+                        CreateFilterMapping(
+                            original: originalFilter1,
+                            replacement: replacementFilter1,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup1.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup1,
+                                        replacement: replacementFilterGroup1,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1.Id,
+                                                    OriginalLabel = originalFilterItem1.Label,
+                                                    ReplacementId = replacementFilterItem1.Id,
+                                                    ReplacementLabel = replacementFilterItem1.Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            )
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -2447,7 +2712,70 @@ public class ReplacementServiceTests
         var dataSetMapping = _fixture
             .DefaultDataSetMapping()
             .WithOriginalDataFile(originalFile)
-            .WithReplacementDataFile(replacementFile);
+            .WithReplacementDataFile(replacementFile)
+            .WithFilterMappings(
+                new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilters[0].Id,
+                        CreateFilterMapping(
+                            original: originalFilters[0],
+                            replacement: replacementFilters[0],
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilters[0].FilterGroups[0].Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilters[0].FilterGroups[0],
+                                        replacement: replacementFilters[0].FilterGroups[0],
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilters[0].FilterGroups[0].FilterItems[0].Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilters[0].FilterGroups[0].FilterItems[0].Id,
+                                                    OriginalLabel = originalFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                    ReplacementId = replacementFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Id,
+                                                    ReplacementLabel = replacementFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[0]
+                                                        .Label,
+                                                }
+                                            },
+                                            {
+                                                originalFilters[0].FilterGroups[0].FilterItems[1].Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilters[0].FilterGroups[0].FilterItems[1].Id,
+                                                    OriginalLabel = originalFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[1]
+                                                        .Label,
+                                                    ReplacementId = replacementFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[1]
+                                                        .Id,
+                                                    ReplacementLabel = replacementFilters[0]
+                                                        .FilterGroups[0]
+                                                        .FilterItems[1]
+                                                        .Label,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                }
+            );
 
         var contentDbContextId = Guid.NewGuid().ToString();
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -2489,11 +2817,9 @@ public class ReplacementServiceTests
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var filterRepository = new FilterRepository(statisticsDbContext);
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                //filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
@@ -2842,6 +3168,48 @@ public class ReplacementServiceTests
             cacheKeyService ?? Mock.Of<ICacheKeyService>(Strict),
             privateBlobCacheService ?? Mock.Of<IPrivateBlobCacheService>(Strict)
         );
+    }
+
+    private static FilterMapping CreateFilterMapping(
+        Filter original,
+        Filter? replacement = null,
+        Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
+        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterMapping
+        {
+            OriginalId = original.Id,
+            OriginalColumnName = original.Name,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementColumnName = replacement?.Name,
+            ReplacementLabel = replacement?.Label,
+            FilterGroupMappings = filterGroupMappings ?? [],
+            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
+            Status = status,
+        };
+    }
+
+    private static FilterGroupMapping CreateFilterGroupMapping(
+        FilterGroup original,
+        FilterGroup? replacement = null,
+        Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
+        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterGroupMapping
+        {
+            OriginalId = original.Id,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementLabel = replacement?.Label,
+            FilterItemMappings = filterItemMappings ?? [],
+            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
+            Status = status,
+        };
     }
 
     private static IndicatorMapping CreateIndicatorMapping(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -175,7 +175,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFIx
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
@@ -537,7 +537,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
                     contentDbContext,
@@ -718,7 +718,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //'filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
@@ -1132,7 +1132,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -1663,7 +1663,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -2025,7 +2025,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -2290,7 +2290,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 privateBlobCacheService: privateBlobCacheService.Object,
                 cacheKeyService: cacheKeyService.Object,
                 releaseVersionService: releaseVersionService.Object,
@@ -2493,7 +2493,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
@@ -2719,7 +2719,7 @@ public class ReplacementServiceTests
             var replacementService = BuildReplacementService(
                 contentDbContext,
                 statisticsDbContext,
-                filterRepository: filterRepository,
+                //filterRepository: filterRepository, // @MarkFix
                 releaseVersionService: releaseVersionService.Object,
                 releaseFileRepository: releaseFileRepository.Object,
                 replacementPlanService: BuildReplacementPlanService(
@@ -2826,7 +2826,6 @@ public class ReplacementServiceTests
     private static ReplacementService BuildReplacementService(
         ContentDbContext contentDbContext,
         StatisticsDbContext statisticsDbContext,
-        IFilterRepository? filterRepository = null,
         IReleaseVersionService? releaseVersionService = null,
         IReleaseFileRepository? releaseFileRepository = null,
         IReplacementPlanService? replacementPlanService = null,
@@ -2837,7 +2836,6 @@ public class ReplacementServiceTests
         return new ReplacementService(
             contentDbContext,
             statisticsDbContext,
-            filterRepository ?? new FilterRepository(statisticsDbContext),
             releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
             releaseFileRepository ?? Mock.Of<IReleaseFileRepository>(Strict),
             replacementPlanService ?? Mock.Of<IReplacementPlanService>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -2527,16 +2527,16 @@ public class ReplacementServiceTests
             // 'Filter a' should be the only filter in the sequence
             var filterA = Assert.Single(updatedSequence);
             Assert.Equal(replacementFilters[0].Id, filterA.Id);
-            var filterAGroups = filterA.ChildSequence;
+            var filterAGroups = filterA.FilterGroupSequence;
 
             // 'Group a' should be the only group in the sequence
             var filterAGroupA = Assert.Single(filterAGroups);
             Assert.Equal(replacementFilters[0].FilterGroups[0].Id, filterAGroupA.Id);
 
             // 'Group a' should still have two filter items in the same order as the original sequence
-            Assert.Equal(2, filterAGroupA.ChildSequence.Count);
-            Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[1].Id, filterAGroupA.ChildSequence[0]);
-            Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[0].Id, filterAGroupA.ChildSequence[1]);
+            Assert.Equal(2, filterAGroupA.FilterItemSequence.Count);
+            Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[1].Id, filterAGroupA.FilterItemSequence[0]);
+            Assert.Equal(replacementFilters[0].FilterGroups[0].FilterItems[0].Id, filterAGroupA.FilterItemSequence[1]);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
@@ -190,8 +190,9 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
         // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
         // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
         var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
-        if (replacementGroupLabelToGroupMap != null) // if parent filter isn't mapped, no group replacements to refer to
+        if (replacementGroupLabelToGroupMap != null)
         {
+            // parent is mapped
             var mappedReplacementGroupIds = filterGroupMappings
                 .Values.Where(m => m.ReplacementId.HasValue)
                 .Select(m => m.ReplacementId!.Value);
@@ -245,8 +246,9 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
         // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
         // if parent is mapped, we can figure out which replacement items for this group are unmapped
         var unmappedReplacementItems = new List<UnmappedFilterItem>();
-        if (replacementItemLabelToItemMap != null) // if parent isn't mapped, no replacement so no unmappedReplacementItems
+        if (replacementItemLabelToItemMap != null)
         {
+            // parent is mapped
             var mappedReplacementItemIds = filterItemMappings
                 .Values.Where(m => m.ReplacementId.HasValue)
                 .Select(m => m.ReplacementId!.Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
@@ -1,0 +1,262 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using LinqToDB.Internal.Common;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api/bau")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class CreateFilterMappingsForPreexistingDataSetMappingsController(
+    ContentDbContext contentDbContext,
+    StatisticsDbContext statisticsDbContext
+) : ControllerBase
+{
+    [HttpPut("create-filter-mappings")]
+    public async Task<ActionResult> CreateFilterMappings(CancellationToken cancellationToken = default)
+    {
+        var dataSetMappings = contentDbContext.DataSetMappings.ToList();
+
+        foreach (var mapping in dataSetMappings)
+        {
+            var originalSubjectId = await contentDbContext
+                .Files.Where(f =>
+                    f.Id == mapping.OriginalDataFileId
+                    && f.Type == FileType.Data
+                    && mapping.FilterMappings.IsNullOrEmpty()
+                )
+                .Select(f => f.SubjectId!.Value)
+                .SingleAsync(cancellationToken);
+
+            var replacementSubjectId = await contentDbContext
+                .Files.Where(f =>
+                    f.Id == mapping.ReplacementDataFileId
+                    && f.Type == FileType.Data
+                    && mapping.FilterMappings.IsNullOrEmpty()
+                )
+                .Select(f => f.SubjectId!.Value)
+                .SingleAsync(cancellationToken);
+
+            // NOTE: Basically copied from DataSetMappingService.GenerateInitialFilterMapping, although we save
+            // filterMappings unmappedReplacementFilters rather than return them
+            var originalFilters = await statisticsDbContext
+                .Filter.AsNoTracking()
+                .Include(f => f.FilterGroups)
+                    .ThenInclude(fg => fg.FilterItems)
+                .Where(f => f.SubjectId == originalSubjectId)
+                .ToListAsync(cancellationToken);
+
+            var replacementFilters = await statisticsDbContext
+                .Filter.AsNoTracking()
+                .Include(f => f.FilterGroups)
+                    .ThenInclude(fg => fg.FilterItems)
+                .Where(f => f.SubjectId == replacementSubjectId)
+                .ToListAsync(cancellationToken);
+
+            // Create dictionaries to speed up performance when creating filterMappings/unmappedReplacementFilters
+            var replacementFiltersMap = replacementFilters.ToDictionary(f => f.Name, f => f); // automap filters by column name
+
+            var replacementFilterIdToGroupLabelToGroupMap = replacementFilters
+                .SelectMany(f => f.FilterGroups.Select(g => new { FilterId = f.Id, FilterGroup = g }))
+                .GroupBy(x => x.FilterId)
+                .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterGroup.Label, g => g.FilterGroup)); // automap groups by label
+
+            var replacementGroupIdToItemLabelToItemMap = replacementFilters
+                .SelectMany(f => f.FilterGroups)
+                .SelectMany(g => g.FilterItems.Select(i => new { FilterGroupId = g.Id, FilterItem = i }))
+                .GroupBy(x => x.FilterGroupId)
+                .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterItem.Label, g => g.FilterItem)); // automap items by label
+
+            // Now we created FilterMappings
+            var filterMappings = new Dictionary<Guid, FilterMapping>();
+            foreach (var originalFilter in originalFilters)
+            {
+                replacementFiltersMap.TryGetValue(originalFilter.Name, out var replacementFilter);
+
+                var replacementGroupLabelToGroupMap =
+                    replacementFilter != null
+                        ? replacementFilterIdToGroupLabelToGroupMap.GetValueOrDefault(replacementFilter.Id)
+                        : null;
+
+                var (filterGroupMappings, unmappedReplacementGroups) = GenerateInitialFilterGroupMapping(
+                    originalFilter.FilterGroups,
+                    replacementGroupLabelToGroupMap,
+                    replacementGroupIdToItemLabelToItemMap
+                );
+
+                var filterMapping = new FilterMapping
+                {
+                    OriginalId = originalFilter.Id,
+                    OriginalColumnName = originalFilter.Name,
+                    OriginalLabel = originalFilter.Label,
+
+                    ReplacementId = replacementFilter?.Id,
+                    ReplacementColumnName = replacementFilter?.Name,
+                    ReplacementLabel = replacementFilter?.Label,
+
+                    FilterGroupMappings = filterGroupMappings,
+                    UnmappedReplacementFilterGroups = unmappedReplacementGroups,
+
+                    Status = replacementFilter == null ? MapStatus.Unset : MapStatus.AutoSet,
+                };
+
+                filterMappings.Add(filterMapping.OriginalId, filterMapping);
+            }
+
+            // Now we create UnmappedReplacementFilters
+            var mappedReplacementFilterIds = filterMappings
+                .Values.Where(m => m.ReplacementId.HasValue)
+                .Select(m => m.ReplacementId!.Value);
+
+            var unmappedReplacementFilters = replacementFiltersMap
+                .Values.ExceptBy(mappedReplacementFilterIds, filter => filter.Id)
+                .Select(filter => new UnmappedFilter
+                {
+                    Id = filter.Id,
+                    Label = filter.Label,
+                    ColumnName = filter.Name,
+
+                    UnmappedReplacementFilterGroups = filter
+                        .FilterGroups.Select(group => new UnmappedFilterGroup
+                        {
+                            Id = group.Id,
+                            Label = group.Label,
+                            UnmappedReplacementFilterItems = group
+                                .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                                .ToList(),
+                        })
+                        .ToList(),
+                })
+                .ToList();
+
+            mapping.FilterMappings = filterMappings;
+            mapping.UnmappedReplacementFilters = unmappedReplacementFilters;
+        }
+
+        await contentDbContext.SaveChangesAsync(cancellationToken);
+        return Ok("All DataSetMapping.FilterMappings created");
+    }
+
+    private static (Dictionary<Guid, FilterGroupMapping>, List<UnmappedFilterGroup>) GenerateInitialFilterGroupMapping(
+        List<FilterGroup> originalFilterGroups,
+        Dictionary<string, FilterGroup>? replacementGroupLabelToGroupMap,
+        Dictionary<Guid, Dictionary<string, FilterItem>> replacementGroupIdToItemLabelToItemMap
+    )
+    {
+        var filterGroupMappings = new Dictionary<Guid, FilterGroupMapping>();
+
+        foreach (var originalFilterGroup in originalFilterGroups)
+        {
+            FilterGroup? replacementFilterGroup = null;
+            replacementGroupLabelToGroupMap?.TryGetValue(originalFilterGroup.Label, out replacementFilterGroup);
+
+            var replacementItemLabelToItemMap =
+                replacementFilterGroup != null
+                    ? replacementGroupIdToItemLabelToItemMap.GetValueOrDefault(replacementFilterGroup.Id)
+                    : null;
+            var (filterItemMappings, unmappedReplacementItems) = GenerateInitialFilterItemMapping(
+                originalFilterGroup.FilterItems,
+                replacementItemLabelToItemMap
+            );
+
+            var filterGroupMapping = new FilterGroupMapping
+            {
+                OriginalId = originalFilterGroup.Id,
+                OriginalLabel = originalFilterGroup.Label,
+
+                ReplacementId = replacementFilterGroup?.Id,
+                ReplacementLabel = replacementFilterGroup?.Label,
+
+                FilterItemMappings = filterItemMappings,
+                UnmappedReplacementFilterItems = unmappedReplacementItems,
+
+                Status =
+                    replacementGroupLabelToGroupMap == null
+                        ? MapStatus.ParentNotMapped
+                        : (replacementFilterGroup == null ? MapStatus.Unset : MapStatus.AutoSet),
+            };
+
+            filterGroupMappings.Add(filterGroupMapping.OriginalId, filterGroupMapping);
+        }
+
+        // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
+        // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
+        var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
+        if (replacementGroupLabelToGroupMap != null) // if parent filter isn't mapped, no group replacements to refer to
+        {
+            var mappedReplacementGroupIds = filterGroupMappings
+                .Values.Where(m => m.ReplacementId.HasValue)
+                .Select(m => m.ReplacementId!.Value);
+
+            unmappedReplacementGroups = replacementGroupLabelToGroupMap
+                .Values.ExceptBy(mappedReplacementGroupIds, group => group.Id)
+                .Select(group => new UnmappedFilterGroup
+                {
+                    Id = group.Id,
+                    Label = group.Label,
+
+                    UnmappedReplacementFilterItems = group
+                        .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                        .ToList(),
+                })
+                .ToList();
+        }
+
+        return (filterGroupMappings, unmappedReplacementGroups);
+    }
+
+    private static (Dictionary<Guid, FilterItemMapping>, List<UnmappedFilterItem>) GenerateInitialFilterItemMapping(
+        List<FilterItem> originalFilterItems,
+        Dictionary<string, FilterItem>? replacementItemLabelToItemMap
+    )
+    {
+        var filterItemMappings = new Dictionary<Guid, FilterItemMapping>();
+
+        foreach (var originalFilterItem in originalFilterItems)
+        {
+            FilterItem? replacementFilterItem = null;
+            replacementItemLabelToItemMap?.TryGetValue(originalFilterItem.Label, out replacementFilterItem);
+
+            var filterItemMapping = new FilterItemMapping
+            {
+                OriginalId = originalFilterItem.Id,
+                OriginalLabel = originalFilterItem.Label,
+
+                ReplacementId = replacementFilterItem?.Id,
+                ReplacementLabel = replacementFilterItem?.Label,
+
+                Status =
+                    replacementItemLabelToItemMap == null
+                        ? MapStatus.ParentNotMapped
+                        : (replacementFilterItem == null ? MapStatus.Unset : MapStatus.AutoSet),
+            };
+
+            filterItemMappings.Add(filterItemMapping.OriginalId, filterItemMapping);
+        }
+
+        // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
+        // if parent is mapped, we can figure out which replacement items for this group are unmapped
+        var unmappedReplacementItems = new List<UnmappedFilterItem>();
+        if (replacementItemLabelToItemMap != null) // if parent isn't mapped, no replacement so no unmappedReplacementItems
+        {
+            var mappedReplacementItemIds = filterItemMappings
+                .Values.Where(m => m.ReplacementId.HasValue)
+                .Select(m => m.ReplacementId!.Value);
+
+            unmappedReplacementItems = replacementItemLabelToItemMap
+                .Values.ExceptBy(mappedReplacementItemIds, item => item.Id)
+                .Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                .ToList();
+        }
+
+        return (filterItemMappings, unmappedReplacementItems);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260629123643_Ees7279AddFiltersToDataSetMappingsTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260629123643_Ees7279AddFiltersToDataSetMappingsTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,13 +12,15 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629123643_Ees7279AddFiltersToDataSetMappingsTable")]
+    partial class Ees7279AddFiltersToDataSetMappingsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.9")
+                .HasAnnotation("ProductVersion", "8.0.28")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -1620,43 +1623,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("Users", t =>
-                        {
-                            t.HasCheckConstraint("CK_Users_Active_SoftDeleted", "[Active] = 0 OR [SoftDeleted] IS NULL");
-                        });
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserPreReleaseRole", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
-
-                    b.Property<Guid>("CreatedById")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTimeOffset?>("EmailSent")
-                        .HasColumnType("datetimeoffset");
-
-                    b.Property<Guid>("ReleaseVersionId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CreatedById");
-
-                    b.HasIndex("ReleaseVersionId");
-
-                    b.HasIndex("UserId", "ReleaseVersionId")
-                        .IsUnique();
-
-                    b.ToTable("UserPreReleaseRoles");
+                    b.ToTable("Users");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserPublicationRole", b =>
@@ -1665,10 +1632,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("datetime2");
 
-                    b.Property<Guid>("CreatedById")
+                    b.Property<Guid?>("CreatedById")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTimeOffset?>("EmailSent")
@@ -1691,10 +1658,48 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("PublicationId");
 
-                    b.HasIndex("UserId", "PublicationId")
+                    b.HasIndex("UserId", "PublicationId", "Role")
                         .IsUnique();
 
                     b.ToTable("UserPublicationRoles");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserReleaseRole", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("datetime2");
+
+                    b.Property<Guid?>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTimeOffset?>("EmailSent")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<Guid>("ReleaseVersionId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Role")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("nvarchar(20)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedById");
+
+                    b.HasIndex("ReleaseVersionId");
+
+                    b.HasIndex("UserId", "ReleaseVersionId", "Role")
+                        .IsUnique();
+
+                    b.ToTable("UserReleaseRoles");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
@@ -2580,40 +2585,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Navigation("Role");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserPreReleaseRole", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion", "ReleaseVersion")
-                        .WithMany()
-                        .HasForeignKey("ReleaseVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("CreatedBy");
-
-                    b.Navigation("ReleaseVersion");
-
-                    b.Navigation("User");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserPublicationRole", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
                         .WithMany()
                         .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.NoAction);
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
                         .WithMany()
@@ -2630,6 +2607,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Navigation("CreatedBy");
 
                     b.Navigation("Publication");
+
+                    b.Navigation("User");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.UserReleaseRole", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById");
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion", "ReleaseVersion")
+                        .WithMany()
+                        .HasForeignKey("ReleaseVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CreatedBy");
+
+                    b.Navigation("ReleaseVersion");
 
                     b.Navigation("User");
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260629123643_Ees7279AddFiltersToDataSetMappingsTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260629123643_Ees7279AddFiltersToDataSetMappingsTable.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7279AddFiltersToDataSetMappingsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FilterMappings",
+                table: "DataSetMappings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "{}"
+            );
+
+            migrationBuilder.AddColumn<string>(
+                name: "UnmappedReplacementFilters",
+                table: "DataSetMappings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "[]"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "FilterMappings", table: "DataSetMappings");
+
+            migrationBuilder.DropColumn(name: "UnmappedReplacementFilters", table: "DataSetMappings");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -12,7 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
@@ -24,8 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
 public class ReplacementPlanService(
     ContentDbContext contentDbContext,
-    StatisticsDbContext statisticsDbContext,
-    IFilterRepository filterRepository,
     IFootnoteRepository footnoteRepository,
     IDataSetVersionService dataSetVersionService,
     ITimePeriodService timePeriodService,
@@ -119,7 +116,7 @@ public class ReplacementPlanService(
                 var originalSubjectId = originalReleaseFile.File.SubjectId!.Value;
                 var replacementSubjectId = replacementReleaseFile.File.SubjectId!.Value;
 
-                var replacementSubjectMeta = await GetReplacementSubjectMeta(replacementSubjectId);
+                var replacementTimePeriods = await timePeriodService.GetTimePeriods(replacementSubjectId);
 
                 var mapping = await contentDbContext.DataSetMappings.SingleAsync(
                     map =>
@@ -134,110 +131,19 @@ public class ReplacementPlanService(
                     releaseVersionId: releaseVersionId,
                     subjectId: originalSubjectId,
                     mapping,
-                    replacementSubjectMeta
+                    replacementTimePeriods
                 );
                 var footnotes = await ValidateFootnotes(
                     releaseVersionId: releaseVersionId,
                     subjectId: originalSubjectId,
-                    mapping,
-                    replacementSubjectMeta
+                    mapping
                 );
 
                 var apiDataSetVersionPlan = replacementApiDataSetVersion is null
                     ? null
                     : await GetApiVersionPlanViewModel(replacementApiDataSetVersion, cancellationToken);
 
-                var indicatorMappings = mapping.IndicatorMappings.Values.ToDictionary(
-                    map => map.OriginalId,
-                    map => new ReplacementPlanIndicatorMappingViewModel
-                    {
-                        Source = new ReplacementPlanIndicatorViewModel
-                        {
-                            Id = map.OriginalId,
-                            Name = map.OriginalColumnName,
-                            Label = map.OriginalLabel,
-                        },
-                        Type = map.Status.ToString(),
-                        CandidateKey = map.ReplacementId,
-                    }
-                );
-                var indicatorCandidates = mapping // candidates are all possible replacement indicators
-                    .IndicatorMappings.Values.Where(indMap => indMap.ReplacementId != null)
-                    .Select(indMap => new
-                    {
-                        Id = indMap.ReplacementId!.Value,
-                        ColumnName = indMap.ReplacementColumnName!,
-                        Label = indMap.ReplacementLabel!,
-                    })
-                    .Concat(
-                        mapping.UnmappedReplacementIndicators.Select(i => new
-                        {
-                            i.Id,
-                            i.ColumnName,
-                            i.Label,
-                        })
-                    )
-                    .ToDictionary(
-                        i => i.Id,
-                        i => new ReplacementPlanIndicatorViewModel
-                        {
-                            Id = i.Id,
-                            Name = i.ColumnName,
-                            Label = i.Label,
-                        }
-                    );
-                var locationMappings = mapping.LocationMappings.Values.ToDictionary(
-                    map => map.OriginalId,
-                    map => new ReplacementPlanLocationMappingViewModel
-                    {
-                        Source = new ReplacementPlanLocationViewModel
-                        {
-                            Id = map.OriginalId,
-                            Code = map.OriginalCode,
-                            Name = map.OriginalName,
-                        },
-                        Type = map.Status.ToString(),
-                        CandidateKey = map.ReplacementId,
-                    }
-                );
-                var locationCandidates = mapping // candidates are all possible replacement locations
-                    .LocationMappings.Values.Where(l => l.ReplacementId != null)
-                    .Select(l => new
-                    {
-                        Id = l.ReplacementId!.Value,
-                        Code = l.ReplacementCode!,
-                        Name = l.ReplacementName!,
-                    })
-                    .Concat(
-                        mapping.UnmappedReplacementLocations.Select(l => new
-                        {
-                            l.Id,
-                            l.Code,
-                            l.Name,
-                        })
-                    )
-                    .ToDictionary(
-                        l => l.Id,
-                        l => new ReplacementPlanLocationViewModel
-                        {
-                            Id = l.Id,
-                            Code = l.Code,
-                            Name = l.Name,
-                        }
-                    );
-                var mappingPlan = new ReplacementPlanMappingViewModel
-                {
-                    Indicators = new ReplacementPlanIndicatorsMappingViewModel
-                    {
-                        Mappings = indicatorMappings,
-                        Candidates = indicatorCandidates,
-                    },
-                    Locations = new ReplacementPlanLocationMappingsViewModel
-                    {
-                        Mappings = locationMappings,
-                        Candidates = locationCandidates,
-                    },
-                };
+                var mappingPlan = ReplacementPlanMappingViewModel.FromModel(mapping);
 
                 return new DataReplacementPlanViewModel
                 {
@@ -286,25 +192,11 @@ public class ReplacementPlanService(
             );
     }
 
-    private async Task<ReplacementSubjectMeta> GetReplacementSubjectMeta(Guid subjectId)
-    {
-        var filtersIncludingItems = await filterRepository.GetFiltersIncludingItems(subjectId);
-
-        var filters = filtersIncludingItems.ToDictionary(filter => filter.Name, filter => filter);
-
-        var timePeriods = await timePeriodService.GetTimePeriods(subjectId);
-
-        // We don't need to include data about locations or indicators here - DataSetMapping contains the data we require to
-        // validate the replacement
-
-        return new ReplacementSubjectMeta { Filters = filters, TimePeriods = timePeriods };
-    }
-
     private List<DataBlockReplacementPlanViewModel> ValidateDataBlocks(
         Guid releaseVersionId,
         Guid subjectId,
         DataSetMapping mapping,
-        ReplacementSubjectMeta replacementSubjectMeta
+        IList<(int Year, TimeIdentifier TimeIdentifier)> replacementTimePeriods
     )
     {
         return contentDbContext
@@ -314,17 +206,21 @@ public class ReplacementPlanService(
             .Where(dataBlock => dataBlock.Query.SubjectId == subjectId)
             .Select(dataBlock =>
             {
-                var existingFilters = ValidateFiltersForDataBlock(dataBlock, replacementSubjectMeta);
-                var newlyIntroducedFilters = FindNewlyIntroducedFiltersForDataBlock(dataBlock, replacementSubjectMeta);
-                var indicatorGroups = CreateIndicatorGroupReplacementViewModel(dataBlock.Query.Indicators, mapping);
-                var locations = ValidateLocationsForDataBlock(dataBlock.Query.LocationIds, mapping);
-                var timePeriods = ValidateTimePeriodsForDataBlock(dataBlock, replacementSubjectMeta);
+                var existingFilters = ValidateFiltersForDataBlock(
+                    dataBlock.Query.GetFilterItemIds().ToHashSet(),
+                    mapping
+                );
+                var indicatorGroups = CreateIndicatorGroupReplacementViewModel(
+                    dataBlock.Query.Indicators.ToHashSet(),
+                    mapping
+                );
+                var locations = ValidateLocationsForDataBlock(dataBlock.Query.LocationIds.ToHashSet(), mapping);
+                var timePeriods = ValidateTimePeriodsForDataBlock(dataBlock, replacementTimePeriods);
 
                 return new DataBlockReplacementPlanViewModel(
                     dataBlock.Id,
                     dataBlock.Name,
                     existingFilters,
-                    newlyIntroducedFilters,
                     indicatorGroups,
                     locations,
                     timePeriods
@@ -336,25 +232,20 @@ public class ReplacementPlanService(
     private async Task<List<FootnoteReplacementPlanViewModel>> ValidateFootnotes(
         Guid releaseVersionId,
         Guid subjectId,
-        DataSetMapping mapping,
-        ReplacementSubjectMeta replacementSubjectMeta
-    )
-    {
-        var footnotes = await footnoteRepository.GetFootnotes(releaseVersionId: releaseVersionId, subjectId: subjectId);
-        return footnotes.Select(footnote => ValidateFootnote(footnote, replacementSubjectMeta, mapping)).ToList();
-    }
-
-    private static FootnoteReplacementPlanViewModel ValidateFootnote(
-        Footnote footnote,
-        ReplacementSubjectMeta replacementSubjectMeta,
         DataSetMapping mapping
     )
     {
-        var filters = ValidateFiltersForFootnote(footnote, replacementSubjectMeta);
-        var filterGroups = ValidateFilterGroupsForFootnote(footnote, replacementSubjectMeta);
-        var filterItems = ValidateFilterItemsForFootnote(footnote, replacementSubjectMeta);
+        var footnotes = await footnoteRepository.GetFootnotes(releaseVersionId: releaseVersionId, subjectId: subjectId);
+        return footnotes.Select(footnote => ValidateFootnote(footnote, mapping)).ToList();
+    }
+
+    private static FootnoteReplacementPlanViewModel ValidateFootnote(Footnote footnote, DataSetMapping mapping)
+    {
+        var filters = ValidateFiltersForFootnote(footnote, mapping);
+        var filterGroups = ValidateFilterGroupsForFootnote(footnote, mapping);
+        var filterItems = ValidateFilterItemsForFootnote(footnote, mapping);
         var indicatorGroups = CreateIndicatorGroupReplacementViewModel(
-            footnote.Indicators.Select(indFootnote => indFootnote.IndicatorId),
+            footnote.Indicators.Select(indFootnote => indFootnote.IndicatorId).ToHashSet(),
             mapping
         );
 
@@ -370,154 +261,127 @@ public class ReplacementPlanService(
 
     private static List<FootnoteFilterReplacementViewModel> ValidateFiltersForFootnote(
         Footnote footnote,
-        ReplacementSubjectMeta replacementSubjectMeta
+        DataSetMapping mapping
     )
     {
-        return footnote
-            .Filters.Select(filterFootnote => filterFootnote.Filter)
-            .OrderBy(filter => filter.Label, LabelComparer)
-            .Select(filter => new FootnoteFilterReplacementViewModel(
-                id: filter.Id,
-                label: filter.Label,
-                target: FindReplacementFilter(replacementSubjectMeta, filter.Name)?.Id
+        var footnoteFilterIds = footnote.Filters.Select(f => f.FilterId).ToHashSet();
+
+        return mapping
+            .FilterMappings.Values.Where(filterMap => footnoteFilterIds.Contains(filterMap.OriginalId))
+            .Select(filterMap => new FootnoteFilterReplacementViewModel(
+                id: filterMap.OriginalId,
+                label: filterMap.OriginalLabel,
+                target: filterMap.ReplacementId
             ))
+            .OrderBy(f => f.Label, LabelComparer)
             .ToList();
     }
 
     private static List<FootnoteFilterGroupReplacementViewModel> ValidateFilterGroupsForFootnote(
         Footnote footnote,
-        ReplacementSubjectMeta replacementSubjectMeta
+        DataSetMapping mapping
     )
     {
-        return footnote
-            .FilterGroups.Select(filterGroupFootnote => filterGroupFootnote.FilterGroup)
-            .OrderBy(filterGroup => filterGroup.Label, LabelComparer)
-            .Select(filterGroup => new FootnoteFilterGroupReplacementViewModel(
-                id: filterGroup.Id,
-                label: filterGroup.Label,
-                filterId: filterGroup.FilterId,
-                filterLabel: filterGroup.Filter.Label,
-                target: FindReplacementFilterGroup(
-                    replacementSubjectMeta,
-                    filterGroup.Filter.Name,
-                    filterGroup.Label
-                )?.Id
+        var footnoteFilterGroupIds = footnote.FilterGroups.Select(g => g.FilterGroupId).ToHashSet();
+        return mapping
+            .FilterMappings.Values.SelectMany(
+                filterMap => filterMap.FilterGroupMappings.Values,
+                (filterMap, groupMap) => new { Filter = filterMap, FilterGroup = groupMap }
+            )
+            .Where(pair => footnoteFilterGroupIds.Contains(pair.FilterGroup.OriginalId))
+            .Select(pair => new FootnoteFilterGroupReplacementViewModel(
+                id: pair.FilterGroup.OriginalId,
+                label: pair.FilterGroup.OriginalLabel,
+                filterId: pair.Filter.OriginalId,
+                filterLabel: pair.Filter.OriginalLabel,
+                target: pair.FilterGroup.ReplacementId
             ))
+            .OrderBy(f => f.Label, LabelComparer)
             .ToList();
     }
 
     private static List<FootnoteFilterItemReplacementViewModel> ValidateFilterItemsForFootnote(
         Footnote footnote,
-        ReplacementSubjectMeta replacementSubjectMeta
+        DataSetMapping mapping
     )
     {
-        return footnote
-            .FilterItems.Select(filterItemFootnote => filterItemFootnote.FilterItem)
-            .OrderBy(filterItem => filterItem.Label, LabelComparer)
-            .Select(filterItem => new FootnoteFilterItemReplacementViewModel(
-                id: filterItem.Id,
-                label: filterItem.Label,
-                filterId: filterItem.FilterGroup.FilterId,
-                filterLabel: filterItem.FilterGroup.Filter.Label,
-                filterGroupId: filterItem.FilterGroupId,
-                filterGroupLabel: filterItem.FilterGroup.Label,
-                target: FindReplacementFilterItem(
-                    replacementSubjectMeta,
-                    filterItem.FilterGroup.Filter.Name,
-                    filterItem.FilterGroup.Label,
-                    filterItem.Label
-                )?.Id
+        var footnoteFilterItemIds = footnote.FilterItems.Select(f => f.FilterItemId).ToHashSet();
+        return mapping
+            .FilterMappings.Values.SelectMany(
+                filterMap => filterMap.FilterGroupMappings.Values,
+                (filterMap, groupMap) => new { Filter = filterMap, FilterGroup = groupMap }
+            )
+            .SelectMany(
+                pair => pair.FilterGroup.FilterItemMappings.Values,
+                (pair, itemMap) =>
+                    new
+                    {
+                        pair.Filter,
+                        pair.FilterGroup,
+                        FilterItem = itemMap,
+                    }
+            )
+            .Where(trio => footnoteFilterItemIds.Contains(trio.FilterItem.OriginalId))
+            .Select(trio => new FootnoteFilterItemReplacementViewModel(
+                id: trio.FilterItem.OriginalId,
+                label: trio.FilterItem.OriginalLabel,
+                filterId: trio.Filter.OriginalId,
+                filterLabel: trio.Filter.OriginalLabel,
+                filterGroupId: trio.FilterGroup.OriginalId,
+                filterGroupLabel: trio.FilterGroup.OriginalLabel,
+                target: trio.FilterItem.ReplacementId
             ))
             .ToList();
     }
 
-    private List<FilterReplacementViewModel> FindNewlyIntroducedFiltersForDataBlock(
-        DataBlock dataBlock,
-        ReplacementSubjectMeta replacementSubjectMeta
+    private static Dictionary<Guid, FilterReplacementViewModel> ValidateFiltersForDataBlock(
+        HashSet<Guid> dataBlockFilterItemIds,
+        DataSetMapping mapping
     )
     {
-        var existingFilterItemIds = dataBlock.Query.GetFilterItemIds();
-
-        var existingFilterNames = statisticsDbContext
-            .FilterItem.AsQueryable()
-            .Where(fi => existingFilterItemIds.Contains(fi.Id))
-            .Select(fi => fi.FilterGroup.Filter)
-            .Select(f => f.Name)
-            .Distinct()
-            .ToList();
-
-        return replacementSubjectMeta
-            .Filters.Select(d => d.Value)
-            .ToList()
-            .Where(f => !existingFilterNames.Contains(f.Name))
-            .Select(CreateNewlyIntroducedFilterReplacementViewModel)
-            .ToList();
-    }
-
-    private static FilterReplacementViewModel CreateNewlyIntroducedFilterReplacementViewModel(Filter filter)
-    {
-        var filterGroupReplacementViewModels = filter
-            .FilterGroups.Select(fg => new FilterGroupReplacementViewModel(
-                fg.Id,
-                fg.Label,
-                fg.FilterItems.Select(fi => new FilterItemReplacementViewModel(fi.Id, fi.Label, null))
-            ))
-            .ToDictionary(f => f.Id);
-
-        return new FilterReplacementViewModel(
-            filter.Id,
-            target: null, // null because this a new filter, therefore not replacing any existing filter
-            filter.Label,
-            filter.Name,
-            filterGroupReplacementViewModels
-        );
-    }
-
-    private Dictionary<Guid, FilterReplacementViewModel> ValidateFiltersForDataBlock(
-        DataBlock dataBlock,
-        ReplacementSubjectMeta replacementSubjectMeta
-    )
-    {
-        return statisticsDbContext
-            .FilterItem.AsQueryable()
-            .Where(filterItem => dataBlock.Query.GetFilterItemIds().Contains(filterItem.Id))
-            .Include(filterItem => filterItem.FilterGroup)
-                .ThenInclude(filterGroup => filterGroup.Filter)
-            .ToList()
-            .GroupBy(filterItem => filterItem.FilterGroup.Filter)
-            .OrderBy(filter => filter.Key.Label, LabelComparer)
+        return mapping
+            .FilterMappings.Values.Where(filterMap =>
+                filterMap
+                    .FilterGroupMappings.Values.SelectMany(groupMap => groupMap.FilterItemMappings.Values)
+                    .Select(item => item.OriginalId)
+                    .Any(dataBlockFilterItemIds.Contains)
+            )
             .ToDictionary(
-                filter => filter.Key.Id,
-                filter =>
-                {
-                    return new FilterReplacementViewModel(
-                        id: filter.Key.Id,
-                        target: FindReplacementFilter(replacementSubjectMeta, filter.Key.Name)?.Id,
-                        name: filter.Key.Name,
-                        label: filter.Key.Label,
-                        groups: filter
-                            .GroupBy(filterItem => filterItem.FilterGroup)
-                            .OrderBy(group => group.Key.Label, LabelComparer)
-                            .ToDictionary(
-                                group => group.Key.Id,
-                                group =>
-                                    ValidateFilterGroupForReplacement(
-                                        new FilterGroup
-                                        {
-                                            Id = group.Key.Id,
-                                            Label = group.Key.Label,
-                                            FilterItems = group.Key.FilterItems.Intersect(filter).ToList(),
-                                        },
-                                        replacementSubjectMeta
+                filterMap => filterMap.OriginalId,
+                filterMap => new FilterReplacementViewModel(
+                    id: filterMap.OriginalId,
+                    name: filterMap.OriginalColumnName,
+                    label: filterMap.OriginalLabel,
+                    target: filterMap.ReplacementId,
+                    groups: filterMap
+                        .FilterGroupMappings.Values.Where(groupMap =>
+                            groupMap
+                                .FilterItemMappings.Values.Select(item => item.OriginalId)
+                                .Any(dataBlockFilterItemIds.Contains)
+                        )
+                        .ToDictionary(
+                            groupMap => groupMap.OriginalId,
+                            groupMap => new FilterGroupReplacementViewModel(
+                                id: groupMap.OriginalId,
+                                label: groupMap.OriginalLabel,
+                                target: groupMap.ReplacementId,
+                                filters: groupMap
+                                    .FilterItemMappings.Values.Where(itemMap =>
+                                        dataBlockFilterItemIds.Contains(itemMap.OriginalId)
                                     )
+                                    .Select(itemMap => new FilterItemReplacementViewModel(
+                                        id: itemMap.OriginalId,
+                                        label: itemMap.OriginalLabel,
+                                        target: itemMap.ReplacementId
+                                    ))
                             )
-                    );
-                }
+                        )
+                )
             );
     }
 
-    private Dictionary<string, LocationReplacementViewModel> ValidateLocationsForDataBlock(
-        List<Guid> dataBlockLocationIds,
+    private static Dictionary<string, LocationReplacementViewModel> ValidateLocationsForDataBlock(
+        HashSet<Guid> dataBlockLocationIds,
         DataSetMapping mapping
     )
     {
@@ -542,19 +406,19 @@ public class ReplacementPlanService(
 
     private static TimePeriodRangeReplacementViewModel ValidateTimePeriodsForDataBlock(
         DataBlock dataBlock,
-        ReplacementSubjectMeta replacementSubjectMeta
+        IList<(int Year, TimeIdentifier TimeIdentifier)> replacementTimePeriods
     )
     {
         return new TimePeriodRangeReplacementViewModel(
             start: ValidateTimePeriodForReplacement(
                 dataBlock.Query.TimePeriod!.StartYear,
                 dataBlock.Query.TimePeriod.StartCode,
-                replacementSubjectMeta
+                replacementTimePeriods
             ),
             end: ValidateTimePeriodForReplacement(
                 dataBlock.Query.TimePeriod.EndYear,
                 dataBlock.Query.TimePeriod.EndCode,
-                replacementSubjectMeta
+                replacementTimePeriods
             )
         );
     }
@@ -562,49 +426,18 @@ public class ReplacementPlanService(
     private static TimePeriodReplacementViewModel ValidateTimePeriodForReplacement(
         int year,
         TimeIdentifier code,
-        ReplacementSubjectMeta replacementSubjectMeta
+        IList<(int Year, TimeIdentifier TimeIdentifier)> replacementTimePeriods
     )
     {
         return new TimePeriodReplacementViewModel(
             year: year,
             code: code,
-            valid: replacementSubjectMeta.TimePeriods.Contains((year, code))
-        );
-    }
-
-    private static FilterGroupReplacementViewModel ValidateFilterGroupForReplacement(
-        FilterGroup filterGroup,
-        ReplacementSubjectMeta replacementSubjectMeta
-    )
-    {
-        return new FilterGroupReplacementViewModel(
-            id: filterGroup.Id,
-            label: filterGroup.Label,
-            filters: filterGroup
-                .FilterItems.Select(item => ValidateFilterItemForReplacement(item, replacementSubjectMeta))
-                .OrderBy(item => item.Label, LabelComparer)
-        );
-    }
-
-    private static FilterItemReplacementViewModel ValidateFilterItemForReplacement(
-        FilterItem filterItem,
-        ReplacementSubjectMeta replacementSubjectMeta
-    )
-    {
-        return new FilterItemReplacementViewModel(
-            id: filterItem.Id,
-            label: filterItem.Label,
-            target: FindReplacementFilterItem(
-                replacementSubjectMeta,
-                filterItem.FilterGroup.Filter.Name,
-                filterItem.FilterGroup.Label,
-                filterItem.Label
-            )?.Id
+            valid: replacementTimePeriods.Contains((year, code))
         );
     }
 
     private static Dictionary<Guid, IndicatorGroupReplacementViewModel> CreateIndicatorGroupReplacementViewModel(
-        IEnumerable<Guid> indicatorIds,
+        HashSet<Guid> indicatorIds,
         DataSetMapping mapping
     )
     {
@@ -627,37 +460,5 @@ public class ReplacementPlanService(
                         ))
                 )
             );
-    }
-
-    private static Filter? FindReplacementFilter(ReplacementSubjectMeta replacementSubjectMeta, string filterName)
-    {
-        return replacementSubjectMeta.Filters.GetValueOrDefault(filterName);
-    }
-
-    private static FilterGroup? FindReplacementFilterGroup(
-        ReplacementSubjectMeta replacementSubjectMeta,
-        string filterName,
-        string filterGroupLabel
-    )
-    {
-        var replacementFilter = FindReplacementFilter(replacementSubjectMeta, filterName);
-        return replacementFilter?.FilterGroups.SingleOrDefault(filterGroup => filterGroup.Label == filterGroupLabel);
-    }
-
-    private static FilterItem? FindReplacementFilterItem(
-        ReplacementSubjectMeta replacementSubjectMeta,
-        string filterName,
-        string filterGroupLabel,
-        string filterItemLabel
-    )
-    {
-        var replacementFilterGroup = FindReplacementFilterGroup(replacementSubjectMeta, filterName, filterGroupLabel);
-        return replacementFilterGroup?.FilterItems.SingleOrDefault(filterItem => filterItem.Label == filterItemLabel);
-    }
-
-    private class ReplacementSubjectMeta
-    {
-        public Dictionary<string, Filter> Filters { get; set; } = new();
-        public IList<(int Year, TimeIdentifier TimeIdentifier)> TimePeriods { get; set; } = null!;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -334,50 +334,92 @@ public class ReplacementPlanService(
             .ToList();
     }
 
+    // Returns only items (and their parent group/filter) that are included in the data block
     private static Dictionary<Guid, FilterReplacementViewModel> ValidateFiltersForDataBlock(
         HashSet<Guid> dataBlockFilterItemIds,
         DataSetMapping mapping
     )
     {
-        return mapping
-            .FilterMappings.Values.Where(filterMap =>
-                filterMap
-                    .FilterGroupMappings.Values.SelectMany(groupMap => groupMap.FilterItemMappings.Values)
-                    .Select(item => item.OriginalId)
-                    .Any(dataBlockFilterItemIds.Contains)
-            )
-            .ToDictionary(
-                filterMap => filterMap.OriginalId,
-                filterMap => new FilterReplacementViewModel(
-                    id: filterMap.OriginalId,
-                    name: filterMap.OriginalColumnName,
-                    label: filterMap.OriginalLabel,
-                    target: filterMap.ReplacementId,
-                    groups: filterMap
-                        .FilterGroupMappings.Values.Where(groupMap =>
-                            groupMap
-                                .FilterItemMappings.Values.Select(item => item.OriginalId)
-                                .Any(dataBlockFilterItemIds.Contains)
-                        )
-                        .ToDictionary(
-                            groupMap => groupMap.OriginalId,
-                            groupMap => new FilterGroupReplacementViewModel(
-                                id: groupMap.OriginalId,
-                                label: groupMap.OriginalLabel,
-                                target: groupMap.ReplacementId,
-                                items: groupMap
-                                    .FilterItemMappings.Values.Where(itemMap =>
-                                        dataBlockFilterItemIds.Contains(itemMap.OriginalId)
-                                    )
-                                    .Select(itemMap => new FilterItemReplacementViewModel(
-                                        id: itemMap.OriginalId,
-                                        label: itemMap.OriginalLabel,
-                                        target: itemMap.ReplacementId
-                                    ))
-                            )
-                        )
-                )
+        var result = new Dictionary<Guid, FilterReplacementViewModel>();
+
+        foreach (var filterMap in mapping.FilterMappings.Values)
+        {
+            var groupViewModels = ValidateFilterGroupsForDataBlock(
+                dataBlockFilterItemIds,
+                filterMap.FilterGroupMappings
             );
+
+            if (groupViewModels.Count > 0)
+            {
+                result.Add(
+                    filterMap.OriginalId,
+                    new FilterReplacementViewModel(
+                        id: filterMap.OriginalId,
+                        target: filterMap.ReplacementId,
+                        label: filterMap.OriginalLabel,
+                        name: filterMap.OriginalColumnName,
+                        groups: groupViewModels
+                    )
+                );
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<Guid, FilterGroupReplacementViewModel> ValidateFilterGroupsForDataBlock(
+        HashSet<Guid> dataBlockFilterItemIds,
+        Dictionary<Guid, FilterGroupMapping> filterGroupMappings
+    )
+    {
+        var groupViewModels = new Dictionary<Guid, FilterGroupReplacementViewModel>();
+
+        foreach (var groupMap in filterGroupMappings)
+        {
+            var itemViewModels = ValidateFilterItemsForDataBlock(
+                dataBlockFilterItemIds,
+                groupMap.Value.FilterItemMappings
+            );
+
+            if (itemViewModels.Count > 0)
+            {
+                groupViewModels.Add(
+                    groupMap.Value.OriginalId,
+                    new FilterGroupReplacementViewModel(
+                        groupMap.Value.OriginalId,
+                        groupMap.Value.OriginalLabel,
+                        groupMap.Value.ReplacementId,
+                        itemViewModels
+                    )
+                );
+            }
+        }
+
+        return groupViewModels;
+    }
+
+    private static List<FilterItemReplacementViewModel> ValidateFilterItemsForDataBlock(
+        HashSet<Guid> dataBlockFilterItemIds,
+        Dictionary<Guid, FilterItemMapping> filterItemMappings
+    )
+    {
+        var itemViewModels = new List<FilterItemReplacementViewModel>();
+
+        foreach (var itemMap in filterItemMappings)
+        {
+            if (dataBlockFilterItemIds.Contains(itemMap.Value.OriginalId))
+            {
+                itemViewModels.Add(
+                    new FilterItemReplacementViewModel(
+                        itemMap.Value.OriginalId,
+                        itemMap.Value.OriginalLabel,
+                        itemMap.Value.ReplacementId
+                    )
+                );
+            }
+        }
+
+        return itemViewModels;
     }
 
     private static Dictionary<string, LocationReplacementViewModel> ValidateLocationsForDataBlock(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -365,7 +365,7 @@ public class ReplacementPlanService(
                                 id: groupMap.OriginalId,
                                 label: groupMap.OriginalLabel,
                                 target: groupMap.ReplacementId,
-                                filters: groupMap
+                                items: groupMap
                                     .FilterItemMappings.Values.Where(itemMap =>
                                         dataBlockFilterItemIds.Contains(itemMap.OriginalId)
                                     )

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -25,7 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 public class ReplacementService(
     ContentDbContext contentDbContext,
     StatisticsDbContext statisticsDbContext,
-    IFilterRepository filterRepository,
     IReleaseVersionService releaseVersionService,
     IReleaseFileRepository releaseFileRepository,
     IReplacementPlanService replacementPlanService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -160,7 +160,7 @@ public class ReplacementService(
             .Filters.Where(plan => plan.Value.Target != null)
             .ToDictionary(plan => plan.Value.Id, plan => plan.Value.Target!.Value);
         var filterItemTargets = replacementPlan
-            .Filters.SelectMany(filter => filter.Value.Groups.SelectMany(group => group.Value.Filters))
+            .Filters.SelectMany(filter => filter.Value.Groups.SelectMany(group => group.Value.Items))
             .ToDictionary(ReplacementPlanOriginalId, ReplacementPlanTargetId);
         var indicatorTargets = replacementPlan
             .IndicatorGroups.SelectMany(group => group.Value.Indicators)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -12,7 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -120,10 +120,7 @@ public class ReplacementService(
                     && mapping.ReplacementDataFileId == replacementReleaseFile.FileId
                 );
 
-                replacementReleaseFile.FilterSequence = await ReplaceFilterSequence(
-                    originalReleaseFile,
-                    replacementReleaseFile
-                );
+                replacementReleaseFile.FilterSequence = ReplaceFilterSequence(originalReleaseFile, mapping);
                 replacementReleaseFile.IndicatorSequence = ReplaceIndicatorSequence(originalReleaseFile, mapping);
                 replacementReleaseFile.Summary = originalReleaseFile.Summary; // Set Data guidance
 
@@ -642,9 +639,9 @@ public class ReplacementService(
         );
     }
 
-    private async Task<List<FilterSequenceEntry>?> ReplaceFilterSequence(
+    private static List<FilterSequenceEntry>? ReplaceFilterSequence(
         ReleaseFile originalReleaseFile,
-        ReleaseFile replacementReleaseFile
+        DataSetMapping mapping
     )
     {
         // If the sequence is null then leave it so we continue to fallback to ordering by label alphabetically
@@ -653,17 +650,9 @@ public class ReplacementService(
             return null;
         }
 
-        var originalFilters = await filterRepository.GetFiltersIncludingItems(
-            originalReleaseFile.File.SubjectId!.Value
-        );
-        var replacementFilters = await filterRepository.GetFiltersIncludingItems(
-            replacementReleaseFile.File.SubjectId!.Value
-        );
-
         return ReplacementServiceHelper.ReplaceFilterSequence(
-            originalFilters: originalFilters,
-            replacementFilters: replacementFilters,
-            originalReleaseFile
+            originalSequence: originalReleaseFile.FilterSequence,
+            mapping: mapping
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -14,7 +14,7 @@ public abstract class ReplacementServiceHelper
         DataSetMapping mapping
     )
     {
-        // Replace filters that have been mapped
+        // 1. Add mapped replacement filters
         var replacementSequence = new List<FilterSequenceEntry>();
         var filterIdsWithMapping = mapping
             .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -9,7 +9,7 @@ public abstract class ReplacementServiceHelper
 {
     private static IComparer<string> LabelComparer { get; } = new LabelRelationalComparer();
 
-    public static List<FilterSequenceEntry>? ReplaceFilterSequence(
+    public static List<FilterSequenceEntry> ReplaceFilterSequence(
         List<FilterSequenceEntry> originalSequence,
         DataSetMapping mapping
     )

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -1,9 +1,7 @@
 ﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
@@ -12,170 +10,126 @@ public abstract class ReplacementServiceHelper
     private static IComparer<string> LabelComparer { get; } = new LabelRelationalComparer();
 
     public static List<FilterSequenceEntry>? ReplaceFilterSequence(
-        List<Filter> originalFilters,
-        List<Filter> replacementFilters,
-        ReleaseFile originalReleaseFile
+        List<FilterSequenceEntry> originalSequence,
+        DataSetMapping mapping
     )
     {
-        // If the sequence is undefined then leave it so we continue to fallback to ordering by label alphabetically
-        if (originalReleaseFile.FilterSequence == null)
+        // Replace filters that have been mapped
+        var replacementSequence = new List<FilterSequenceEntry>();
+        var filterIdsWithMapping = mapping
+            .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
+            .Select(filterMap => filterMap.OriginalId)
+            .ToHashSet();
+        foreach (var filterSequenceEntry in originalSequence)
         {
-            return null;
-        }
-
-        var originalFiltersLabelMap = originalFilters.ToDictionary(filter => filter.Name, filter => filter);
-
-        // Step 1: Create id to replacement-id maps and work out newly added filters, filter groups and filter items
-
-        var filtersMap = new Dictionary<Guid, Guid>();
-        var filterGroupsMap = new Dictionary<Guid, Guid>();
-        var filterItemsMap = new Dictionary<Guid, Guid>();
-        var newlyAddedFilters = new List<Filter>();
-        var newlyAddedFilterGroups = new Dictionary<Guid, List<FilterGroup>>();
-        var newlyAddedFilterItems = new Dictionary<Guid, List<FilterItem>>();
-
-        replacementFilters.ForEach(replacementFilter =>
-        {
-            if (originalFiltersLabelMap.TryGetValue(replacementFilter.Name, out var originalFilter))
+            if (filterIdsWithMapping.Contains(filterSequenceEntry.Id))
             {
-                filtersMap.Add(originalFilter.Id, replacementFilter.Id);
-                var originalFilterGroupsLabelMap = originalFilter.FilterGroups.ToDictionary(fg => fg.Label);
-                replacementFilter.FilterGroups.ForEach(replacementFilterGroup =>
-                {
-                    if (
-                        originalFilterGroupsLabelMap.TryGetValue(
-                            replacementFilterGroup.Label,
-                            out var originalFilterGroup
-                        )
-                    )
-                    {
-                        filterGroupsMap.Add(originalFilterGroup.Id, replacementFilterGroup.Id);
-                        var originalFilterItemsLabelMap = originalFilterGroup.FilterItems.ToDictionary(fi => fi.Label);
-                        replacementFilterGroup.FilterItems.ForEach(replacementFilterItem =>
-                        {
-                            if (
-                                originalFilterItemsLabelMap.TryGetValue(
-                                    replacementFilterItem.Label,
-                                    out var originalFilterItem
-                                )
-                            )
-                            {
-                                filterItemsMap.Add(originalFilterItem.Id, replacementFilterItem.Id);
-                            }
-                            else
-                            {
-                                if (
-                                    newlyAddedFilterItems.TryGetValue(
-                                        originalFilterGroup.Id,
-                                        out var newlyAddedFilterItemList
-                                    )
-                                )
-                                {
-                                    newlyAddedFilterItemList.Add(replacementFilterItem);
-                                }
-                                else
-                                {
-                                    newlyAddedFilterItems.Add(originalFilterGroup.Id, ListOf(replacementFilterItem));
-                                }
-                            }
-                        });
-                    }
-                    else
-                    {
-                        if (newlyAddedFilterGroups.TryGetValue(originalFilter.Id, out var newlyAddedFilterGroupList))
-                        {
-                            newlyAddedFilterGroupList.Add(replacementFilterGroup);
-                        }
-                        else
-                        {
-                            newlyAddedFilterGroups.Add(originalFilter.Id, ListOf(replacementFilterGroup));
-                        }
-                    }
-                });
-            }
-            else
-            {
-                newlyAddedFilters.Add(replacementFilter);
-            }
-        });
-
-        // Step 2: Create a new sequence based on the original:
-        // - Remove any entries that don't exist in the replacement
-        // - Swap the remaining id's with their replacements
-        // - Append new entries that were added in the replacement
-
-        var filterSequence = originalReleaseFile
-            .FilterSequence.Where(filter => filtersMap.ContainsKey(filter.Id))
-            .Select(filter =>
-            {
-                var newFilterSequenceEntry = new FilterSequenceEntry(
-                    filtersMap[filter.Id],
-                    filter
-                        .ChildSequence.Where(filterGroup => filterGroupsMap.ContainsKey(filterGroup.Id))
-                        .Select(filterGroup =>
-                        {
-                            var newFilterGroupSequenceEntry = new FilterGroupSequenceEntry(
-                                filterGroupsMap[filterGroup.Id],
-                                filterGroup
-                                    .ChildSequence.Where(filterItem => filterItemsMap.ContainsKey(filterItem))
-                                    .Select(filterItem => filterItemsMap[filterItem])
-                                    .ToList()
-                            );
-
-                            if (newlyAddedFilterItems.TryGetValue(filterGroup.Id, out var newlyAddedFilterItemList))
-                            {
-                                newFilterGroupSequenceEntry.ChildSequence.AddRange(
-                                    newlyAddedFilterItemList
-                                        .OrderBy(fi => !IsTotal(fi.Label))
-                                        .ThenBy(fi => fi.Label, LabelComparer)
-                                        .Select(fi => fi.Id)
-                                );
-                            }
-
-                            return newFilterGroupSequenceEntry;
-                        })
-                        .ToList()
+                var replacementGroupSequence = GenerateReplacementGroupSequence(
+                    mapping.FilterMappings[filterSequenceEntry.Id],
+                    filterSequenceEntry
                 );
 
-                if (newlyAddedFilterGroups.TryGetValue(filter.Id, out var newlyAddedFilterGroupList))
-                {
-                    newFilterSequenceEntry.ChildSequence.AddRange(
-                        newlyAddedFilterGroupList
-                            .OrderBy(fg => !IsTotal(fg.Label))
-                            .ThenBy(fg => fg.Label, LabelComparer)
-                            .Select(fg => new FilterGroupSequenceEntry(
-                                fg.Id,
-                                fg.FilterItems.OrderBy(fi => !IsTotal(fi.Label))
-                                    .ThenBy(fi => fi.Label, LabelComparer)
-                                    .Select(fi => fi.Id)
-                                    .ToList()
-                            ))
-                    );
-                }
+                replacementSequence.Add(
+                    new FilterSequenceEntry(
+                        Id: mapping.FilterMappings[filterSequenceEntry.Id].ReplacementId!.Value,
+                        FilterGroupSequence: replacementGroupSequence
+                    )
+                );
+            }
+        }
 
-                return newFilterSequenceEntry;
-            })
-            .ToList();
-
-        filterSequence.AddRange(
-            newlyAddedFilters
-                .OrderBy(f => f.Label, LabelComparer)
-                .Select(f => new FilterSequenceEntry(
-                    f.Id,
-                    f.FilterGroups.OrderBy(fg => !IsTotal(fg.Label))
-                        .ThenBy(fg => fg.Label, LabelComparer)
-                        .Select(fg => new FilterGroupSequenceEntry(
-                            fg.Id,
-                            fg.FilterItems.OrderBy(fi => !IsTotal(fi.Label))
-                                .ThenBy(fi => fi.Label, LabelComparer)
-                                .Select(fi => fi.Id)
+        // 2. Add unmapped replacement filters
+        replacementSequence.AddRange(
+            mapping
+                .UnmappedReplacementFilters.OrderBy(unmappedFilter => unmappedFilter.Label, LabelComparer)
+                .Select(unmappedFilter => new FilterSequenceEntry(
+                    Id: unmappedFilter.Id,
+                    FilterGroupSequence: unmappedFilter
+                        .UnmappedReplacementFilterGroups.OrderBy(unmappedGroup => unmappedGroup.Label, LabelComparer)
+                        .Select(unmappedGroup => new FilterGroupSequenceEntry(
+                            Id: unmappedGroup.Id,
+                            FilterItemSequence: unmappedGroup
+                                .UnmappedReplacementFilterItems.OrderBy(
+                                    unmappedItem => unmappedItem.Label,
+                                    LabelComparer
+                                )
+                                .Select(unmappedItem => unmappedItem.Id)
                                 .ToList()
                         ))
                         .ToList()
                 ))
         );
 
-        return filterSequence;
+        return replacementSequence;
+    }
+
+    private static List<FilterGroupSequenceEntry> GenerateReplacementGroupSequence(
+        FilterMapping filterMapping,
+        FilterSequenceEntry originalFilterSequenceEntry
+    )
+    {
+        var replacementGroupSequence = new List<FilterGroupSequenceEntry>();
+        var groupIdsWithMapping = filterMapping
+            .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
+            .Select(groupMap => groupMap.OriginalId)
+            .ToHashSet();
+        foreach (var groupSequenceEntry in originalFilterSequenceEntry.FilterGroupSequence)
+        {
+            if (groupIdsWithMapping.Contains(groupSequenceEntry.Id))
+            {
+                var replacementItemSequence = GenerateReplacementItemSequence(
+                    filterMapping.FilterGroupMappings[groupSequenceEntry.Id],
+                    groupSequenceEntry
+                );
+
+                replacementGroupSequence.Add(
+                    new FilterGroupSequenceEntry(
+                        Id: filterMapping.FilterGroupMappings[groupSequenceEntry.Id].ReplacementId!.Value,
+                        FilterItemSequence: replacementItemSequence
+                    )
+                );
+            }
+        }
+
+        replacementGroupSequence.AddRange(
+            filterMapping
+                .UnmappedReplacementFilterGroups.OrderBy(unmappedGroup => unmappedGroup.Label)
+                .Select(unmappedGroup => new FilterGroupSequenceEntry(
+                    Id: unmappedGroup.Id,
+                    FilterItemSequence: unmappedGroup
+                        .UnmappedReplacementFilterItems.OrderBy(unmappedItem => unmappedItem.Label)
+                        .Select(unmappedItem => unmappedItem.Id)
+                        .ToList()
+                ))
+        );
+
+        return replacementGroupSequence;
+    }
+
+    private static List<Guid> GenerateReplacementItemSequence(
+        FilterGroupMapping groupMapping,
+        FilterGroupSequenceEntry originalGroupSequenceEntry
+    )
+    {
+        var replacementItemSequence = new List<Guid>();
+        var itemIdsWithMapping = groupMapping
+            .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
+            .Select(itemMap => itemMap.OriginalId)
+            .ToHashSet();
+
+        foreach (var sequenceItemId in originalGroupSequenceEntry.FilterItemSequence)
+        {
+            if (itemIdsWithMapping.Contains(sequenceItemId))
+            {
+                replacementItemSequence.Add(groupMapping.FilterItemMappings[sequenceItemId].ReplacementId!.Value);
+            }
+        }
+
+        replacementItemSequence.AddRange(
+            groupMapping.UnmappedReplacementFilterItems.Select(unmappedItem => unmappedItem.Id)
+        );
+
+        return replacementItemSequence;
     }
 
     public static List<IndicatorGroupSequenceEntry> ReplaceIndicatorSequence(
@@ -336,10 +290,5 @@ public abstract class ReplacementServiceHelper
         replacementSequence.AddRange(unmappedReplacementIndicatorsWithNewGroups);
 
         return replacementSequence;
-    }
-
-    private static bool IsTotal(string input)
-    {
-        return input.Equals("Total", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -340,6 +340,8 @@ public record ReplacementPlanMappingViewModel
     public ReplacementPlanIndicatorsMappingViewModel Indicators { get; init; } = null!;
 
     public ReplacementPlanLocationMappingsViewModel Locations { get; init; } = null!;
+
+    public ReplacementPlanFilterMappingsViewModel Filters { get; init; } = null!;
 }
 
 public record ReplacementPlanIndicatorsMappingViewModel
@@ -361,9 +363,7 @@ public record ReplacementPlanIndicatorMappingViewModel
 public record ReplacementPlanIndicatorViewModel
 {
     public Guid Id { get; init; }
-
     public string Name { get; init; } = ""; // csv column name
-
     public string Label { get; init; } = "";
 }
 
@@ -388,4 +388,75 @@ public record ReplacementPlanLocationViewModel
     public Guid Id { get; init; }
     public string Code { get; init; } = "";
     public string Name { get; init; } = "";
+}
+
+public record ReplacementPlanFilterMappingsViewModel
+{
+    // Key is original filter id
+    public Dictionary<Guid, ReplacementPlanFilterMappingViewModel> Mappings { get; init; } = new();
+
+    // Key is replacement filter id
+    public Dictionary<Guid, ReplacementPlanFilterViewModel> Candidates { get; init; } = new();
+}
+
+public record ReplacementPlanFilterMappingViewModel
+{
+    public ReplacementPlanFilterViewModel Source { get; init; } = null!;
+    public string Type { get; init; } = "";
+    public Guid? CandidateKey { get; init; } // replacement filter id
+
+    public ReplacementPlanFilterGroupMappingsViewModel FilterGroup { get; init; } = null!;
+}
+
+public record ReplacementPlanFilterViewModel
+{
+    public Guid Id { get; init; }
+    public string Label { get; init; } = "";
+    public string Name { get; init; } = ""; // csv column name
+}
+
+public record ReplacementPlanFilterGroupMappingsViewModel
+{
+    // Key is original filter group id
+    public Dictionary<Guid, ReplacementPlanFilterGroupMappingViewModel> Mappings { get; init; } = new();
+
+    // Key is replacement filter group id
+    public Dictionary<Guid, ReplacementPlanFilterGroupViewModel> Candidates { get; init; } = new();
+}
+
+public record ReplacementPlanFilterGroupMappingViewModel
+{
+    public ReplacementPlanFilterItemViewModel Source { get; init; } = null!;
+    public string Type { get; init; } = "";
+    public Guid? CandidateKey { get; init; } // replacement filter group id
+
+    public ReplacementPlanFilterItemMappingsViewModel FilterItem { get; init; } = null!;
+}
+
+public record ReplacementPlanFilterGroupViewModel
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = "";
+}
+
+public record ReplacementPlanFilterItemMappingsViewModel
+{
+    // Key is original filter item id
+    public Dictionary<Guid, ReplacementPlanFilterItemMappingViewModel> Mappings { get; init; } = new();
+
+    // Key is replacement filter item id
+    public Dictionary<Guid, ReplacementPlanFilterItemViewModel> Candidates { get; init; } = new();
+}
+
+public record ReplacementPlanFilterItemMappingViewModel
+{
+    public ReplacementPlanFilterItemViewModel Source { get; init; } = null!;
+    public string Type { get; init; } = "";
+    public Guid? CandidateKey { get; init; } // replacement filter item id
+}
+
+public record ReplacementPlanFilterItemViewModel
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = "";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -1,9 +1,9 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
@@ -14,13 +14,11 @@ public class DataReplacementPlanViewModel
     public ReplaceApiDataSetVersionPlanViewModel? ApiDataSetVersionPlan { get; init; }
     public ReplacementPlanMappingViewModel Mapping { get; init; } = new();
 
-    // If the number of filters has changed, then data blocks will have the wrong number of filter items:
-    // - If a filter has been removed, then any DataBlock will be invalid as old filter items from the removed filter
-    // will not (and cannot be) be mapped. If there are no DataBlocks then it will be valid. So we don't need to worry about the number
-    // of filters being reduced, as DataBlocks will be invalid and prevent the replacement.
-    // - But if an additional filter has been added, then DataBlocks will still be marked valid despite missing
-    // an item from the new filter, meaning they'll return no results after the replacement is complete.
-    // However, if there are no DataBlocks, then the additional filter doesn't need to invalidate the replacement.
+    // If the replacement introduces additional filters, existing data blocks become problematic: the data blocks won't
+    // contain filter items for the new filters, and will appear valid, but will return no results after the
+    // replacement.
+    // If the replacement removes filters, then existing data blocks referencing the removed filters' items will be
+    // considered invalid and prevent the replacement, so we don't need to handle that case.
     public bool HasDataBlockAndReplacementHasAdditionalFilter =>
         DataBlocks.Any() && Mapping.Filters.Mappings.Count < Mapping.Filters.Candidates.Count;
     public Guid OriginalSubjectId { get; init; }
@@ -246,7 +244,7 @@ public class TimePeriodRangeReplacementViewModel
 
 public class TimePeriodReplacementViewModel : ReplacementViewModel
 {
-    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public TimeIdentifier Code { get; }
 
     public int Year { get; }
@@ -342,7 +340,7 @@ public record ReplacementPlanIndicatorMappingsViewModel
                     Name = indicatorMap.OriginalColumnName,
                     Label = indicatorMap.OriginalLabel,
                 },
-                Type = indicatorMap.Status.ToString(),
+                Type = indicatorMap.Status,
                 CandidateKey = indicatorMap.ReplacementId,
             }
         );
@@ -382,7 +380,9 @@ public record ReplacementPlanIndicatorMappingsViewModel
 public record ReplacementPlanIndicatorMappingViewModel
 {
     public ReplacementPlanIndicatorViewModel Source { get; init; } = null!;
-    public string Type { get; init; } = "";
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MapStatus Type { get; init; }
     public Guid? CandidateKey { get; init; } // replacement indicator id
 }
 
@@ -413,7 +413,7 @@ public record ReplacementPlanLocationMappingsViewModel
                     Code = locationMap.OriginalCode,
                     Name = locationMap.OriginalName,
                 },
-                Type = locationMap.Status.ToString(),
+                Type = locationMap.Status,
                 CandidateKey = locationMap.ReplacementId,
             }
         );
@@ -454,7 +454,10 @@ public record ReplacementPlanLocationMappingsViewModel
 public record ReplacementPlanLocationMappingViewModel
 {
     public ReplacementPlanLocationViewModel Source { get; init; } = null!;
-    public string Type { get; init; } = "";
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MapStatus Type { get; init; }
+
     public Guid? CandidateKey { get; init; } // replacement location id
 }
 
@@ -486,7 +489,7 @@ public record ReplacementPlanFilterMappingsViewModel
                     Label = filterMap.OriginalLabel,
                 },
                 CandidateKey = filterMap.ReplacementId,
-                Type = filterMap.Status.ToString(),
+                Type = filterMap.Status,
                 FilterGroups = ReplacementPlanFilterGroupMappingsViewModel.FromModel(filterMap),
             }
         );
@@ -523,7 +526,10 @@ public record ReplacementPlanFilterMappingsViewModel
 public record ReplacementPlanFilterMappingViewModel
 {
     public ReplacementPlanFilterViewModel Source { get; init; } = null!;
-    public string Type { get; init; } = "";
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MapStatus Type { get; init; }
+
     public Guid? CandidateKey { get; init; } // replacement filter id
 
     public ReplacementPlanFilterGroupMappingsViewModel FilterGroups { get; init; } = null!;
@@ -556,7 +562,7 @@ public record ReplacementPlanFilterGroupMappingsViewModel
                     Label = groupMap.OriginalLabel,
                 },
                 CandidateKey = groupMap.ReplacementId,
-                Type = groupMap.Status.ToString(),
+                Type = groupMap.Status,
                 FilterItems = ReplacementPlanFilterItemMappingsViewModel.FromModel(groupMap),
             }
         );
@@ -583,7 +589,10 @@ public record ReplacementPlanFilterGroupMappingsViewModel
 public record ReplacementPlanFilterGroupMappingViewModel
 {
     public ReplacementPlanFilterGroupViewModel Source { get; init; } = null!;
-    public string Type { get; init; } = "";
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MapStatus Type { get; init; }
+
     public Guid? CandidateKey { get; init; } // replacement filter group id
 
     public ReplacementPlanFilterItemMappingsViewModel FilterItems { get; init; } = null!;
@@ -615,7 +624,7 @@ public record ReplacementPlanFilterItemMappingsViewModel
                     Label = itemMap.OriginalLabel,
                 },
                 CandidateKey = itemMap.ReplacementId,
-                Type = itemMap.Status.ToString(),
+                Type = itemMap.Status,
             }
         );
         var itemCandidates = groupMapping
@@ -637,7 +646,10 @@ public record ReplacementPlanFilterItemMappingsViewModel
 public record ReplacementPlanFilterItemMappingViewModel
 {
     public ReplacementPlanFilterItemViewModel Source { get; init; } = null!;
-    public string Type { get; init; } = "";
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public MapStatus Type { get; init; }
+
     public Guid? CandidateKey { get; init; } // replacement filter item id
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -39,38 +39,27 @@ public class DataReplacementPlanViewModel
     }
 }
 
-public class DataBlockReplacementPlanViewModel
+public class DataBlockReplacementPlanViewModel(
+    Guid id,
+    string name,
+    Dictionary<Guid, FilterReplacementViewModel>? filters = null,
+    Dictionary<Guid, IndicatorGroupReplacementViewModel>? indicators = null,
+    Dictionary<string, LocationReplacementViewModel>? locations = null,
+    TimePeriodRangeReplacementViewModel? timePeriods = null
+)
 {
-    public Guid Id { get; }
-    public string Name { get; }
-    public Dictionary<Guid, FilterReplacementViewModel> Filters { get; }
-    private List<FilterReplacementViewModel> NewlyIntroducedFilters { get; }
-    public Dictionary<Guid, IndicatorGroupReplacementViewModel> IndicatorGroups { get; }
-    public Dictionary<string, LocationReplacementViewModel> Locations { get; } // Key is GeographicLevel
-    public TimePeriodRangeReplacementViewModel? TimePeriods { get; }
-
-    public DataBlockReplacementPlanViewModel(
-        Guid id,
-        string name,
-        Dictionary<Guid, FilterReplacementViewModel>? originalFilters = null,
-        List<FilterReplacementViewModel>? newlyIntroducedFilters = null,
-        Dictionary<Guid, IndicatorGroupReplacementViewModel>? indicators = null,
-        Dictionary<string, LocationReplacementViewModel>? locations = null,
-        TimePeriodRangeReplacementViewModel? timePeriods = null
-    )
-    {
-        Id = id;
-        Name = name;
-        Filters = originalFilters ?? new Dictionary<Guid, FilterReplacementViewModel>();
-        NewlyIntroducedFilters = newlyIntroducedFilters ?? new List<FilterReplacementViewModel>();
-        IndicatorGroups = indicators ?? new Dictionary<Guid, IndicatorGroupReplacementViewModel>();
-        Locations = locations ?? new Dictionary<string, LocationReplacementViewModel>();
-        TimePeriods = timePeriods;
-    }
+    public Guid Id { get; } = id;
+    public string Name { get; } = name;
+    public Dictionary<Guid, FilterReplacementViewModel> Filters { get; } =
+        filters ?? new Dictionary<Guid, FilterReplacementViewModel>();
+    public Dictionary<Guid, IndicatorGroupReplacementViewModel> IndicatorGroups { get; } =
+        indicators ?? new Dictionary<Guid, IndicatorGroupReplacementViewModel>();
+    public Dictionary<string, LocationReplacementViewModel> Locations { get; } =
+        locations ?? new Dictionary<string, LocationReplacementViewModel>(); // Key is GeographicLevel
+    public TimePeriodRangeReplacementViewModel? TimePeriods { get; } = timePeriods;
 
     public bool Valid =>
-        NewlyIntroducedFilters.IsNullOrEmpty()
-        && Filters.All(model => model.Value.Valid)
+        Filters.All(model => model.Value.Valid)
         && IndicatorGroups.All(model => model.Value.Valid)
         && Locations.Values.All(model => model.Valid)
         && (TimePeriods?.Valid ?? true);
@@ -81,31 +70,25 @@ public class DataBlockReplacementPlanViewModel
     }
 }
 
-public class FootnoteReplacementPlanViewModel
+public class FootnoteReplacementPlanViewModel(
+    Guid id,
+    string content,
+    IEnumerable<FootnoteFilterReplacementViewModel>? filters = null,
+    IEnumerable<FootnoteFilterGroupReplacementViewModel>? filterGroups = null,
+    IEnumerable<FootnoteFilterItemReplacementViewModel>? filterItems = null,
+    Dictionary<Guid, IndicatorGroupReplacementViewModel>? indicatorGroups = null
+)
 {
-    public Guid Id { get; }
-    public string Content { get; }
-    public IEnumerable<FootnoteFilterReplacementViewModel> Filters { get; }
-    public IEnumerable<FootnoteFilterGroupReplacementViewModel> FilterGroups { get; }
-    public IEnumerable<FootnoteFilterItemReplacementViewModel> FilterItems { get; }
-    public Dictionary<Guid, IndicatorGroupReplacementViewModel> IndicatorGroups { get; }
-
-    public FootnoteReplacementPlanViewModel(
-        Guid id,
-        string content,
-        IEnumerable<FootnoteFilterReplacementViewModel>? filters = null,
-        IEnumerable<FootnoteFilterGroupReplacementViewModel>? filterGroups = null,
-        IEnumerable<FootnoteFilterItemReplacementViewModel>? filterItems = null,
-        Dictionary<Guid, IndicatorGroupReplacementViewModel>? indicatorGroups = null
-    )
-    {
-        Id = id;
-        Content = content;
-        Filters = filters ?? new List<FootnoteFilterReplacementViewModel>();
-        FilterGroups = filterGroups ?? new List<FootnoteFilterGroupReplacementViewModel>();
-        FilterItems = filterItems ?? new List<FootnoteFilterItemReplacementViewModel>();
-        IndicatorGroups = indicatorGroups ?? new Dictionary<Guid, IndicatorGroupReplacementViewModel>();
-    }
+    public Guid Id { get; } = id;
+    public string Content { get; } = content;
+    public IEnumerable<FootnoteFilterReplacementViewModel> Filters { get; } =
+        filters ?? new List<FootnoteFilterReplacementViewModel>();
+    public IEnumerable<FootnoteFilterGroupReplacementViewModel> FilterGroups { get; } =
+        filterGroups ?? new List<FootnoteFilterGroupReplacementViewModel>();
+    public IEnumerable<FootnoteFilterItemReplacementViewModel> FilterItems { get; } =
+        filterItems ?? new List<FootnoteFilterItemReplacementViewModel>();
+    public Dictionary<Guid, IndicatorGroupReplacementViewModel> IndicatorGroups { get; } =
+        indicatorGroups ?? new Dictionary<Guid, IndicatorGroupReplacementViewModel>();
 
     public bool Valid =>
         Filters.All(model => model.Valid)
@@ -119,54 +102,35 @@ public class FootnoteReplacementPlanViewModel
     }
 }
 
-public class FootnoteFilterReplacementViewModel : TargetableReplacementViewModel
+public class FootnoteFilterReplacementViewModel(Guid id, string label, Guid? target)
+    : TargetableReplacementViewModel(id, label, target);
+
+public class FootnoteFilterGroupReplacementViewModel(
+    Guid id,
+    string label,
+    Guid? target,
+    Guid filterId,
+    string filterLabel
+) : TargetableReplacementViewModel(id, label, target)
 {
-    public FootnoteFilterReplacementViewModel(Guid id, string label, Guid? target)
-        : base(id, label, target) { }
+    public Guid FilterId { get; } = filterId;
+    public string FilterLabel { get; } = filterLabel;
 }
 
-public class FootnoteFilterGroupReplacementViewModel : TargetableReplacementViewModel
+public class FootnoteFilterItemReplacementViewModel(
+    Guid id,
+    string label,
+    Guid? target,
+    Guid filterGroupId,
+    string filterGroupLabel,
+    Guid filterId,
+    string filterLabel
+) : TargetableReplacementViewModel(id, label, target)
 {
-    public Guid FilterId { get; }
-    public string FilterLabel { get; }
-
-    public FootnoteFilterGroupReplacementViewModel(
-        Guid id,
-        string label,
-        Guid? target,
-        Guid filterId,
-        string filterLabel
-    )
-        : base(id, label, target)
-    {
-        FilterId = filterId;
-        FilterLabel = filterLabel;
-    }
-}
-
-public class FootnoteFilterItemReplacementViewModel : TargetableReplacementViewModel
-{
-    public Guid FilterGroupId { get; }
-    public string FilterGroupLabel { get; }
-    public Guid FilterId { get; }
-    public string FilterLabel { get; }
-
-    public FootnoteFilterItemReplacementViewModel(
-        Guid id,
-        string label,
-        Guid? target,
-        Guid filterGroupId,
-        string filterGroupLabel,
-        Guid filterId,
-        string filterLabel
-    )
-        : base(id, label, target)
-    {
-        FilterGroupId = filterGroupId;
-        FilterGroupLabel = filterGroupLabel;
-        FilterId = filterId;
-        FilterLabel = filterLabel;
-    }
+    public Guid FilterGroupId { get; } = filterGroupId;
+    public string FilterGroupLabel { get; } = filterGroupLabel;
+    public Guid FilterId { get; } = filterId;
+    public string FilterLabel { get; } = filterLabel;
 }
 
 public class FilterReplacementViewModel(
@@ -183,40 +147,31 @@ public class FilterReplacementViewModel(
     public string Name { get; } = name;
     public Dictionary<Guid, FilterGroupReplacementViewModel> Groups { get; } = groups;
 
-    public bool Valid => Groups.All(group => group.Value.Valid);
+    public bool Valid => Target.HasValue && Groups.All(group => group.Value.Valid);
 }
 
-public class FilterGroupReplacementViewModel
+public class FilterGroupReplacementViewModel(
+    Guid id,
+    string label,
+    Guid? target,
+    IEnumerable<FilterItemReplacementViewModel> filters
+)
 {
-    public Guid Id { get; }
-    public string Label { get; }
-    public IEnumerable<FilterItemReplacementViewModel> Filters { get; }
+    public Guid Id { get; } = id;
+    public string Label { get; } = label;
+    public Guid? Target { get; } = target;
+    public IEnumerable<FilterItemReplacementViewModel> Filters { get; } = filters; // @MarkFix rename to Items
 
-    public bool Valid => Filters.All(filter => filter.Valid);
-
-    public FilterGroupReplacementViewModel(Guid id, string label, IEnumerable<FilterItemReplacementViewModel> filters)
-    {
-        Id = id;
-        Label = label;
-        Filters = filters;
-    }
+    public bool Valid => Target.HasValue && Filters.All(filter => filter.Valid);
 }
 
-public class FilterItemReplacementViewModel : TargetableReplacementViewModel
-{
-    public FilterItemReplacementViewModel(Guid id, string label, Guid? target)
-        : base(id, label, target) { }
-}
+public class FilterItemReplacementViewModel(Guid id, string label, Guid? target)
+    : TargetableReplacementViewModel(id, label, target);
 
-public class IndicatorReplacementViewModel : TargetableReplacementViewModel
+public class IndicatorReplacementViewModel(Guid id, string label, Guid? target, string name)
+    : TargetableReplacementViewModel(id, label, target)
 {
-    public string Name { get; }
-
-    public IndicatorReplacementViewModel(Guid id, string label, Guid? target, string name)
-        : base(id, label, target)
-    {
-        Name = name; // csv column name
-    }
+    public string Name { get; } = name; // csv column name
 }
 
 public class IndicatorGroupReplacementViewModel
@@ -337,20 +292,82 @@ public abstract class ReplacementViewModel
 
 public record ReplacementPlanMappingViewModel
 {
-    public ReplacementPlanIndicatorsMappingViewModel Indicators { get; init; } = null!;
+    public ReplacementPlanIndicatorMappingsViewModel Indicators { get; init; } = null!;
 
     public ReplacementPlanLocationMappingsViewModel Locations { get; init; } = null!;
 
     public ReplacementPlanFilterMappingsViewModel Filters { get; init; } = null!;
+
+    public static ReplacementPlanMappingViewModel FromModel(DataSetMapping mapping)
+    {
+        var indicatorMappings = ReplacementPlanIndicatorMappingsViewModel.FromModel(mapping);
+        var locationMappings = ReplacementPlanLocationMappingsViewModel.FromModel(mapping);
+        var filterMappings = ReplacementPlanFilterMappingsViewModel.FromModel(mapping);
+
+        return new ReplacementPlanMappingViewModel
+        {
+            Indicators = indicatorMappings,
+            Locations = locationMappings,
+            Filters = filterMappings,
+        };
+    }
 }
 
-public record ReplacementPlanIndicatorsMappingViewModel
+public record ReplacementPlanIndicatorMappingsViewModel
 {
     // Key is original indicator id
     public Dictionary<Guid, ReplacementPlanIndicatorMappingViewModel> Mappings { get; init; } = null!;
 
     // Key is replacement indicator id
     public Dictionary<Guid, ReplacementPlanIndicatorViewModel> Candidates { get; init; } = null!;
+
+    public static ReplacementPlanIndicatorMappingsViewModel FromModel(DataSetMapping mapping)
+    {
+        var indicatorMappings = mapping.IndicatorMappings.Values.ToDictionary(
+            indicatorMap => indicatorMap.OriginalId,
+            indicatorMap => new ReplacementPlanIndicatorMappingViewModel
+            {
+                Source = new ReplacementPlanIndicatorViewModel
+                {
+                    Id = indicatorMap.OriginalId,
+                    Name = indicatorMap.OriginalColumnName,
+                    Label = indicatorMap.OriginalLabel,
+                },
+                Type = indicatorMap.Status.ToString(),
+                CandidateKey = indicatorMap.ReplacementId,
+            }
+        );
+        var indicatorCandidates = mapping // candidates are all possible replacement indicators
+            .IndicatorMappings.Values.Where(indicatorMap => indicatorMap.ReplacementId != null)
+            .Select(indicatorMap => new
+            {
+                Id = indicatorMap.ReplacementId!.Value,
+                ColumnName = indicatorMap.ReplacementColumnName!,
+                Label = indicatorMap.ReplacementLabel!,
+            })
+            .Concat(
+                mapping.UnmappedReplacementIndicators.Select(unmappedIndicator => new
+                {
+                    unmappedIndicator.Id,
+                    unmappedIndicator.ColumnName,
+                    unmappedIndicator.Label,
+                })
+            )
+            .ToDictionary(
+                x => x.Id,
+                x => new ReplacementPlanIndicatorViewModel
+                {
+                    Id = x.Id,
+                    Name = x.ColumnName,
+                    Label = x.Label,
+                }
+            );
+        return new ReplacementPlanIndicatorMappingsViewModel
+        {
+            Mappings = indicatorMappings,
+            Candidates = indicatorCandidates,
+        };
+    }
 }
 
 public record ReplacementPlanIndicatorMappingViewModel
@@ -374,6 +391,55 @@ public record ReplacementPlanLocationMappingsViewModel
 
     // Key is replacement location id
     public Dictionary<Guid, ReplacementPlanLocationViewModel> Candidates { get; init; } = new();
+
+    public static ReplacementPlanLocationMappingsViewModel FromModel(DataSetMapping mapping)
+    {
+        var locationMappings = mapping.LocationMappings.Values.ToDictionary(
+            locationMap => locationMap.OriginalId,
+            locationMap => new ReplacementPlanLocationMappingViewModel
+            {
+                Source = new ReplacementPlanLocationViewModel
+                {
+                    Id = locationMap.OriginalId,
+                    Code = locationMap.OriginalCode,
+                    Name = locationMap.OriginalName,
+                },
+                Type = locationMap.Status.ToString(),
+                CandidateKey = locationMap.ReplacementId,
+            }
+        );
+        var locationCandidates = mapping // candidates are all possible replacement locations
+            .LocationMappings.Values.Where(locationMap => locationMap.ReplacementId != null)
+            .Select(locationMap => new
+            {
+                Id = locationMap.ReplacementId!.Value,
+                Code = locationMap.ReplacementCode!,
+                Name = locationMap.ReplacementName!,
+            })
+            .Concat(
+                mapping.UnmappedReplacementLocations.Select(unmappedLocation => new
+                {
+                    unmappedLocation.Id,
+                    unmappedLocation.Code,
+                    unmappedLocation.Name,
+                })
+            )
+            .ToDictionary(
+                x => x.Id,
+                x => new ReplacementPlanLocationViewModel
+                {
+                    Id = x.Id,
+                    Code = x.Code,
+                    Name = x.Name,
+                }
+            );
+
+        return new ReplacementPlanLocationMappingsViewModel
+        {
+            Mappings = locationMappings,
+            Candidates = locationCandidates,
+        };
+    }
 }
 
 public record ReplacementPlanLocationMappingViewModel
@@ -397,6 +463,52 @@ public record ReplacementPlanFilterMappingsViewModel
 
     // Key is replacement filter id
     public Dictionary<Guid, ReplacementPlanFilterViewModel> Candidates { get; init; } = new();
+
+    public static ReplacementPlanFilterMappingsViewModel FromModel(DataSetMapping mapping)
+    {
+        var filterMappings = mapping.FilterMappings.Values.ToDictionary(
+            filterMap => filterMap.OriginalId,
+            filterMap => new ReplacementPlanFilterMappingViewModel
+            {
+                Source = new ReplacementPlanFilterViewModel
+                {
+                    Id = filterMap.OriginalId,
+                    Name = filterMap.OriginalColumnName,
+                    Label = filterMap.OriginalLabel,
+                },
+                CandidateKey = filterMap.ReplacementId,
+                Type = filterMap.Status.ToString(),
+                FilterGroups = ReplacementPlanFilterGroupMappingsViewModel.FromModel(filterMap),
+            }
+        );
+        var filterCandidates = mapping
+            .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
+            .Select(filterMap => new
+            {
+                Id = filterMap.ReplacementId!.Value,
+                Label = filterMap.ReplacementLabel!,
+                Name = filterMap.ReplacementColumnName!,
+            })
+            .Concat(
+                mapping.UnmappedReplacementFilters.Select(unmappedFilter => new
+                {
+                    unmappedFilter.Id,
+                    unmappedFilter.Label,
+                    Name = unmappedFilter.ColumnName,
+                })
+            )
+            .ToDictionary(
+                x => x.Id,
+                x => new ReplacementPlanFilterViewModel
+                {
+                    Id = x.Id,
+                    Label = x.Label,
+                    Name = x.Name,
+                }
+            );
+
+        return new ReplacementPlanFilterMappingsViewModel { Mappings = filterMappings, Candidates = filterCandidates };
+    }
 }
 
 public record ReplacementPlanFilterMappingViewModel
@@ -405,7 +517,7 @@ public record ReplacementPlanFilterMappingViewModel
     public string Type { get; init; } = "";
     public Guid? CandidateKey { get; init; } // replacement filter id
 
-    public ReplacementPlanFilterGroupMappingsViewModel FilterGroup { get; init; } = null!;
+    public ReplacementPlanFilterGroupMappingsViewModel FilterGroups { get; init; } = null!;
 }
 
 public record ReplacementPlanFilterViewModel
@@ -422,15 +534,50 @@ public record ReplacementPlanFilterGroupMappingsViewModel
 
     // Key is replacement filter group id
     public Dictionary<Guid, ReplacementPlanFilterGroupViewModel> Candidates { get; init; } = new();
+
+    public static ReplacementPlanFilterGroupMappingsViewModel FromModel(FilterMapping filterMapping)
+    {
+        var filterGroupMappings = filterMapping.FilterGroupMappings.Values.ToDictionary(
+            groupMap => groupMap.OriginalId,
+            groupMap => new ReplacementPlanFilterGroupMappingViewModel
+            {
+                Source = new ReplacementPlanFilterGroupViewModel
+                {
+                    Id = groupMap.OriginalId,
+                    Label = groupMap.OriginalLabel,
+                },
+                CandidateKey = groupMap.ReplacementId,
+                Type = groupMap.Status.ToString(),
+                FilterItems = ReplacementPlanFilterItemMappingsViewModel.FromModel(groupMap),
+            }
+        );
+        var filterGroupCandidates = filterMapping
+            .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
+            .Select(groupMap => new { Id = groupMap.ReplacementId!.Value, Label = groupMap.ReplacementLabel! })
+            .Concat(
+                filterMapping.UnmappedReplacementFilterGroups.Select(unmappedGroup => new
+                {
+                    unmappedGroup.Id,
+                    unmappedGroup.Label,
+                })
+            )
+            .ToDictionary(x => x.Id, x => new ReplacementPlanFilterGroupViewModel { Id = x.Id, Label = x.Label });
+
+        return new ReplacementPlanFilterGroupMappingsViewModel
+        {
+            Mappings = filterGroupMappings,
+            Candidates = filterGroupCandidates,
+        };
+    }
 }
 
 public record ReplacementPlanFilterGroupMappingViewModel
 {
-    public ReplacementPlanFilterItemViewModel Source { get; init; } = null!;
+    public ReplacementPlanFilterGroupViewModel Source { get; init; } = null!;
     public string Type { get; init; } = "";
     public Guid? CandidateKey { get; init; } // replacement filter group id
 
-    public ReplacementPlanFilterItemMappingsViewModel FilterItem { get; init; } = null!;
+    public ReplacementPlanFilterItemMappingsViewModel FilterItems { get; init; } = null!;
 }
 
 public record ReplacementPlanFilterGroupViewModel
@@ -446,6 +593,36 @@ public record ReplacementPlanFilterItemMappingsViewModel
 
     // Key is replacement filter item id
     public Dictionary<Guid, ReplacementPlanFilterItemViewModel> Candidates { get; init; } = new();
+
+    public static ReplacementPlanFilterItemMappingsViewModel FromModel(FilterGroupMapping groupMapping)
+    {
+        var itemMappings = groupMapping.FilterItemMappings.Values.ToDictionary(
+            itemMap => itemMap.OriginalId,
+            itemMap => new ReplacementPlanFilterItemMappingViewModel
+            {
+                Source = new ReplacementPlanFilterItemViewModel
+                {
+                    Id = itemMap.OriginalId,
+                    Label = itemMap.OriginalLabel,
+                },
+                CandidateKey = itemMap.ReplacementId,
+                Type = itemMap.Status.ToString(),
+            }
+        );
+        var itemCandidates = groupMapping
+            .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
+            .Select(itemMap => new { Id = itemMap.ReplacementId!.Value, Label = itemMap.ReplacementLabel! })
+            .Concat(
+                groupMapping.UnmappedReplacementFilterItems.Select(unmappedItem => new
+                {
+                    unmappedItem.Id,
+                    unmappedItem.Label,
+                })
+            )
+            .ToDictionary(x => x.Id, x => new ReplacementPlanFilterItemViewModel { Id = x.Id, Label = x.Label });
+
+        return new ReplacementPlanFilterItemMappingsViewModel { Mappings = itemMappings, Candidates = itemCandidates };
+    }
 }
 
 public record ReplacementPlanFilterItemMappingViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -13,11 +13,22 @@ public class DataReplacementPlanViewModel
     public IEnumerable<FootnoteReplacementPlanViewModel> Footnotes { get; init; } = [];
     public ReplaceApiDataSetVersionPlanViewModel? ApiDataSetVersionPlan { get; init; }
     public ReplacementPlanMappingViewModel Mapping { get; init; } = new();
+
+    // If the number of filters has changed, then data blocks will have the wrong number of filter items:
+    // - If a filter has been removed, then any DataBlock will be invalid as old filter items from the removed filter
+    // will not (and cannot be) be mapped. If there are no DataBlocks then it will be valid. So we don't need to worry about the number
+    // of filters being reduced, as DataBlocks will be invalid and prevent the replacement.
+    // - But if an additional filter has been added, then DataBlocks will still be marked valid despite missing
+    // an item from the new filter, meaning they'll return no results after the replacement is complete.
+    // However, if there are no DataBlocks, then the additional filter doesn't need to invalidate the replacement.
+    public bool HasDataBlockAndReplacementHasAdditionalFilter =>
+        DataBlocks.Any() && Mapping.Filters.Mappings.Count < Mapping.Filters.Candidates.Count;
     public Guid OriginalSubjectId { get; init; }
     public Guid ReplacementSubjectId { get; init; }
 
     public bool Valid =>
-        DataBlocks.All(info => info.Valid)
+        !HasDataBlockAndReplacementHasAdditionalFilter
+        && DataBlocks.All(info => info.Valid)
         && Footnotes.All(info => info.Valid)
         && (ApiDataSetVersionPlan?.Valid ?? true);
 
@@ -158,9 +169,9 @@ public class FilterGroupReplacementViewModel(
     public Guid Id { get; } = id;
     public string Label { get; } = label;
     public Guid? Target { get; } = target;
-    public IEnumerable<FilterItemReplacementViewModel> Items { get; } = items; // @MarkFix rename to Items
+    public IEnumerable<FilterItemReplacementViewModel> Items { get; } = items;
 
-    public bool Valid => Target.HasValue && Items.All(filter => filter.Valid);
+    public bool Valid => Target.HasValue && Items.All(item => item.Valid);
 }
 
 public class FilterItemReplacementViewModel(Guid id, string label, Guid? target)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -21,10 +21,8 @@ public class DataReplacementPlanViewModel
         && Footnotes.All(info => info.Valid)
         && (ApiDataSetVersionPlan?.Valid ?? true);
 
-    /**
-     * Trimmed down version of the data replacement plan that
-     * only shows full replacement details for invalid items.
-     */
+    // Trimmed down version of the data replacement plan that
+    // only shows full replacement details for invalid items.
     public DataReplacementPlanViewModel ToSummary()
     {
         return new DataReplacementPlanViewModel
@@ -154,15 +152,15 @@ public class FilterGroupReplacementViewModel(
     Guid id,
     string label,
     Guid? target,
-    IEnumerable<FilterItemReplacementViewModel> filters
+    IEnumerable<FilterItemReplacementViewModel> items
 )
 {
     public Guid Id { get; } = id;
     public string Label { get; } = label;
     public Guid? Target { get; } = target;
-    public IEnumerable<FilterItemReplacementViewModel> Filters { get; } = filters; // @MarkFix rename to Items
+    public IEnumerable<FilterItemReplacementViewModel> Items { get; } = items; // @MarkFix rename to Items
 
-    public bool Valid => Target.HasValue && Filters.All(filter => filter.Valid);
+    public bool Valid => Target.HasValue && Items.All(filter => filter.Valid);
 }
 
 public class FilterItemReplacementViewModel(Guid id, string label, Guid? target)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
@@ -30,6 +30,16 @@ public static class DataSetMappingGeneratorExtensions
         File replacementDataFile
     ) => generator.ForInstance(m => m.SetReplacementDataFile(replacementDataFile));
 
+    public static Generator<DataSetMapping> WithFilterMappings(
+        this Generator<DataSetMapping> generator,
+        Dictionary<Guid, FilterMapping> filterMappings
+    ) => generator.ForInstance(m => m.SetFilterMappings(filterMappings));
+
+    public static Generator<DataSetMapping> WithUnmappedReplacementFilters(
+        this Generator<DataSetMapping> generator,
+        List<UnmappedFilter> unmappedFilters
+    ) => generator.ForInstance(m => m.SetUnmappedReplacementFilters(unmappedFilters));
+
     public static Generator<DataSetMapping> WithIndicatorMappings(
         this Generator<DataSetMapping> generator,
         Dictionary<Guid, IndicatorMapping> indicatorMappings
@@ -52,6 +62,9 @@ public static class DataSetMappingGeneratorExtensions
 
     public static InstanceSetters<DataSetMapping> SetDefaults(this InstanceSetters<DataSetMapping> setters) =>
         setters
+            .SetDefault(m => m.OriginalDataFileId)
+            .SetDefault(m => m.ReplacementDataFileId)
+            .Set(m => m.FilterMappings, new Dictionary<Guid, FilterMapping>())
             .Set(m => m.IndicatorMappings, new Dictionary<Guid, IndicatorMapping>())
             .Set(m => m.LocationMappings, new Dictionary<Guid, LocationMapping>());
 
@@ -74,6 +87,16 @@ public static class DataSetMappingGeneratorExtensions
         this InstanceSetters<DataSetMapping> setters,
         Content.Model.File replacementDataFile
     ) => setters.Set(m => m.ReplacementDataFile, replacementDataFile).SetReplacementDataFileId(replacementDataFile.Id);
+
+    public static InstanceSetters<DataSetMapping> SetFilterMappings(
+        this InstanceSetters<DataSetMapping> setters,
+        Dictionary<Guid, FilterMapping> filterMappings
+    ) => setters.Set(m => m.FilterMappings, filterMappings);
+
+    public static InstanceSetters<DataSetMapping> SetUnmappedReplacementFilters(
+        this InstanceSetters<DataSetMapping> setters,
+        List<UnmappedFilter> unmappedFilters
+    ) => setters.Set(m => m.UnmappedReplacementFilters, unmappedFilters);
 
     public static InstanceSetters<DataSetMapping> SetIndicatorMappings(
         this InstanceSetters<DataSetMapping> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -241,7 +241,6 @@ public record FilterItemMapping
     public MapStatus Status { get; set; }
 }
 
-// @MarkFix add automapping of filters when first generating a DataSetMapping
 // @MarkFix code to generate replacement plan from filter mappings
 // @MarkFix code to complete replacement based on filter mappings
 // @MarkFix add tests for automapping filters

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -21,8 +21,10 @@ public record DataSetMapping
     public List<UnmappedIndicator> UnmappedReplacementIndicators { get; init; } = [];
 
     public Dictionary<Guid, LocationMapping> LocationMappings { get; init; } = null!;
-
     public List<UnmappedLocation> UnmappedReplacementLocations { get; init; } = [];
+
+    public Dictionary<Guid, FilterMapping> FilterMappings { get; init; } = null!;
+    public List<UnmappedFilter> UnmappedReplacementFilters { get; init; } = [];
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -91,6 +93,27 @@ public record DataSetMapping
                         ?? new List<UnmappedLocation>(),
                     ValueComparer.CreateDefault<List<UnmappedLocation>>(false)
                 );
+
+            builder
+                .Property(x => x.FilterMappings)
+                .HasConversion(
+                    locationMappings => JsonSerializer.Serialize(locationMappings, JsonOptions),
+                    locMappingString =>
+                        JsonSerializer.Deserialize<Dictionary<Guid, FilterMapping>>(locMappingString, JsonOptions)
+                        ?? new Dictionary<Guid, FilterMapping>(),
+                    ValueComparer.CreateDefault<Dictionary<Guid, FilterMapping>>(false)
+                )
+                .HasColumnType("nvarchar(max)");
+
+            builder
+                .Property(x => x.UnmappedReplacementFilters)
+                .HasConversion(
+                    unmappedFilters => JsonSerializer.Serialize(unmappedFilters, JsonOptions),
+                    unmappedFiltersString =>
+                        JsonSerializer.Deserialize<List<UnmappedFilter>>(unmappedFiltersString, JsonOptions)
+                        ?? new List<UnmappedFilter>(),
+                    ValueComparer.CreateDefault<List<UnmappedFilter>>(false)
+                );
         }
     }
 }
@@ -150,3 +173,77 @@ public record LocationMapping
 
     public MapStatus Status { get; set; }
 }
+
+public record UnmappedFilter
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = "";
+    public string ColumnName { get; set; } = "";
+
+    // All child groups of an unmapped filter must also be unmapped
+    public List<UnmappedFilterGroup> UnmappedReplacementFilterGroups { get; set; } = [];
+}
+
+public record UnmappedFilterGroup
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = "";
+
+    // All child items of an unmapped group must also be unmapped
+    public List<UnmappedFilterItem> UnmappedReplacementFilterItems { get; set; } = [];
+}
+
+public record UnmappedFilterItem
+{
+    public Guid Id { get; set; }
+    public string Label { get; set; } = "";
+}
+
+public record FilterMapping
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+    public string OriginalColumnName { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; } = "";
+    public string? ReplacementColumnName { get; set; } = "";
+
+    public Dictionary<Guid, FilterGroupMapping> FilterGroupMappings { get; set; } = [];
+    public List<UnmappedFilterGroup> UnmappedReplacementFilterGroups { get; set; } = [];
+
+    public MapStatus Status { get; set; }
+}
+
+public record FilterGroupMapping
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; } = "";
+
+    public Dictionary<Guid, FilterItemMapping> FilterItemMappings { get; set; } = [];
+    public List<UnmappedFilterItem> UnmappedReplacementFilterItems { get; set; } = [];
+
+    public MapStatus Status { get; set; }
+}
+
+public record FilterItemMapping
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; } = "";
+
+    public MapStatus Status { get; set; }
+}
+
+// @MarkFix add automapping of filters when first generating a DataSetMapping
+// @MarkFix code to generate replacement plan from filter mappings
+// @MarkFix code to complete replacement based on filter mappings
+// @MarkFix add tests for automapping filters
+// @MarkFix add tests for replacement plan generation
+// @MarkFix add tests for completing replacement
+// @MarkFix initialise existing DataSetMappings that don't have FilterMappings set with migration endpoint? or just delete any DataSetMappings to speed up development?

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -123,6 +123,7 @@ public enum MapStatus
     Unset,
     ManuallySet, // user manually mapped this (whether to another Id or nothing)
     AutoSet, // automatically mapped when the initial mapping was created
+    ParentNotMapped,
 }
 
 public record UnmappedIndicator

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -97,9 +97,9 @@ public record DataSetMapping
             builder
                 .Property(x => x.FilterMappings)
                 .HasConversion(
-                    locationMappings => JsonSerializer.Serialize(locationMappings, JsonOptions),
-                    locMappingString =>
-                        JsonSerializer.Deserialize<Dictionary<Guid, FilterMapping>>(locMappingString, JsonOptions)
+                    filterMappings => JsonSerializer.Serialize(filterMappings, JsonOptions),
+                    filterMappingString =>
+                        JsonSerializer.Deserialize<Dictionary<Guid, FilterMapping>>(filterMappingString, JsonOptions)
                         ?? new Dictionary<Guid, FilterMapping>(),
                     ValueComparer.CreateDefault<Dictionary<Guid, FilterMapping>>(false)
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -207,8 +207,8 @@ public record FilterMapping
     public string OriginalColumnName { get; set; } = "";
 
     public Guid? ReplacementId { get; set; }
-    public string? ReplacementLabel { get; set; } = "";
-    public string? ReplacementColumnName { get; set; } = "";
+    public string? ReplacementLabel { get; set; }
+    public string? ReplacementColumnName { get; set; }
 
     public Dictionary<Guid, FilterGroupMapping> FilterGroupMappings { get; set; } = [];
     public List<UnmappedFilterGroup> UnmappedReplacementFilterGroups { get; set; } = [];
@@ -222,7 +222,7 @@ public record FilterGroupMapping
     public string OriginalLabel { get; set; } = "";
 
     public Guid? ReplacementId { get; set; }
-    public string? ReplacementLabel { get; set; } = "";
+    public string? ReplacementLabel { get; set; }
 
     public Dictionary<Guid, FilterItemMapping> FilterItemMappings { get; set; } = [];
     public List<UnmappedFilterItem> UnmappedReplacementFilterItems { get; set; } = [];
@@ -236,7 +236,7 @@ public record FilterItemMapping
     public string OriginalLabel { get; set; } = "";
 
     public Guid? ReplacementId { get; set; }
-    public string? ReplacementLabel { get; set; } = "";
+    public string? ReplacementLabel { get; set; }
 
     public MapStatus Status { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -240,8 +240,3 @@ public record FilterItemMapping
 
     public MapStatus Status { get; set; }
 }
-
-// @MarkFix add tests for automapping filters
-// @MarkFix add tests for replacement plan generation
-// @MarkFix add tests for completing replacement
-// @MarkFix initialise existing DataSetMappings that don't have FilterMappings set with migration endpoint? or just delete any DataSetMappings to speed up development?

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -241,7 +241,6 @@ public record FilterItemMapping
     public MapStatus Status { get; set; }
 }
 
-// @MarkFix code to complete replacement based on filter mappings
 // @MarkFix add tests for automapping filters
 // @MarkFix add tests for replacement plan generation
 // @MarkFix add tests for completing replacement

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -23,8 +23,8 @@ public record DataSetMapping
     public Dictionary<Guid, LocationMapping> LocationMappings { get; init; } = null!;
     public List<UnmappedLocation> UnmappedReplacementLocations { get; init; } = [];
 
-    public Dictionary<Guid, FilterMapping> FilterMappings { get; init; } = null!;
-    public List<UnmappedFilter> UnmappedReplacementFilters { get; init; } = [];
+    public Dictionary<Guid, FilterMapping> FilterMappings { get; set; } = null!; // EES-7370 Change set -> init
+    public List<UnmappedFilter> UnmappedReplacementFilters { get; set; } = []; // EES-7370 Change set -> init
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -241,7 +241,6 @@ public record FilterItemMapping
     public MapStatus Status { get; set; }
 }
 
-// @MarkFix code to generate replacement plan from filter mappings
 // @MarkFix code to complete replacement based on filter mappings
 // @MarkFix add tests for automapping filters
 // @MarkFix add tests for replacement plan generation

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -41,13 +41,8 @@ public class ReleaseFile
     public DateTime? Published { get; set; }
 }
 
-public abstract record SequenceEntry<TEntry, TChild>(TEntry Id, List<TChild> ChildSequence);
+public record FilterSequenceEntry(Guid Id, List<FilterGroupSequenceEntry> FilterGroupSequence);
 
-public record FilterSequenceEntry(Guid Id, List<FilterGroupSequenceEntry> ChildSequence)
-    : SequenceEntry<Guid, FilterGroupSequenceEntry>(Id, ChildSequence);
+public record FilterGroupSequenceEntry(Guid Id, List<Guid> FilterItemSequence);
 
-public record FilterGroupSequenceEntry(Guid Id, List<Guid> ChildSequence)
-    : SequenceEntry<Guid, Guid>(Id, ChildSequence);
-
-public record IndicatorGroupSequenceEntry(Guid Id, List<Guid> ChildSequence)
-    : SequenceEntry<Guid, Guid>(Id, ChildSequence);
+public record IndicatorGroupSequenceEntry(Guid Id, List<Guid> ChildSequence);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
@@ -26,6 +26,298 @@ public class DataSetMappingServiceTests
     private readonly DataFixture _fixture = new();
 
     [Fact]
+    public async Task CreateInitialDataSetMappingIfReplacement_GenerateMapping_Filters_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var originalSubjectId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
+
+        var originalFile = new File
+        {
+            Id = originalDataFileId,
+            SubjectId = originalSubjectId,
+            Type = FileType.Data,
+        };
+
+        var replacementFile = new File
+        {
+            Id = replacementDataFileId,
+            SubjectId = replacementSubjectId,
+            Type = FileType.Data,
+            Replacing = originalFile,
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.Files.AddRange(originalFile, replacementFile);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var originalFilterItem1A1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 1A1" };
+        var originalFilterItem1A2 = new FilterItem
+        {
+            Id = Guid.NewGuid(),
+            Label = "Item 1A2", // no matching replacement
+        };
+        var originalFilterGroup1A = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 1A",
+            FilterItems = [originalFilterItem1A1, originalFilterItem1A2],
+        };
+
+        var originalFilterItem1B1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 1B1" };
+        var originalFilterGroup1B = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 1B", // no matching replacement
+            FilterItems = [originalFilterItem1B1],
+        };
+
+        var originalFilter1 = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Name = "filter1",
+            Label = "Filter 1",
+            FilterGroups = [originalFilterGroup1A, originalFilterGroup1B],
+            SubjectId = originalFile.SubjectId!.Value,
+        };
+
+        var originalFilterItem2A1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 2A1" };
+        var originalFilterGroup2A = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 2A",
+            FilterItems = [originalFilterItem2A1],
+        };
+        var originalFilter2 = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Name = "filter2", // no matching replacement
+            Label = "Filter 2",
+            FilterGroups = [originalFilterGroup2A],
+            SubjectId = originalFile.SubjectId!.Value,
+        };
+
+        var replacementFilterItem1A1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 1A1" };
+        var replacementFilterItem1A2 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 1A2 updated" };
+        var replacementFilterGroup1A = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 1A",
+            FilterItems = [replacementFilterItem1A1, replacementFilterItem1A2],
+        };
+
+        var replacementFilterItem1B1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 1B1" };
+        var replacementFilterGroup1B = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 1B updated",
+            FilterItems = [replacementFilterItem1B1],
+        };
+
+        var replacementFilter1 = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Name = "filter1",
+            Label = "Filter 1",
+            FilterGroups = [replacementFilterGroup1A, replacementFilterGroup1B],
+            SubjectId = replacementFile.SubjectId!.Value,
+        };
+
+        var replacementFilterItem2A1 = new FilterItem { Id = Guid.NewGuid(), Label = "Item 2A1" };
+        var replacementFilterGroup2A = new FilterGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Group 2A",
+            FilterItems = [replacementFilterItem2A1],
+        };
+        var replacementFilter2 = new Filter
+        {
+            Id = Guid.NewGuid(),
+            Name = "filter2-updated",
+            Label = "Filter 2 updated",
+            FilterGroups = [replacementFilterGroup2A],
+            SubjectId = replacementFile.SubjectId!.Value,
+        };
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.Filter.AddRange(
+                originalFilter1,
+                originalFilter2,
+                replacementFilter1,
+                replacementFilter2
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        var service = BuildDataSetMappingService(contentDbContextId, statisticsDbContextId);
+
+        await service.CreateInitialDataSetMappingIfReplacement(replacementFileId: replacementDataFileId);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = contentDbContext.DataSetMappings.Single(m =>
+                m.OriginalDataFileId == originalDataFileId && m.ReplacementDataFileId == replacementDataFileId
+            );
+
+            var expectedMapping = new DataSetMapping
+            {
+                OriginalDataFileId = originalDataFileId,
+                ReplacementDataFileId = replacementDataFileId,
+                FilterMappings = new Dictionary<Guid, FilterMapping>
+                {
+                    {
+                        originalFilter1.Id,
+                        CreateFilterMapping(
+                            original: originalFilter1,
+                            replacement: replacementFilter1,
+                            status: MapStatus.AutoSet,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup1A.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup1A,
+                                        replacement: replacementFilterGroup1A,
+                                        status: MapStatus.AutoSet,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem1A1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1A1.Id,
+                                                    OriginalLabel = originalFilterItem1A1.Label,
+                                                    ReplacementId = replacementFilterItem1A1.Id,
+                                                    ReplacementLabel = replacementFilterItem1A1.Label,
+                                                    Status = MapStatus.AutoSet,
+                                                }
+                                            },
+                                            {
+                                                originalFilterItem1A2.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1A2.Id,
+                                                    OriginalLabel = originalFilterItem1A2.Label,
+                                                    Status = MapStatus.Unset,
+                                                }
+                                            },
+                                        },
+                                        unmappedReplacementFilterItems:
+                                        [
+                                            new UnmappedFilterItem
+                                            {
+                                                Id = replacementFilterItem1A2.Id,
+                                                Label = replacementFilterItem1A2.Label,
+                                            },
+                                        ]
+                                    )
+                                },
+                                {
+                                    originalFilterGroup1B.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup1B,
+                                        status: MapStatus.Unset,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem1B1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem1B1.Id,
+                                                    OriginalLabel = originalFilterItem1B1.Label,
+                                                    Status = MapStatus.ParentNotMapped,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            },
+                            unmappedReplacementFilterGroups:
+                            [
+                                new UnmappedFilterGroup
+                                {
+                                    Id = replacementFilterGroup1B.Id,
+                                    Label = replacementFilterGroup1B.Label,
+                                    UnmappedReplacementFilterItems =
+                                    [
+                                        new UnmappedFilterItem
+                                        {
+                                            Id = replacementFilterItem1B1.Id,
+                                            Label = replacementFilterItem1B1.Label,
+                                        },
+                                    ],
+                                },
+                            ]
+                        )
+                    },
+                    {
+                        originalFilter2.Id,
+                        CreateFilterMapping(
+                            original: originalFilter2,
+                            status: MapStatus.Unset,
+                            filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                            {
+                                {
+                                    originalFilterGroup2A.Id,
+                                    CreateFilterGroupMapping(
+                                        original: originalFilterGroup2A,
+                                        status: MapStatus.ParentNotMapped,
+                                        filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                        {
+                                            {
+                                                originalFilterItem2A1.Id,
+                                                new FilterItemMapping
+                                                {
+                                                    OriginalId = originalFilterItem2A1.Id,
+                                                    OriginalLabel = originalFilterItem2A1.Label,
+                                                    Status = MapStatus.ParentNotMapped,
+                                                }
+                                            },
+                                        }
+                                    )
+                                },
+                            }
+                        )
+                    },
+                },
+                UnmappedReplacementFilters =
+                [
+                    new UnmappedFilter
+                    {
+                        Id = replacementFilter2.Id,
+                        ColumnName = replacementFilter2.Name,
+                        Label = replacementFilter2.Label,
+                        UnmappedReplacementFilterGroups =
+                        [
+                            new UnmappedFilterGroup
+                            {
+                                Id = replacementFilterGroup2A.Id,
+                                Label = replacementFilterGroup2A.Label,
+                                UnmappedReplacementFilterItems =
+                                [
+                                    new UnmappedFilterItem
+                                    {
+                                        Id = replacementFilterItem2A1.Id,
+                                        Label = replacementFilterItem2A1.Label,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+            result.AssertDeepEqualTo(expectedMapping, ignoreProperties: [mapping => mapping.Id]);
+        }
+    }
+
+    [Fact]
     public async Task CreateInitialDataSetMappingIfReplacement_GenerateMapping_Indicators_Success()
     {
         var originalDataFileId = Guid.NewGuid();
@@ -440,6 +732,48 @@ public class DataSetMappingServiceTests
         );
 
         return new DataSetMappingService(dbContextSupplier);
+    }
+
+    private static FilterMapping CreateFilterMapping(
+        Filter original,
+        Filter? replacement = null,
+        Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
+        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterMapping
+        {
+            OriginalId = original.Id,
+            OriginalColumnName = original.Name,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementColumnName = replacement?.Name,
+            ReplacementLabel = replacement?.Label,
+            FilterGroupMappings = filterGroupMappings ?? [],
+            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
+            Status = status,
+        };
+    }
+
+    private static FilterGroupMapping CreateFilterGroupMapping(
+        FilterGroup original,
+        FilterGroup? replacement = null,
+        Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
+        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
+        MapStatus status = MapStatus.Unset
+    )
+    {
+        return new FilterGroupMapping
+        {
+            OriginalId = original.Id,
+            OriginalLabel = original.Label,
+            ReplacementId = replacement?.Id,
+            ReplacementLabel = replacement?.Label,
+            FilterItemMappings = filterItemMappings ?? [],
+            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
+            Status = status,
+        };
     }
 
     private static IndicatorMapping CreateIndicatorMapping(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -1,8 +1,10 @@
 #nullable enable
+using AngleSharp.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -27,13 +29,19 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
 
         var originalFile = replacementFile.Replacing!;
 
-        var (initialIndicatorMappingDictionary, unmappedReplacementIndicators) = await GenerateInitialIndicatorMapping(
+        var (indicatorMappings, unmappedReplacementIndicators) = await GenerateInitialIndicatorMapping(
             statisticsDbContext,
             originalFile.SubjectId!.Value,
             replacementFile.SubjectId!.Value
         );
 
-        var (initialLocationMappingDictionary, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
+        var (locationMappings, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
+            statisticsDbContext,
+            originalFile.SubjectId!.Value,
+            replacementFile.SubjectId!.Value
+        );
+
+        var (filterMappings, unmappedReplacementFilters) = await GenerateInitialFilterMapping(
             statisticsDbContext,
             originalFile.SubjectId!.Value,
             replacementFile.SubjectId!.Value
@@ -43,10 +51,12 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         {
             OriginalDataFileId = originalFile.Id,
             ReplacementDataFileId = replacementFile.Id,
-            IndicatorMappings = initialIndicatorMappingDictionary,
+            IndicatorMappings = indicatorMappings,
             UnmappedReplacementIndicators = unmappedReplacementIndicators,
-            LocationMappings = initialLocationMappingDictionary,
+            LocationMappings = locationMappings,
             UnmappedReplacementLocations = unmappedReplacementLocations,
+            FilterMappings = filterMappings,
+            UnmappedReplacementFilters = unmappedReplacementFilters,
         };
 
         contentDbContext.DataSetMappings.Add(newMapping);
@@ -69,7 +79,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             .Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
             .ToDictionaryAsync(i => i.Name, i => i);
 
-        var initialMappingDictionary = originalIndicators.ToDictionary(
+        var indicatorMappings = originalIndicators.ToDictionary(
             originalIndicator => originalIndicator.Id,
             originalIndicator =>
             {
@@ -105,12 +115,12 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             }
         );
 
-        var mappedReplacementIds = initialMappingDictionary
+        var mappedReplacementIndicatorIds = indicatorMappings
             .Values.Where(m => m.ReplacementId.HasValue)
             .Select(m => m.ReplacementId!.Value);
 
-        var unmappedReplacements = replacementIndicatorNameToIndicatorMap
-            .Values.ExceptBy(mappedReplacementIds, indicator => indicator.Id)
+        var unmappedReplacementIndicators = replacementIndicatorNameToIndicatorMap
+            .Values.ExceptBy(mappedReplacementIndicatorIds, indicator => indicator.Id)
             .Select(i => new UnmappedIndicator
             {
                 Id = i.Id,
@@ -121,7 +131,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             })
             .ToList();
 
-        return (initialMappingDictionary, unmappedReplacements);
+        return (indicatorMappings, unmappedReplacementIndicators);
     }
 
     private async Task<(Dictionary<Guid, LocationMapping>, List<UnmappedLocation>)> GenerateInitialLocationMapping(
@@ -137,31 +147,31 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             .Distinct()
             .ToListAsync();
 
-        var replacementLocationMap = await statisticsDbContext
+        var replacementIdToLocationMap = await statisticsDbContext
             .Observation.AsNoTracking()
             .Where(o => o.SubjectId == replacementSubjectId)
             .Select(observation => observation.Location)
             .Distinct()
             .ToDictionaryAsync(location => location.Id, location => location);
 
-        var initialMappingDictionary = originalLocations.ToDictionary(
+        var locationMappings = originalLocations.ToDictionary(
             originalLocation => originalLocation.Id,
             originalLocation =>
             {
-                replacementLocationMap.TryGetValue(originalLocation.Id, out var replacementLocation);
+                replacementIdToLocationMap.TryGetValue(originalLocation.Id, out var replacementLocation);
                 if (replacementLocation == null)
                 {
                     // If none matching by Id, check if any matching by GeogLvl + Code. We don't check by Name to
                     // preserve behaviour from before location mapping was introduced (which allowed analysts to
                     // change/fix location names with replacements).
-                    var candidateReplacements = replacementLocationMap
+                    var matchingReplacements = replacementIdToLocationMap
                         .Values.Where(location =>
                             location.GeographicLevel == originalLocation.GeographicLevel
                             && location.ToLocationAttribute().GetCodeOrFallback()
                                 == originalLocation.ToLocationAttribute().GetCodeOrFallback()
                         )
                         .ToList();
-                    replacementLocation = candidateReplacements.Count == 1 ? candidateReplacements[0] : null;
+                    replacementLocation = matchingReplacements.Count == 1 ? matchingReplacements[0] : null;
                 }
 
                 return new LocationMapping
@@ -179,12 +189,12 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             }
         );
 
-        var mappedReplacementIds = initialMappingDictionary
+        var mappedReplacementLocationIds = locationMappings
             .Values.Where(map => map.ReplacementId.HasValue)
             .Select(map => map.ReplacementId!.Value);
 
-        var unmappedReplacements = replacementLocationMap
-            .Values.ExceptBy(mappedReplacementIds, location => location.Id)
+        var unmappedReplacementLocations = replacementIdToLocationMap
+            .Values.ExceptBy(mappedReplacementLocationIds, location => location.Id)
             .Select(location => new UnmappedLocation
             {
                 Id = location.Id,
@@ -194,6 +204,220 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             })
             .ToList();
 
-        return (initialMappingDictionary, unmappedReplacements);
+        return (locationMappings, unmappedReplacementLocations);
+    }
+
+    private static async Task<(Dictionary<Guid, FilterMapping>, List<UnmappedFilter>)> GenerateInitialFilterMapping(
+        StatisticsDbContext statisticsDbContext,
+        Guid originalSubjectId,
+        Guid replacementSubjectId
+    )
+    {
+        var originalFilters = await statisticsDbContext
+            .Filter.AsNoTracking()
+            .Include(f => f.FilterGroups)
+                .ThenInclude(fg => fg.FilterItems)
+            .Where(f => f.SubjectId == originalSubjectId)
+            .ToListAsync();
+
+        var replacementFilters = await statisticsDbContext
+            .Filter.AsNoTracking()
+            .Include(f => f.FilterGroups)
+                .ThenInclude(fg => fg.FilterItems)
+            .Where(f => f.SubjectId == replacementSubjectId)
+            .ToListAsync();
+
+        // Create dictionaries to speed up performance when creating filterMappings/unmappedReplacementFilters
+        var replacementFiltersMap = replacementFilters.ToDictionary(f => f.Name, f => f); // automap filters by column name
+
+        var replacementFilterIdToGroupLabelToGroupMap = replacementFilters
+            .SelectMany(f => f.FilterGroups.Select(g => new { FilterId = f.Id, FilterGroup = g }))
+            .GroupBy(x => x.FilterId)
+            .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterGroup.Label, g => g.FilterGroup)); // automap groups by label
+
+        var replacementGroupIdToItemLabelToItemMap = replacementFilters
+            .SelectMany(f => f.FilterGroups)
+            .SelectMany(g => g.FilterItems.Select(i => new { FilterGroupId = g.Id, FilterItem = i }))
+            .GroupBy(x => x.FilterGroupId)
+            .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterItem.Label, g => g.FilterItem)); // automap items by label
+
+        // Now we created FilterMappings
+        var filterMappings = new Dictionary<Guid, FilterMapping>();
+        foreach (var originalFilter in originalFilters)
+        {
+            replacementFiltersMap.TryGetValue(originalFilter.Name, out var replacementFilter);
+
+            var replacementGroupLabelToGroupMap =
+                replacementFilter != null
+                    ? replacementFilterIdToGroupLabelToGroupMap.GetValueOrDefault(replacementFilter.Id)
+                    : null;
+
+            var (filterGroupMappings, unmappedReplacementGroups) = GenerateInitialFilterGroupMapping(
+                originalFilter.FilterGroups,
+                replacementGroupLabelToGroupMap,
+                replacementGroupIdToItemLabelToItemMap
+            );
+
+            var filterMapping = new FilterMapping
+            {
+                OriginalId = originalFilter.Id,
+                OriginalColumnName = originalFilter.Name,
+                OriginalLabel = originalFilter.Label,
+
+                ReplacementId = replacementFilter?.Id,
+                ReplacementColumnName = replacementFilter?.Name,
+                ReplacementLabel = replacementFilter?.Label,
+
+                FilterGroupMappings = filterGroupMappings,
+                UnmappedReplacementFilterGroups = unmappedReplacementGroups,
+
+                Status = replacementFilter == null ? MapStatus.Unset : MapStatus.AutoSet,
+            };
+
+            filterMappings.Add(filterMapping.OriginalId, filterMapping);
+        }
+
+        // Now we create UnmappedReplacementFilters
+        var mappedReplacementFilterIds = filterMappings
+            .Values.Where(m => m.ReplacementId.HasValue)
+            .Select(m => m.ReplacementId!.Value);
+
+        var unmappedReplacementFilters = replacementFiltersMap
+            .Values.ExceptBy(mappedReplacementFilterIds, filter => filter.Id)
+            .Select(filter => new UnmappedFilter
+            {
+                Id = filter.Id,
+                Label = filter.Label,
+                ColumnName = filter.Name,
+
+                UnmappedReplacementFilterGroups = filter
+                    .FilterGroups.Select(group => new UnmappedFilterGroup
+                    {
+                        Id = group.Id,
+                        Label = group.Label,
+                        UnmappedReplacementFilterItems = group
+                            .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                            .ToList(),
+                    })
+                    .ToList(),
+            })
+            .ToList();
+
+        return (filterMappings, unmappedReplacementFilters);
+    }
+
+    private static (Dictionary<Guid, FilterGroupMapping>, List<UnmappedFilterGroup>) GenerateInitialFilterGroupMapping(
+        List<FilterGroup> originalFilterGroups,
+        Dictionary<string, FilterGroup>? replacementGroupLabelToGroupMap,
+        Dictionary<Guid, Dictionary<string, FilterItem>> replacementGroupIdToItemLabelToItemMap
+    )
+    {
+        var filterGroupMappings = new Dictionary<Guid, FilterGroupMapping>();
+
+        foreach (var originalFilterGroup in originalFilterGroups)
+        {
+            FilterGroup? replacementFilterGroup = null;
+            replacementGroupLabelToGroupMap?.TryGetValue(originalFilterGroup.Label, out replacementFilterGroup);
+
+            var replacementItemLabelToItemMap =
+                replacementFilterGroup != null
+                    ? replacementGroupIdToItemLabelToItemMap.GetValueOrDefault(replacementFilterGroup.Id)
+                    : null;
+            var (filterItemMappings, unmappedReplacementItems) = GenerateInitialFilterItemMapping(
+                originalFilterGroup.FilterItems,
+                replacementItemLabelToItemMap
+            );
+
+            var filterGroupMapping = new FilterGroupMapping
+            {
+                OriginalId = originalFilterGroup.Id,
+                OriginalLabel = originalFilterGroup.Label,
+
+                ReplacementId = replacementFilterGroup?.Id,
+                ReplacementLabel = replacementFilterGroup?.Label,
+
+                FilterItemMappings = filterItemMappings,
+                UnmappedReplacementFilterItems = unmappedReplacementItems,
+
+                Status =
+                    replacementGroupLabelToGroupMap == null
+                        ? MapStatus.ParentNotMapped
+                        : (replacementFilterGroup == null ? MapStatus.Unset : MapStatus.AutoSet),
+            };
+
+            filterGroupMappings.Add(filterGroupMapping.OriginalId, filterGroupMapping);
+        }
+
+        // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
+        // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
+        var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
+        if (replacementGroupLabelToGroupMap != null) // if parent filter isn't mapped, no group replacements to refer to
+        {
+            var mappedReplacementGroupIds = filterGroupMappings
+                .Values.Where(m => m.ReplacementId.HasValue)
+                .Select(m => m.ReplacementId!.Value);
+
+            unmappedReplacementGroups = replacementGroupLabelToGroupMap
+                .Values.ExceptBy(mappedReplacementGroupIds, group => group.Id)
+                .Select(group => new UnmappedFilterGroup
+                {
+                    Id = group.Id,
+                    Label = group.Label,
+
+                    UnmappedReplacementFilterItems = group
+                        .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                        .ToList(),
+                })
+                .ToList();
+        }
+
+        return (filterGroupMappings, unmappedReplacementGroups);
+    }
+
+    private static (Dictionary<Guid, FilterItemMapping>, List<UnmappedFilterItem>) GenerateInitialFilterItemMapping(
+        List<FilterItem> originalFilterItems,
+        Dictionary<string, FilterItem>? replacementItemLabelToItemMap
+    )
+    {
+        var filterItemMappings = new Dictionary<Guid, FilterItemMapping>();
+
+        foreach (var originalFilterItem in originalFilterItems)
+        {
+            FilterItem? replacementFilterItem = null;
+            replacementItemLabelToItemMap?.TryGetValue(originalFilterItem.Label, out replacementFilterItem);
+
+            var filterItemMapping = new FilterItemMapping
+            {
+                OriginalId = originalFilterItem.Id,
+                OriginalLabel = originalFilterItem.Label,
+
+                ReplacementId = replacementFilterItem?.Id,
+                ReplacementLabel = replacementFilterItem?.Label,
+
+                Status =
+                    replacementItemLabelToItemMap == null
+                        ? MapStatus.ParentNotMapped
+                        : (replacementFilterItem == null ? MapStatus.Unset : MapStatus.AutoSet),
+            };
+
+            filterItemMappings.Add(filterItemMapping.OriginalId, filterItemMapping);
+        }
+
+        // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
+        // if parent is mapped, we can figure out which replacement items for this group are unmapped
+        var unmappedReplacementItems = new List<UnmappedFilterItem>();
+        if (replacementItemLabelToItemMap != null) // if parent isn't mapped, no replacement so no unmappedReplacementItems
+        {
+            var mappedReplacementItemIds = filterItemMappings
+                .Values.Where(m => m.ReplacementId.HasValue)
+                .Select(m => m.ReplacementId!.Value);
+
+            unmappedReplacementItems = replacementItemLabelToItemMap
+                .Values.ExceptBy(mappedReplacementItemIds, item => item.Id)
+                .Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
+                .ToList();
+        }
+
+        return (filterItemMappings, unmappedReplacementItems);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -351,8 +351,9 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
         // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
         var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
-        if (replacementGroupLabelToGroupMap != null) // if parent filter isn't mapped, no group replacements to refer to
+        if (replacementGroupLabelToGroupMap != null)
         {
+            // parent filter is mapped
             var mappedReplacementGroupIds = filterGroupMappings
                 .Values.Where(m => m.ReplacementId.HasValue)
                 .Select(m => m.ReplacementId!.Value);
@@ -406,8 +407,9 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
         // if parent is mapped, we can figure out which replacement items for this group are unmapped
         var unmappedReplacementItems = new List<UnmappedFilterItem>();
-        if (replacementItemLabelToItemMap != null) // if parent isn't mapped, no replacement so no unmappedReplacementItems
+        if (replacementItemLabelToItemMap != null)
         {
+            // parent is mapped
             var mappedReplacementItemIds = filterItemMappings
                 .Values.Where(m => m.ReplacementId.HasValue)
                 .Select(m => m.ReplacementId!.Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -213,19 +213,16 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         Guid replacementSubjectId
     )
     {
-        var originalFilters = await statisticsDbContext
+        var filters = await statisticsDbContext
             .Filter.AsNoTracking()
             .Include(f => f.FilterGroups)
                 .ThenInclude(fg => fg.FilterItems)
-            .Where(f => f.SubjectId == originalSubjectId)
+            .Where(f => f.SubjectId == originalSubjectId || f.SubjectId == replacementSubjectId)
             .ToListAsync();
 
-        var replacementFilters = await statisticsDbContext
-            .Filter.AsNoTracking()
-            .Include(f => f.FilterGroups)
-                .ThenInclude(fg => fg.FilterItems)
-            .Where(f => f.SubjectId == replacementSubjectId)
-            .ToListAsync();
+        var originalFilters = filters.Where(f => f.SubjectId == originalSubjectId).ToList();
+
+        var replacementFilters = filters.Where(f => f.SubjectId == replacementSubjectId).ToList();
 
         // Create dictionaries to speed up performance when creating filterMappings/unmappedReplacementFilters
         var replacementFiltersMap = replacementFilters.ToDictionary(f => f.Name, f => f); // automap filters by column name

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectMetaServiceTests.cs
@@ -1125,32 +1125,32 @@ public class SubjectMetaServiceTests
             var savedFilter1 = savedSequence[0];
             Assert.Equal(request[0].Id, savedFilter1.Id);
 
-            Assert.Equal(2, savedFilter1.ChildSequence.Count);
-            var savedFilter1Group1 = savedFilter1.ChildSequence[0];
-            var savedFilter1Group2 = savedFilter1.ChildSequence[1];
+            Assert.Equal(2, savedFilter1.FilterGroupSequence.Count);
+            var savedFilter1Group1 = savedFilter1.FilterGroupSequence[0];
+            var savedFilter1Group2 = savedFilter1.FilterGroupSequence[1];
 
             Assert.Equal(request[0].FilterGroups[0].Id, savedFilter1Group1.Id);
             Assert.Equal(request[0].FilterGroups[1].Id, savedFilter1Group2.Id);
 
-            Assert.Equal(2, savedFilter1Group1.ChildSequence.Count);
-            Assert.Equal(request[0].FilterGroups[0].FilterItems[0], savedFilter1Group1.ChildSequence[0]);
-            Assert.Equal(request[0].FilterGroups[0].FilterItems[1], savedFilter1Group1.ChildSequence[1]);
+            Assert.Equal(2, savedFilter1Group1.FilterItemSequence.Count);
+            Assert.Equal(request[0].FilterGroups[0].FilterItems[0], savedFilter1Group1.FilterItemSequence[0]);
+            Assert.Equal(request[0].FilterGroups[0].FilterItems[1], savedFilter1Group1.FilterItemSequence[1]);
 
-            Assert.Equal(2, savedFilter1Group2.ChildSequence.Count);
-            Assert.Equal(request[0].FilterGroups[1].FilterItems[0], savedFilter1Group2.ChildSequence[0]);
-            Assert.Equal(request[0].FilterGroups[1].FilterItems[1], savedFilter1Group2.ChildSequence[1]);
+            Assert.Equal(2, savedFilter1Group2.FilterItemSequence.Count);
+            Assert.Equal(request[0].FilterGroups[1].FilterItems[0], savedFilter1Group2.FilterItemSequence[0]);
+            Assert.Equal(request[0].FilterGroups[1].FilterItems[1], savedFilter1Group2.FilterItemSequence[1]);
 
             // Filter 2
             var savedFilter2 = savedSequence[1];
             Assert.Equal(request[1].Id, savedFilter2.Id);
 
-            Assert.Single(savedFilter2.ChildSequence);
-            var savedFilter2Group1 = savedFilter2.ChildSequence[0];
+            Assert.Single(savedFilter2.FilterGroupSequence);
+            var savedFilter2Group1 = savedFilter2.FilterGroupSequence[0];
 
             Assert.Equal(request[1].FilterGroups[0].Id, savedFilter2Group1.Id);
 
-            Assert.Single(savedFilter2Group1.ChildSequence);
-            Assert.Equal(request[1].FilterGroups[0].FilterItems[0], savedFilter2Group1.ChildSequence[0]);
+            Assert.Single(savedFilter2Group1.FilterItemSequence);
+            Assert.Equal(request[1].FilterGroups[0].FilterItems[0], savedFilter2Group1.FilterItemSequence[0]);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/FiltersMetaViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/FiltersMetaViewModelBuilder.cs
@@ -31,7 +31,7 @@ public static class FiltersMetaViewModelBuilder
             {
                 return new FilterMetaViewModel(input, index)
                 {
-                    Options = BuildFilterGroups(input.Value.FilterGroups, input.Sequence?.ChildSequence),
+                    Options = BuildFilterGroups(input.Value.FilterGroups, input.Sequence?.FilterGroupSequence),
                 };
             },
             sequence: sequence
@@ -60,7 +60,7 @@ public static class FiltersMetaViewModelBuilder
             resultSelector: (input, index) =>
                 new FilterGroupMetaViewModel(input, index)
                 {
-                    Options = BuildFilterItems(input.Value.FilterItems, input.Sequence?.ChildSequence),
+                    Options = BuildFilterItems(input.Value.FilterItems, input.Sequence?.FilterItemSequence),
                 },
             sequence: sequence
         );

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionsTests.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.TestData;
 using Microsoft.EntityFrameworkCore;
+using FilterMapping = GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMapping;
 using IndicatorMapping = GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMapping;
 
 #pragma warning disable CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well.

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -95,6 +95,7 @@ describe('ReleaseDataFileReplacePage', () => {
 
   const testValidReplacementPlan: DataReplacementPlan = {
     valid: true,
+    hasDataBlockAndReplacementHasAdditionalFilter: false,
     dataBlocks: [],
     footnotes: [],
     originalSubjectId: 'subject-1',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -423,7 +423,7 @@ function Plan({
                         {Object.values(filter.groups).map(group => (
                           <SummaryListItem key={group.id} term={group.label}>
                             <ul className="govuk-list">
-                              {group.filters.map(filterItem => (
+                              {group.items.map(filterItem => (
                                 <li key={filterItem.id}>
                                   {filterItem.label}
                                   {!filterItem.valid && notPresentTag}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
@@ -23,6 +23,7 @@ const testReplacementPlan: DataReplacementPlan = {
   originalSubjectId: 'subId',
   replacementSubjectId: 'repId',
   valid: false,
+  hasDataBlockAndReplacementHasAdditionalFilter: false,
   footnotes: [],
   mapping: {
     indicators: {
@@ -146,7 +147,7 @@ const testReplacementPlan: DataReplacementPlan = {
             '7f7dd166-b7bc-4d09-83b5-19756451278b': {
               id: '7f7dd166-b7bc-4d09-83b5-19756451278b',
               label: 'Default',
-              filters: [
+              items: [
                 {
                   id: '6424fca3-f3b7-4d99-b5c4-9711556aaec3',
                   label: 'Not specified',
@@ -219,6 +220,7 @@ const testReplacementPlanWithLocation: DataReplacementPlan = {
   originalSubjectId: 'subId',
   replacementSubjectId: 'repId',
   valid: false,
+  hasDataBlockAndReplacementHasAdditionalFilter: false,
   footnotes: [],
   mapping: {
     indicators: {
@@ -342,7 +344,7 @@ const testReplacementPlanWithLocation: DataReplacementPlan = {
             '7f7dd166-b7bc-4d09-83b5-19756451278b': {
               id: '7f7dd166-b7bc-4d09-83b5-19756451278b',
               label: 'Default',
-              filters: [
+              items: [
                 {
                   id: '6424fca3-f3b7-4d99-b5c4-9711556aaec3',
                   label: 'Not specified',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -43,7 +43,7 @@ describe('DataReplacementPlan', () => {
                 id: 'group-1',
                 label: 'Group 1',
                 valid: false,
-                filters: [
+                items: [
                   {
                     id: 'item-1',
                     label: 'Item 1',
@@ -61,7 +61,7 @@ describe('DataReplacementPlan', () => {
                 id: 'group-2',
                 label: 'Group 2',
                 valid: true,
-                filters: [
+                items: [
                   {
                     id: 'item-3',
                     label: 'Item 3',
@@ -83,7 +83,7 @@ describe('DataReplacementPlan', () => {
                 label: 'Group 3',
                 target: 'target-group-3',
                 valid: true,
-                filters: [
+                items: [
                   {
                     id: 'item-4',
                     label: 'Item 4',
@@ -96,7 +96,7 @@ describe('DataReplacementPlan', () => {
                 id: 'group-4',
                 label: 'Group 4',
                 valid: false,
-                filters: [
+                items: [
                   {
                     id: 'item-5',
                     label: 'Item 5',
@@ -344,6 +344,7 @@ describe('DataReplacementPlan', () => {
     originalSubjectId: 'subject-1',
     replacementSubjectId: 'subject-2',
     valid: false,
+    hasDataBlockAndReplacementHasAdditionalFilter: false,
     mapping: {
       indicators: { candidates: {}, mappings: {} },
       locations: { candidates: {}, mappings: {} },
@@ -410,6 +411,7 @@ describe('DataReplacementPlan', () => {
       valid: true,
     },
     valid: true,
+    hasDataBlockAndReplacementHasAdditionalFilter: false,
     mapping: {
       indicators: { candidates: {}, mappings: {} },
       locations: { candidates: {}, mappings: {} },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -60,6 +60,7 @@ describe('DataFilesReplacementTableRow', () => {
       readyToPublish: false,
     },
     valid: true,
+    hasDataBlockAndReplacementHasAdditionalFilter: false,
     mapping: {
       indicators: { mappings: {}, candidates: {} },
       locations: { mappings: {}, candidates: {} },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -130,6 +130,7 @@ describe('ReleaseDataUploadsSection', () => {
 
   const testValidReplacementPlan: DataReplacementPlan = {
     valid: true,
+    hasDataBlockAndReplacementHasAdditionalFilter: false,
     dataBlocks: [],
     footnotes: [],
     originalSubjectId: 'subject-1',

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -119,7 +119,7 @@ export interface ApiDataSetVersionPlan {
   valid: boolean;
 }
 
-type MappingType = 'Unset' | 'ManuallySet' | 'AutoSet';
+type MappingType = 'Unset' | 'ManuallySet' | 'AutoSet' | 'ParentNotMapped';
 
 export interface ReplacementMapping<TSource> {
   type: MappingType;

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -182,8 +182,11 @@ export interface DataReplacementPlan {
   dataBlocks: DataBlockReplacementPlan[];
   footnotes: FootnoteReplacementPlan[];
   apiDataSetVersionPlan?: ApiDataSetVersionPlan;
-  valid: boolean;
   mapping: PlanMappings;
+  // a replacement is invalid if a data blocks exist and an additional filter has been added to the replacement, as
+  // data blocks will be missing a filter items
+  hasDataBlockAndReplacementHasAdditionalFilter: boolean;
+  valid: boolean;
 }
 
 type PlanMappingIndicatorsUpdateResponse = {

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -18,7 +18,7 @@ export interface FilterReplacement extends TargetReplacement {
 }
 
 export interface FilterGroupReplacement extends TargetReplacement {
-  filters: FilterItemReplacement[];
+  items: FilterItemReplacement[];
 }
 
 export type FilterItemReplacement = TargetReplacement;

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -184,7 +184,7 @@ export interface DataReplacementPlan {
   apiDataSetVersionPlan?: ApiDataSetVersionPlan;
   mapping: PlanMappings;
   // a replacement is invalid if a data blocks exist and an additional filter has been added to the replacement, as
-  // data blocks will be missing a filter items
+  // data blocks will be missing a filter item
   hasDataBlockAndReplacementHasAdditionalFilter: boolean;
   valid: boolean;
 }

--- a/tests/test-data/files/small-files/replace-data/one_location_change_after.csv
+++ b/tests/test-data/files/small-files/replace-data/one_location_change_after.csv
@@ -1,0 +1,8 @@
+time_identifier,time_period,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,ind_one,ind_two
+Academic year,202021,Local authority,E92000001,England,330,E08000026,BirminghamUpdated,1,2
+Academic year,202122,Local authority,E92000001,England,370,E08000016,Barnsley,1,2
+Academic year,202223,Local authority,E92000001,England,203,E09000011,Greenwich,1,2
+Academic year,202223,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,330,E08000026,BirminghamUpdated,2,2
+Academic year,202425,Local authority,E92000001,England,330,E08000026,BirminghamUpdated,2,2

--- a/tests/test-data/files/small-files/replace-data/one_location_change_after.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/one_location_change_after.meta.csv
@@ -1,0 +1,3 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+ind_one,Indicator,Indicator one,Indicator group,,,,
+ind_two,Indicator,Indicator two,Indicator group,,,,

--- a/tests/test-data/files/small-files/replace-data/one_location_change_before.csv
+++ b/tests/test-data/files/small-files/replace-data/one_location_change_before.csv
@@ -1,0 +1,8 @@
+time_identifier,time_period,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,ind_one,ind_two
+Academic year,202021,Local authority,E92000001,England,330,E08000025,Birmingham,1,2
+Academic year,202122,Local authority,E92000001,England,370,E08000016,Barnsley,1,2
+Academic year,202223,Local authority,E92000001,England,203,E09000011,Greenwich,1,2
+Academic year,202223,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,330,E08000025,Birmingham,2,2
+Academic year,202425,Local authority,E92000001,England,330,E08000025,Birmingham,2,2

--- a/tests/test-data/files/small-files/replace-data/one_location_change_before.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/one_location_change_before.meta.csv
@@ -1,0 +1,3 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+ind_one,Indicator,Indicator one,Indicator group,,,,
+ind_two,Indicator,Indicator two,Indicator group,,,,

--- a/tests/test-data/files/small-files/replace-data/remove_filter_before.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/remove_filter_before.meta.csv
@@ -1,6 +1,6 @@
 col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
 pupil_sen_status,Filter,SEN provision,,,,EHC plan/Statement of SEN or SEN support/School Action/School Action plus,
-primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI…)",
+primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI)",
 number_of_pupils,Indicator,Headcount,Number of pupils,,0,,
 pupil_gender_boys,Indicator,Boys,Gender,,0,,
 pupil_gender_girls,Indicator,Girls,Gender,,0,,


### PR DESCRIPTION
This PR adds filters to DataSetMapping. This means that rather than linking filters/groups/items on the fly when generating a replacement plan, we now use the FilterMappings and UnmappedReplacementFilters columns to both generate replacement plans and complete replacements (i.e. swap guids in DataBlocks/Footnotes/FilterSequences from originalDataSet -> replacementDataSet)

FilterMappings contain an entry for every single filter in the original data set, and contain group mappings, which in turn contain item mappings. If an item's parent group doesn't have a replacement set, then it will not have a replacement set and will have the new `MapStatus.ParentNotMapped`. Equally, if a group's parent filter doesn't have a replacement set, it also will not have a replacement set and have the `ParentNotMapped` status. This restriction was decided on in order to avoid mappings contradicting each other (i.e. item mapped to an item from a different filter than it's parent filter is mapped to) and/or avoid complex logic to avoid mappings conflicts.

The cost of this approach is that users will have to map the parent filter before they can map a group, and map a parent group before they can map an item. But overall I think it was a good decision - much of the logic required for filter mappings, especially the FilterSequence replacement code (compared to IndicatorSequence), is much simpler as a result.

:rotating_light: After deploying this work, `FilterMappings` for existing DataSetMappings table entries will be empty. This will be fixed by a faffy task to run the BAU endpoint created in this PR immediately after this is deployed. :rotating_light: 

### Other changes

- The `NewlyIntroducedFilters.IsNullOrEmpty()` validity check found in `DataBlockReplacementPlanViewModel` has been replaced by `HasDataBlockAndReplacementHasAdditionalFilter` check in `DataReplacementPlanViewModel`. See code commnent for more details.
- I've removed a character that the screener was failing to parse from `small-files/replace-data/remove_filter_before.meta.csv`. See EES-7365.
- Added a new data set to test location mapping.