### PR TITLE
EES-7379 - adding auditing and diagnostic settings to Azure SQL serve…

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -150,9 +150,6 @@
     },
     "tableToolSearchEndpoint": {
       "value": "https://s101d01-ees-fa-nlsearch.azurewebsites.net/api/natural_language_search_function"
-    },
-    "sqlAuditing": {
-      "value": true
     }
   }
 }

--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -150,6 +150,9 @@
     },
     "tableToolSearchEndpoint": {
       "value": "https://s101d01-ees-fa-nlsearch.azurewebsites.net/api/natural_language_search_function"
+    },
+    "sqlAuditing": {
+      "value": true
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -296,20 +296,12 @@
     "sqlAzureAdministratorSid": {
       "type": "string"
     },
-    "secAlertRetentionDays": {
-      "defaultValue": "14",
+    "databaseAuditBlobRetentionDays": {
+      "defaultValue": "365",
       "type": "string",
       "metadata": {
-        "description": "Number of days to retain the security alerts for"
+        "description": "Number of days to retain database audit logs for in blob storage"
       }
-    },
-    "sqlAuditing": {
-      "type": "bool",
-      "defaultValue": false
-    },
-    "sqlVulnerabilityAssessments": {
-      "type": "bool",
-      "defaultValue": true
     },
     "publicAppBasicAuth": {
       "type": "string",
@@ -2579,7 +2571,6 @@
           },
           "resources": [
             {
-              "condition": "[parameters('sqlAuditing')]",
               "type": "extendedAuditingSettings",
               "apiVersion": "2025-02-01-preview",
               "name": "Default",
@@ -2592,7 +2583,6 @@
               ]
             },
             {
-              "condition": "[parameters('sqlAuditing')]",
               "type": "providers/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
               "name": "Microsoft.Insights/serverAuditToLogAnalytics",
@@ -2686,7 +2676,6 @@
           },
           "resources": [
             {
-              "condition": "[parameters('sqlAuditing')]",
               "type": "extendedAuditingSettings",
               "apiVersion": "2025-02-01-preview",
               "name": "Default",
@@ -2699,7 +2688,6 @@
               ]
             },
             {
-              "condition": "[parameters('sqlAuditing')]",
               "type": "providers/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
               "name": "Microsoft.Insights/serverAuditToLogAnalytics",
@@ -2814,7 +2802,6 @@
           }
         },
         {
-          "condition": "[parameters('sqlVulnerabilityAssessments')]",
           "type": "vulnerabilityAssessments",
           "name": "Default",
           "apiVersion": "2018-06-01-preview",
@@ -2834,7 +2821,6 @@
           }
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "databases/extendedAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "master/Default",
@@ -2844,15 +2830,7 @@
               "FAILED_DATABASE_AUTHENTICATION_GROUP",
               "BATCH_COMPLETED_GROUP"
             ],
-            "isAzureMonitorTargetEnabled": true,
-            "isManagedIdentityInUse": false,
-            "isStorageSecondaryKeyInUse": false,
-            "state": "Enabled",
-            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
-            "storageAccountSubscriptionId": "[subscription().subscriptionId]",
-            "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]"
+            "state": "Disabled"
           },
           "dependsOn": [
             "[concat(resourceId('Microsoft.Sql/servers', variables('coreSqlServerName')))]",
@@ -2860,7 +2838,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "extendedAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "Default",
@@ -2878,7 +2855,7 @@
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]"
+            "retentionDays": "[parameters('databaseAuditBlobRetentionDays')]"
           },
           "dependsOn": [
             "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
@@ -2886,7 +2863,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "devOpsAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "Default",
@@ -2905,7 +2881,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "databases/providers/diagnosticSettings",
           "apiVersion": "2021-05-01-preview",
           "name": "master/Microsoft.Insights/serverAuditToLogAnalytics",
@@ -3088,7 +3063,6 @@
           },
           "resources": [
             {
-              "condition": "[parameters('sqlAuditing')]",
               "type": "providers/diagnosticSettings",
               "apiVersion": "2021-05-01-preview",
               "name": "Microsoft.Insights/serverAuditToLogAnalytics",
@@ -3190,7 +3164,6 @@
           }
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "databases/extendedAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "master/Default",
@@ -3200,15 +3173,7 @@
               "FAILED_DATABASE_AUTHENTICATION_GROUP",
               "BATCH_COMPLETED_GROUP"
             ],
-            "isAzureMonitorTargetEnabled": true,
-            "isManagedIdentityInUse": false,
-            "isStorageSecondaryKeyInUse": false,
-            "state": "Enabled",
-            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
-            "storageAccountSubscriptionId": "[subscription().subscriptionId]",
-            "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]"
+            "state": "Disabled"
           },
           "dependsOn": [
             "[concat(resourceId('Microsoft.Sql/servers', variables('publicSqlServerName')))]",
@@ -3216,7 +3181,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "extendedAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "Default",
@@ -3234,7 +3198,7 @@
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]"
+            "retentionDays": "[parameters('databaseAuditBlobRetentionDays')]"
           },
           "dependsOn": [
             "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
@@ -3242,7 +3206,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "devOpsAuditingSettings",
           "apiVersion": "2025-02-01-preview",
           "name": "Default",
@@ -3261,7 +3224,6 @@
           ]
         },
         {
-          "condition": "[parameters('sqlAuditing')]",
           "type": "databases/providers/diagnosticSettings",
           "apiVersion": "2021-05-01-preview",
           "name": "master/Microsoft.Insights/serverAuditToLogAnalytics",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -830,7 +830,7 @@
     "contentDbName": "content",
     "statisticsDbName": "statistics",
     "statisticsReplicaDbName": "statistics",
-    "appInsightsWorkspace": "[concat(parameters('subscription'), '-', parameters('environment'), '-log')]",
+    "appInsightsWorkspaceName": "[concat(parameters('subscription'), '-', parameters('environment'), '-log')]",
     "dataAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-data')]",
     "dataPlanName": "[concat(parameters('subscription'), '-asp-', parameters('environment'), '-data')]",
     "dataAppInsights": "[concat(parameters('subscription'), '-ai-', parameters('environment'), '-data')]",
@@ -1646,7 +1646,7 @@
       "properties": {
         "applicationId": "[variables('dataAppName')]",
         "Request_Source": "AzureTfsExtensionAzureProject",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -1877,7 +1877,7 @@
       "properties": {
         "applicationId": "[variables('contentAppName')]",
         "Request_Source": "AzureTfsExtensionAzureProject",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -2195,7 +2195,7 @@
       "properties": {
         "applicationId": "[variables('adminAppName')]",
         "Request_Source": "AzureTfsExtensionAzureProject",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -2391,7 +2391,7 @@
       "properties": {
         "applicationId": "[variables('publicAppName')]",
         "Request_Source": "AzureTfsExtensionAzureProject",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -2576,7 +2576,76 @@
             "autoPauseDelay": -1,
             "storageAccountType": "GRS",
             "minCapacity": "[if(not(empty(parameters('minCapacityStatisticsDb'))), parameters('minCapacityStatisticsDb'), json('null'))]"
-          }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('sqlAuditing')]",
+              "type": "extendedAuditingSettings",
+              "apiVersion": "2025-02-01-preview",
+              "name": "Default",
+              "properties": {
+                "state": "Disabled"
+              },
+              "dependsOn": [
+                "[concat(resourceId('Microsoft.Sql/servers', variables('coreSqlServerName')))]",
+                "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('statisticsDbName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('sqlAuditing')]",
+              "type": "providers/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "name": "Microsoft.Insights/serverAuditToLogAnalytics",
+              "properties": {
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]",
+                "logs": [
+                  {
+                    "category": "SQLSecurityAuditEvents",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Errors",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Timeouts",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Blocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Deadlocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "DatabaseWaitStatistics",
+                    "enabled": true
+                  }
+                ],
+                "metrics": [
+                  {
+                    "category": "Basic",
+                    "enabled": true
+                  },
+                  {
+                    "category": "InstanceAndAppAdvanced",
+                    "enabled": true
+                  },
+                  {
+                    "category": "WorkloadManagement",
+                    "enabled": true
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+                "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('statisticsDbName'))]",
+                "[resourceId('Microsoft.Sql/servers/databases/extendedAuditingSettings', variables('coreSqlServerName'), variables('statisticsDbName'), 'Default')]"
+              ]
+            }
+          ]
         },
         {
           "type": "databases",
@@ -2614,40 +2683,86 @@
             "autoPauseDelay": -1,
             "storageAccountType": "GRS",
             "minCapacity": "[if(not(empty(parameters('minCapacityContentDb'))), parameters('minCapacityContentDb'), json('null'))]"
-          }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('sqlAuditing')]",
+              "type": "extendedAuditingSettings",
+              "apiVersion": "2025-02-01-preview",
+              "name": "Default",
+              "properties": {
+                "state": "Disabled"
+              },
+              "dependsOn": [
+                "[concat(resourceId('Microsoft.Sql/servers', variables('coreSqlServerName')))]",
+                "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('contentDbName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('sqlAuditing')]",
+              "type": "providers/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "name": "Microsoft.Insights/serverAuditToLogAnalytics",
+              "properties": {
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]",
+                "logs": [
+                  {
+                    "category": "SQLSecurityAuditEvents",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Errors",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Timeouts",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Blocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Deadlocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "DatabaseWaitStatistics",
+                    "enabled": true
+                  }
+                ],
+                "metrics": [
+                  {
+                    "category": "Basic",
+                    "enabled": true
+                  },
+                  {
+                    "category": "InstanceAndAppAdvanced",
+                    "enabled": true
+                  },
+                  {
+                    "category": "WorkloadManagement",
+                    "enabled": true
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+                "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('contentDbName'))]",
+                "[resourceId('Microsoft.Sql/servers/databases/extendedAuditingSettings', variables('coreSqlServerName'), variables('contentDbName'), 'Default')]"
+              ]
+            }
+          ]
         },
         {
           "name": "[concat(variables('coreSqlServerName'),'/activeDirectory')]",
           "type": "Microsoft.Sql/servers/administrators",
           "apiVersion": "2014-04-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
-          ],
           "properties": {
             "administratorType": "ActiveDirectory",
             "login": "[parameters('sqlAzureAdministratorLogin')]",
             "sid": "[parameters('sqlAzureAdministratorSid')]",
             "tenantId": "[subscription().tenantId]"
-          }
-        },
-        {
-          "name": "[concat(string(variables('coreSqlServerName')), '/', variables('statisticsDbName'), '/current')]",
-          "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
-          "apiVersion": "2014-04-01",
-          "properties": {
-            "status": "Enabled"
-          },
-          "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
-            "[concat(resourceId('Microsoft.Sql/servers', variables('coreSqlServerName')), '/databases/', variables('statisticsDbName'))]"
-          ]
-        },
-        {
-          "name": "[concat(string(variables('coreSqlServerName')), '/', variables('contentDbName'), '/current')]",
-          "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
-          "apiVersion": "2014-04-01",
-          "properties": {
-            "status": "Enabled"
           },
           "dependsOn": [
             "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
@@ -2720,38 +2835,150 @@
         },
         {
           "condition": "[parameters('sqlAuditing')]",
-          "type": "auditingSettings",
-          "name": "DefaultAuditingSettings2",
-          "apiVersion": "2017-03-01-preview",
+          "type": "databases/extendedAuditingSettings",
+          "apiVersion": "2025-02-01-preview",
+          "name": "master/Default",
           "properties": {
-            "State": "Enabled",
-            "storageEndpoint": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob, 'auditing-settings')]",
+            "auditActionsAndGroups": [
+              "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+              "FAILED_DATABASE_AUTHENTICATION_GROUP",
+              "BATCH_COMPLETED_GROUP"
+            ],
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]",
-            "isAzureMonitorTargetEnabled": true
+            "retentionDays": "[parameters('secAlertRetentionDays')]"
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
+            "[concat(resourceId('Microsoft.Sql/servers', variables('coreSqlServerName')))]",
+            "[resourceId('Microsoft.Sql/servers/vulnerabilityAssessments', variables('coreSqlServerName'), 'Default')]"
           ]
         },
         {
           "condition": "[parameters('sqlAuditing')]",
           "type": "extendedAuditingSettings",
-          "name": "Default2",
-          "apiVersion": "2017-03-01-preview",
+          "apiVersion": "2025-02-01-preview",
+          "name": "Default",
           "properties": {
-            "State": "Enabled",
-            "storageEndpoint": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob, 'auditing-settings')]",
+            "auditActionsAndGroups": [
+              "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+              "FAILED_DATABASE_AUTHENTICATION_GROUP",
+              "BATCH_COMPLETED_GROUP"
+            ],
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]",
-            "isAzureMonitorTargetEnabled": true
+            "retentionDays": "[parameters('secAlertRetentionDays')]"
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
+            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/databases/extendedAuditingSettings', variables('coreSqlServerName'), 'master', 'Default')]"
+          ]
+        },
+        {
+          "condition": "[parameters('sqlAuditing')]",
+          "type": "devOpsAuditingSettings",
+          "apiVersion": "2025-02-01-preview",
+          "name": "Default",
+          "properties": {
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
+            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
+            "storageAccountSubscriptionId": "[subscription().subscriptionId]"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/extendedAuditingSettings', variables('coreSqlServerName'), 'Default')]"
+          ]
+        },
+        {
+          "condition": "[parameters('sqlAuditing')]",
+          "type": "databases/providers/diagnosticSettings",
+          "apiVersion": "2021-05-01-preview",
+          "name": "master/Microsoft.Insights/serverAuditToLogAnalytics",
+          "properties": {
+            "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]",
+            "logs": [
+              {
+                "category": "SQLSecurityAuditEvents",
+                "enabled": true
+              },
+              {
+                "category": "Errors",
+                "enabled": true
+              },
+              {
+                "category": "Timeouts",
+                "enabled": true
+              },
+              {
+                "category": "Blocks",
+                "enabled": true
+              },
+              {
+                "category": "Deadlocks",
+                "enabled": true
+              },
+              {
+                "category": "DatabaseWaitStatistics",
+                "enabled": true
+              }
+            ],
+            "metrics": [
+              {
+                "category": "Basic",
+                "enabled": true
+              },
+              {
+                "category": "InstanceAndAppAdvanced",
+                "enabled": true
+              },
+              {
+                "category": "WorkloadManagement",
+                "enabled": true
+              }
+            ]
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/devOpsAuditingSettings', variables('coreSqlServerName'), 'Default')]"
+          ]
+        },
+        {
+          "name": "[concat(string(variables('coreSqlServerName')), '/', variables('statisticsDbName'), '/current')]",
+          "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+          "apiVersion": "2014-04-01",
+          "properties": {
+            "status": "Enabled"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/databases/providers/diagnosticSettings', variables('coreSqlServerName'), 'master', 'Microsoft.Insights', 'serverAuditToLogAnalytics')]"
+          ]
+        },
+        {
+          "name": "[concat(string(variables('coreSqlServerName')), '/', variables('contentDbName'), '/current')]",
+          "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+          "apiVersion": "2014-04-01",
+          "properties": {
+            "status": "Enabled"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/databases/providers/diagnosticSettings', variables('coreSqlServerName'), 'master', 'Microsoft.Insights', 'serverAuditToLogAnalytics')]"
           ]
         }
       ],
@@ -2858,7 +3085,62 @@
             "createMode": "OnlineSecondary",
             "sourceDatabaseId": "[resourceId('Microsoft.Sql/servers/databases', variables('coreSqlServerName'), variables('statisticsDbName'))]",
             "secondaryType": "Geo"
-          }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('sqlAuditing')]",
+              "type": "providers/diagnosticSettings",
+              "apiVersion": "2021-05-01-preview",
+              "name": "Microsoft.Insights/serverAuditToLogAnalytics",
+              "properties": {
+                "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]",
+                "logs": [
+                  {
+                    "category": "SQLSecurityAuditEvents",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Errors",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Timeouts",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Blocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "Deadlocks",
+                    "enabled": true
+                  },
+                  {
+                    "category": "DatabaseWaitStatistics",
+                    "enabled": true
+                  }
+                ],
+                "metrics": [
+                  {
+                    "category": "Basic",
+                    "enabled": true
+                  },
+                  {
+                    "category": "InstanceAndAppAdvanced",
+                    "enabled": true
+                  },
+                  {
+                    "category": "WorkloadManagement",
+                    "enabled": true
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
+                "[resourceId('Microsoft.Sql/servers/databases', variables('publicSqlServerName'), variables('statisticsDbName'))]"
+              ]
+            }
+          ]
         },
         {
           "name": "[concat(variables('publicSqlServerName'),'/activeDirectory')]",
@@ -2909,38 +3191,126 @@
         },
         {
           "condition": "[parameters('sqlAuditing')]",
-          "type": "auditingSettings",
-          "name": "DefaultAuditingSettings",
-          "apiVersion": "2017-03-01-preview",
+          "type": "databases/extendedAuditingSettings",
+          "apiVersion": "2025-02-01-preview",
+          "name": "master/Default",
           "properties": {
-            "State": "Enabled",
-            "storageEndpoint": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob, 'auditing-settings')]",
+            "auditActionsAndGroups": [
+              "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+              "FAILED_DATABASE_AUTHENTICATION_GROUP",
+              "BATCH_COMPLETED_GROUP"
+            ],
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]",
-            "isAzureMonitorTargetEnabled": true
+            "retentionDays": "[parameters('secAlertRetentionDays')]"
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]"
+            "[concat(resourceId('Microsoft.Sql/servers', variables('publicSqlServerName')))]",
+            "[resourceId('Microsoft.Sql/servers/vulnerabilityAssessments', variables('publicSqlServerName'), 'Default')]"
           ]
         },
         {
           "condition": "[parameters('sqlAuditing')]",
           "type": "extendedAuditingSettings",
+          "apiVersion": "2025-02-01-preview",
           "name": "Default",
-          "apiVersion": "2017-03-01-preview",
           "properties": {
-            "State": "Enabled",
-            "storageEndpoint": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob, 'auditing-settings')]",
+            "auditActionsAndGroups": [
+              "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+              "FAILED_DATABASE_AUTHENTICATION_GROUP",
+              "BATCH_COMPLETED_GROUP"
+            ],
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
             "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
             "storageAccountSubscriptionId": "[subscription().subscriptionId]",
             "eventTypesToAudit": "All",
-            "retentionDays": "[parameters('secAlertRetentionDays')]",
-            "isAzureMonitorTargetEnabled": true
+            "retentionDays": "[parameters('secAlertRetentionDays')]"
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]"
+            "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/databases/extendedAuditingSettings', variables('publicSqlServerName'), 'master', 'Default')]"
+          ]
+        },
+        {
+          "condition": "[parameters('sqlAuditing')]",
+          "type": "devOpsAuditingSettings",
+          "apiVersion": "2025-02-01-preview",
+          "name": "Default",
+          "properties": {
+            "isAzureMonitorTargetEnabled": true,
+            "isManagedIdentityInUse": false,
+            "isStorageSecondaryKeyInUse": false,
+            "state": "Enabled",
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
+            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('loggingStorageAccountName')), '2018-02-01').keys[0].value]",
+            "storageAccountSubscriptionId": "[subscription().subscriptionId]"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/extendedAuditingSettings', variables('publicSqlServerName'), 'Default')]"
+          ]
+        },
+        {
+          "condition": "[parameters('sqlAuditing')]",
+          "type": "databases/providers/diagnosticSettings",
+          "apiVersion": "2021-05-01-preview",
+          "name": "master/Microsoft.Insights/serverAuditToLogAnalytics",
+          "properties": {
+            "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]",
+            "logs": [
+              {
+                "category": "SQLSecurityAuditEvents",
+                "enabled": true
+              },
+              {
+                "category": "Errors",
+                "enabled": true
+              },
+              {
+                "category": "Timeouts",
+                "enabled": true
+              },
+              {
+                "category": "Blocks",
+                "enabled": true
+              },
+              {
+                "category": "Deadlocks",
+                "enabled": true
+              },
+              {
+                "category": "DatabaseWaitStatistics",
+                "enabled": true
+              }
+            ],
+            "metrics": [
+              {
+                "category": "Basic",
+                "enabled": true
+              },
+              {
+                "category": "InstanceAndAppAdvanced",
+                "enabled": true
+              },
+              {
+                "category": "WorkloadManagement",
+                "enabled": true
+              }
+            ]
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
+            "[resourceId('Microsoft.Sql/servers/devOpsAuditingSettings', variables('publicSqlServerName'), 'Default')]"
           ]
         }
       ],
@@ -3280,7 +3650,7 @@
       "properties": {
         "Application_Type": "web",
         "ApplicationId": "[variables('notificationsAppName')]",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -3431,7 +3801,7 @@
       "properties": {
         "Application_Type": "web",
         "ApplicationId": "[variables('importerAppName')]",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -3581,7 +3951,7 @@
       "properties": {
         "Application_Type": "web",
         "ApplicationId": "[variables('publisherAppName')]",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
       }
     },
     {
@@ -4683,7 +5053,7 @@
             "value": "[resourceGroup().name]"
           },
           "workspaceResourceId": {
-            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
+            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
           },
           "teamsPowerAutomateWebhookUrl": {
             "reference": {


### PR DESCRIPTION
This PR:
- adds diagnostics capture and auditing to our Azure SQL databases.

## The setup

The PR adds:
- diagnostic settings to each of the database *servers* (core and public)
- auditing to each of the database *servers*, including DevOps activity auditing
- diagnostic settings to the master, content and statistics databases on the core server
- diagnostic settings to the master and statistics databases on the public server (the replica)

Diagnostics and auditing are sent both to blob storage (the eeslogging account) and to our main shared Log Analytics Workspace.

## Disabling database-level auditing

This PR also explicitly *disables* database-level auditing from master, content, statistics and statistics replica.  The secondary reason for doing this is that databases will by default inherit the auditing settings of their owning server, which we've already configured.  This will also have the effect of disabling any database-level auditing config that we've applied manually over the years.

The *primary* reason for doing this is that if we accidentally apply database-level auditing to the statistics primary or replica, the replica will inherit those settings either way, and it will be penalised for logging into a log analytics workspace from a different region (because it's a Geo-replica).

By leaving it at the server level, the primary will handle all of the data sinking and the replica need not.

:warning: Because diagnostic settings may have been applied manually in the past to various databases, we need to clear out any existing settings per database that *we* control, otherwise the deployment will likely fail complaining of 2 or more diagnostic settings trying to use `s101<env>-ees-log` Log Analytics Workspace as a target data sink.  And if it doesn't, it'd likely end up with duplicate diagnostic settings, one in IaC's control and one without.

:warning: Currently only applies to the Dev resource group.  When we see if it's cleared our database advisories from the Dev databases, we can roll out across other environments.  

### Other misc points

The `dependsOn` arrays of the newly added Azure SQL settings may look a little strange, with seemingly unconnected resources depending on others e.g. transparent encryption settings depending on auditing settings.  The reason for this is that ARM (or Azure SQL) attempts to execute all these changes in parallel and so ends up hitting conflicts and timeouts.  Therefore we set up a dependency chain to force them to execute sequentially.

I've removed the `auditingSettings` elements from the ARM template, as these are now deprecated.  `extendedAuditingSettings` is now the preferred control.

## Screenshots

### Server-level auditing settings

<img width="2256" height="2400" alt="image" src="https://github.com/user-attachments/assets/f8fcd499-be11-4ae9-9397-7e9e6ecf5c23" />

### Database-level DISABLED auditing settings

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/41c83809-4981-4c89-9555-b534939a473f" />

### Database-level diagnostic settings

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/07f9a31d-7b67-4bca-835b-12dafa1f820b" />

<img width="2256" height="1757" alt="image" src="https://github.com/user-attachments/assets/6b6c307a-8c89-4bf7-997c-44e1d8f67076" />
