### PR TITLE
EES-7383: Remove test/seed data restriction from Admin theme deletion endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteTestReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteTestReleaseAuthorizationHandlerTests.cs
@@ -83,11 +83,12 @@ public abstract class DeleteTestReleaseAuthorizationHandlerTests
         }
 
         [Fact]
-        public async Task RealReleaseVersion_FailsForAllGlobalRoles()
+        public async Task RealReleaseVersion_SucceedsOnlyForValidGlobalRoles()
         {
-            await AssertHandlerFailsForAllGlobalRoles<DeleteTestReleaseRequirement, ReleaseVersion>(
+            await AssertHandlerSucceedsWithCorrectGlobalRoles<DeleteTestReleaseRequirement, ReleaseVersion>(
                 BuildHandler(enableThemeDeletion: true),
-                _realReleaseVersion
+                _realReleaseVersion,
+                rolesExpectedToSucceed: [GlobalRoles.Role.BauUser]
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -697,33 +697,6 @@ public class ThemeServiceTests
     }
 
     [Fact]
-    public async Task DeleteTheme_DisallowedByNamingConvention()
-    {
-        var theme = new Theme
-        {
-            Title = "Non-conforming title",
-            Publications = [new() { Title = "UI test publication 1" }, new() { Title = "UI test publication 2" }],
-        };
-
-        var contextId = Guid.NewGuid().ToString();
-
-        await using (var context = InMemoryApplicationDbContext(contextId))
-        {
-            context.Add(theme);
-            await context.SaveChangesAsync();
-        }
-
-        await using (var context = InMemoryApplicationDbContext(contextId))
-        {
-            var service = SetupThemeService(context);
-            var result = await service.DeleteTheme(theme.Id);
-
-            result.AssertForbidden();
-            Assert.Equal(1, await context.Themes.CountAsync());
-        }
-    }
-
-    [Fact]
     public async Task DeleteTheme_DisallowedByConfiguration()
     {
         var theme = new Theme

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteTestReleaseAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteTestReleaseAuthorizationHandler.cs
@@ -19,19 +19,7 @@ public class DeleteTestReleaseAuthorizationHandler(IOptions<AppOptions> appOptio
         ReleaseVersion releaseVersion
     )
     {
-        if (!appOptions.Value.EnableThemeDeletion)
-        {
-            return Task.CompletedTask;
-        }
-
-        if (!context.User.IsInRole(GlobalRoles.Role.BauUser.GetEnumLabel()))
-        {
-            return Task.CompletedTask;
-        }
-
-        var theme = releaseVersion.Release.Publication.Theme;
-
-        if (theme.IsTestOrSeedTheme())
+        if (appOptions.Value.EnableThemeDeletion && context.User.IsInRole(GlobalRoles.Role.BauUser.GetEnumLabel()))
         {
             context.Succeed(requirement);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -258,15 +258,6 @@ public class ThemeService(
             return new ForbidResult();
         }
 
-        // For now we only want to delete test themes as we
-        // don't really have a mechanism to clean things up
-        // properly across the entire application.
-        // TODO: EES-1295 ability to completely delete releases
-        if (!theme.IsTestOrSeedTheme())
-        {
-            return new ForbidResult();
-        }
-
         return await Task.FromResult(Unit.Instance);
     }
 


### PR DESCRIPTION
Removes the need for a theme's name to begin with "UI test - " when deleting a theme. Couple of points:
1. EES-1295 is still referenced in comments elsewhere in the codebase (`ReleaseVersionService`), so seemed ok to remove from here
2. Retaining `IsTestOrSeedTheme` extension method for now, as this is used by other methods, but may be removed as part of subsequent work relating to theme deletion
3. `CheckCanDeleteTheme` only does one thing now (checking config setting), and is only referenced by one method, but decided to keep this logic separate for readability.