### PR TITLE
EES-XXXX - force build Screener API Docker image regularly

### DIFF
--- a/useful-scripts/start.ts
+++ b/useful-scripts/start.ts
@@ -348,11 +348,23 @@ async function startDockerServices() {
       servicesToStart.includes('admin') ||
       servicesToStart.includes('dataScreener')
     ) {
+      await $$`docker compose down data-screener`;
+      await $$`docker compose rm -f data-screener`;
+
       cloneRequiredRepository(
         screenerRepositoryName,
         screenerLocalDir,
         screenerRepoUrl,
       );
+
+      // Pull the CRAN packages from a repository snapshot 3 weeks old to better ensure
+      // that we're grabbing dependencies that have pre-compiled binaries during local
+      // development.
+      //
+      // The Screener API build pipeline will continue to pull from the very latest CRAN
+      // repositories as build speed in the build pipeline is not as crucial as it is locally.
+      const cranSnapshotDate = getMondayDateStringForPriorWeek(3);
+      await $$`docker build --build-arg CRAN_REPOSITORY_SNAPSHOT_VERSION=${cranSnapshotDate} -t explore-education-statistics-data-screener ${screenerLocalDir}`;
     }
 
     await $$`docker compose up ${[...args, ...dockerServicesToStart]}`;
@@ -554,4 +566,16 @@ function cloneRequiredRepository(
       console.error(`Failed to pull repository '${repositoryName}'`);
     }
   }
+}
+
+function getMondayDateStringForPriorWeek(numberOfWeeksPrior: number): string {
+  const today = new Date();
+  const dayOfWeek = today.getDay();
+  const isoDayOfWeek = dayOfWeek === 0 ? 7 : dayOfWeek;
+
+  const daysToSubtract = isoDayOfWeek + numberOfWeeksPrior * 7 - 1;
+
+  const previousMonday = new Date(today);
+  previousMonday.setDate(today.getDate() - daysToSubtract);
+  return previousMonday.toISOString().split('T')[0];
 }


### PR DESCRIPTION
This PR goes hand-in-hand with a PR in the Screener API - https://github.com/dfe-analytical-services/ees-screener-api/pull/33.

This PR:
- adds a mechanism to `start.ts` that, upon running Admin or Screener, will shut down existing Screener containers, rebuild the Screener API Docker image *if required*, and then continue startup.

## Specifying CRAN repository snapshot date

We've hit a few instances of the "latest" CRAN repositories not having pre-compiled binaries for several of the Screener API and eesyscreener's dependencies.  This results in lengthy Docker image builds during local development as it has to compile the dependencies locally.

To combat this, we now ask for CRAN repositories from "Monday 3 weeks ago" rather than the latest.

The upshot of this is that every week when starting Admin locally, a fresh Screener API Docker image build will occur using the dependencies from 3 weeks ago.  Assuming nothing changes in the meantime in the Screener API repo, no additional Docker image builds will be forced that week.

In the Screener API build pipeline however, it will use the latest, as it's not as crucial to achieve a fast build there.