### PR TITLE
EES-6891: Retrieve subject meta based on matched observations, rather than the table query

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterItemRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/FilterItemRepository.cs
@@ -122,4 +122,20 @@ public class FilterItemRepository(
             .Where(fi => filterItemIds.Contains(fi.Id))
             .ToListAsync();
     }
+
+    public async Task<IList<FilterItem>> GetFilterItemsFromObservations(IEnumerable<Observation> observations)
+    {
+        var filterItemIds = observations
+            .SelectMany(observation => observation.FilterItems)
+            .Select(ofi => ofi.FilterItemId)
+            .Distinct()
+            .ToList();
+
+        return await statisticsDbContext
+            .FilterItem.AsNoTracking()
+            .Include(fi => fi.FilterGroup)
+                .ThenInclude(fg => fg.Filter)
+            .Where(fi => filterItemIds.Contains(fi.Id))
+            .ToListAsync();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
@@ -41,4 +41,17 @@ public interface IFilterItemRepository
     /// <returns>a set of <see cref="FilterItem" />s, their <see cref="FilterGroup" />s and
     /// <see cref="Filter" />s</returns>
     Task<IList<FilterItem>> GetFilterItems(IEnumerable<Guid> filterItemIds);
+
+    /// <summary>
+    /// Method to retrieve a set of <see cref="FilterItem" />s, their <see cref="FilterGroup" />s and
+    /// <see cref="Filter" />s that are present on a given set of Observations.
+    ///
+    /// Note that this method is for use when there is a set of Observations that has been fetched into memory
+    /// already, as it is optimised for this scenario.
+    /// </summary>
+    ///
+    /// <param name="observations">A set of Observations that have been already fetched into memory.</param>
+    /// <returns>a set of <see cref="FilterItem" />s, their <see cref="FilterGroup" />s and
+    /// <see cref="Filter" />s</returns>
+    Task<IList<FilterItem>> GetFilterItemsFromObservations(IEnumerable<Observation> observations);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
@@ -121,7 +121,7 @@ public class SubjectResultMetaServiceTests
 
         boundaryLevelRepository.Setup(s => s.FindByGeographicLevels(new List<GeographicLevel>())).Returns([]);
 
-        filterItemRepository.Setup(s => s.GetFilterItems(query.GetFilterItemIds())).ReturnsAsync([]);
+        filterItemRepository.Setup(s => s.GetFilterItemsFromObservations(observations)).ReturnsAsync([]);
 
         locationService
             .Setup(s =>
@@ -286,7 +286,7 @@ public class SubjectResultMetaServiceTests
             )
             .Returns(new List<BoundaryLevel> { _countriesBoundaryLevel, _regionsBoundaryLevel });
 
-        filterItemRepository.Setup(s => s.GetFilterItems(query.GetFilterItemIds())).ReturnsAsync([]);
+        filterItemRepository.Setup(s => s.GetFilterItemsFromObservations(observations)).ReturnsAsync([]);
 
         footnoteRepository
             .Setup(s => s.GetFilteredFootnotes(releaseVersion.Id, subject.Id, new List<Guid>(), query.Indicators))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
@@ -95,7 +95,7 @@ public class SubjectResultMetaService : ISubjectResultMetaService
                     subjectId: releaseSubject.SubjectId
                 );
 
-                var filterItems = await _filterItemRepository.GetFilterItems(query.GetFilterItemIds());
+                var filterItems = await _filterItemRepository.GetFilterItemsFromObservations(observations);
                 var filterViewModels = FiltersMetaViewModelBuilder.BuildFiltersFromFilterItems(
                     filterItems,
                     releaseFile.FilterSequence


### PR DESCRIPTION
### Expected table rendered
<img width="1303" height="694" alt="image" src="https://github.com/user-attachments/assets/1b56f893-8f28-4bae-8dca-a3909d00e405" />

### CSV downloads unaffected
<img width="2462" height="493" alt="image" src="https://github.com/user-attachments/assets/36923225-0e27-4a83-af4e-cbb6f4839840" />