### PR TITLE
EES-7335 - Renaming 'BAU User' to 'Super User' on the FE (ONLY WHERE IT IS DISPLAYED OR IN A UI COMPONENT)

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -427,7 +427,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage AnalystCannotReplaceApiDataSet = new(
         Code: nameof(AnalystCannotReplaceApiDataSet),
-        Message: "You do not have permission to start this data replacement. This is because data set with title '{0}' is linked to an API data set version which can only be modified by BAU users. Please contact the explore statistics team at explore.statistics@education.gov.uk for support on starting this replacement."
+        Message: "You do not have permission to start this data replacement. This is because data set with title '{0}' is linked to an API data set version which can only be modified by Super Users. Please contact the explore statistics team at explore.statistics@education.gov.uk for support on starting this replacement."
     );
 
     public static ErrorViewModel GenerateErrorAnalystCannotReplaceApiDataSet(string title)

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationGlossary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationGlossary.tsx
@@ -1266,9 +1266,9 @@ const DocumentationGlossary = () => {
                 measurement: 3,500kg not 3,500 kg.
               </p>
               <p>
-                <a href="#">Contact the BAU team</a> if you need to follow
-                different conventions, for example you’re writing just for
-                scientists or engineers.
+                <a href="#">Contact the Explore Education Statistics mailbox</a>{' '}
+                if you need to follow different conventions, for example you’re
+                writing just for scientists or engineers.
               </p>
               <p>
                 Abbreviating kilograms to kg is fine - you do not need to spell

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/PendingDataReplacementSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/PendingDataReplacementSection.test.tsx
@@ -105,11 +105,6 @@ describe('PendingDataReplacementSection', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
-        /You do not have permission to cancel this data replacement. This is because it is linked to an API data set version which can only be modified by BAU users./i,
-      ),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(
         /Are you sure you want to cancel this data replacement and remove the attached draft API version?/i,
       ),
     ).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -157,7 +157,7 @@ export default function UserInvitePage({
             />
 
             <FormFieldset
-              id="superUser"
+              id="super-user"
               legend="Access level"
               legendSize="m"
               hint="Super Users have elevated permissions."

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -38,7 +38,7 @@ export interface InviteUserPublicationRole {
 
 export interface UserInviteFormValues {
   userEmail: string;
-  isBau: boolean;
+  isSuperUser: boolean;
   userPreReleaseRoles?: InviteUserPreReleaseRole[];
   userPublicationRoles?: InviteUserPublicationRole[];
   publicationId?: string;
@@ -90,7 +90,7 @@ export default function UserInvitePage({
 
     const submission: UserInvite = {
       email: values.userEmail,
-      isBau: values.isBau,
+      isBau: values.isSuperUser,
       userPreReleaseRoles,
       userPublicationRoles,
     };
@@ -105,7 +105,7 @@ export default function UserInvitePage({
       userEmail: Yup.string()
         .required('Provide the users email')
         .email('Provide a valid email address'),
-      isBau: Yup.boolean().required(),
+      isSuperUser: Yup.boolean().required(),
       userPreReleaseRoles: Yup.array().of(
         Yup.object({
           releaseId: Yup.string().required(
@@ -143,7 +143,7 @@ export default function UserInvitePage({
           errorMappings={errorMappings}
           initialValues={{
             userEmail: '',
-            isBau: false,
+            isSuperUser: false,
             userPublicationRoles: [],
           }}
           validationSchema={validationSchema}
@@ -157,14 +157,14 @@ export default function UserInvitePage({
             />
 
             <FormFieldset
-              id="bau"
+              id="superUser"
               legend="Access level"
               legendSize="m"
-              hint="BAU users have elevated permissions."
+              hint="Super Users have elevated permissions."
             >
               <FormFieldCheckbox<UserInviteFormValues>
-                name="isBau"
-                label="BAU User"
+                name="isSuperUser"
+                label="Super User"
               />
             </FormFieldset>
 

--- a/src/explore-education-statistics-admin/src/pages/users/__tests__/ManageUserPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/__tests__/ManageUserPage.test.tsx
@@ -52,7 +52,7 @@ describe('ManageUserPage', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'BAU User',
+        name: 'Super User',
       }),
     ).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
@@ -39,7 +39,7 @@ describe('UserInvitePage', () => {
     expect(screen.getByLabelText('User email')).toBeInTheDocument();
     expect(
       screen.getByRole('checkbox', {
-        name: 'BAU User',
+        name: 'Super User',
       }),
     ).toBeInTheDocument();
     expect(
@@ -426,7 +426,7 @@ describe('UserInvitePage', () => {
     await user.type(screen.getByLabelText('User email'), 'test@test.com');
 
     const checkbox = screen.getByRole('checkbox', {
-      name: 'BAU User',
+      name: 'Super User',
     });
 
     expect(checkbox).not.toBeChecked();

--- a/src/explore-education-statistics-admin/src/pages/users/components/RoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/RoleForm.tsx
@@ -53,7 +53,7 @@ const RoleForm = ({ user, onUpdate }: Props) => {
     >
       <Form id={user.id} onSubmit={handleSubmit}>
         <FormFieldset
-          id="superUser"
+          id="super-user"
           legend="Access level"
           legendSize="m"
           hint="Super Users have elevated permissions."

--- a/src/explore-education-statistics-admin/src/pages/users/components/RoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/RoleForm.tsx
@@ -10,7 +10,7 @@ import { GlobalRole } from '@admin/services/types/GlobalRole';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 
 interface FormValues {
-  isBauUser: boolean;
+  isSuperUser: boolean;
 }
 
 interface FormValues {
@@ -24,9 +24,9 @@ interface Props {
 
 const errorMappings = [
   mapFieldErrors<FormValues>({
-    target: 'isBauUser',
+    target: 'isSuperUser',
     messages: {
-      UserIsAlreadyBauUser: 'User is already a BAU User',
+      UserIsAlreadyBauUser: 'User is already a Super User',
       UserIsAlreadyStandardUser: 'User is already a Standard User',
     },
   }),
@@ -35,7 +35,7 @@ const errorMappings = [
 const RoleForm = ({ user, onUpdate }: Props) => {
   const handleSubmit = async (values: FormValues) => {
     await usersService.updateUserGlobalRole(user.id, {
-      targetGlobalRole: values.isBauUser
+      targetGlobalRole: values.isSuperUser
         ? GlobalRole.BauUser
         : GlobalRole.StandardUser,
     });
@@ -48,21 +48,21 @@ const RoleForm = ({ user, onUpdate }: Props) => {
       errorMappings={errorMappings}
       enableReinitialize
       initialValues={{
-        isBauUser: user.globalRole === GlobalRole.BauUser,
+        isSuperUser: user.globalRole === GlobalRole.BauUser,
       }}
     >
       <Form id={user.id} onSubmit={handleSubmit}>
         <FormFieldset
-          id="bau"
+          id="superUser"
           legend="Access level"
           legendSize="m"
-          hint="BAU users have elevated permissions."
+          hint="Super Users have elevated permissions."
         >
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-quarter">
               <FormFieldCheckbox<FormValues>
-                name="isBauUser"
-                label="BAU User"
+                name="isSuperUser"
+                label="Super User"
               />
             </div>
 

--- a/src/explore-education-statistics-admin/src/pages/users/components/__tests__/RoleForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/__tests__/RoleForm.test.tsx
@@ -19,7 +19,7 @@ describe('RoleForm', () => {
     render(<RoleForm user={testStandardUser} onUpdate={noop} />);
 
     const checkbox = screen.getByRole('checkbox', {
-      name: 'BAU User',
+      name: 'Super User',
     });
 
     expect(checkbox).toBeInTheDocument();
@@ -30,11 +30,11 @@ describe('RoleForm', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders the form for a Bau User', () => {
+  test('renders the form for a Super User', () => {
     render(<RoleForm user={testBauUser} onUpdate={noop} />);
 
     const checkbox = screen.getByRole('checkbox', {
-      name: 'BAU User',
+      name: 'Super User',
     });
 
     expect(checkbox).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe('RoleForm', () => {
     render(<RoleForm user={testStandardUser} onUpdate={handleUpdate} />);
 
     const checkbox = screen.getByRole('checkbox', {
-      name: 'BAU User',
+      name: 'Super User',
     });
 
     expect(checkbox).not.toBeChecked();

--- a/src/explore-education-statistics-admin/src/services/types/GlobalRole.ts
+++ b/src/explore-education-statistics-admin/src/services/types/GlobalRole.ts
@@ -1,5 +1,6 @@
 export const GlobalRole = {
   StandardUser: 'StandardUser',
+  // BAU Users are now referred to as Super Users in the UI, but the backend and frontend code still uses the BAU terminology.
   BauUser: 'BauUser',
 } as const;
 
@@ -7,5 +8,6 @@ export type GlobalRole = (typeof GlobalRole)[keyof typeof GlobalRole];
 
 export const globalRoleLabels: Record<GlobalRole, string> = {
   [GlobalRole.StandardUser]: 'Standard User',
-  [GlobalRole.BauUser]: 'BAU User',
+  // BAU Users are now referred to as Super Users in the UI, but the backend and frontend code still uses the BAU terminology.
+  [GlobalRole.BauUser]: 'Super User',
 };


### PR DESCRIPTION
As it says on the tin.

We want to rename the concept of a BAU User ==> Super User. 

However, we don't want to update all of the database entries, URL paths, code comments/methods/variables/filenames etc... That would be too big of a change and likely require lots of testing.

So this is the MVP changes that purely affect what is displayed, or what describes a UI component (e.g. the `label` attribute of a UI component would need to be changed)