### PR TITLE
EES-7368: Add multiple theme deletion endpoint.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -120,6 +120,7 @@
     <PackageVersion Include="CompareNETObjects" Version="4.84.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="MockQueryable.EntityFrameworkCore" Version="10.0.8" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ThemeControllerTests.cs
@@ -1,6 +1,8 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api;
@@ -35,5 +37,38 @@ public class ThemeControllerTests
 
         var result = await controller.GetThemes();
         Assert.Equal(themes, result.Value);
+    }
+
+    [Fact]
+    public async Task DeleteThemes_Success_ReturnsNoContent()
+    {
+        List<Guid> themeIds = [Guid.NewGuid(), Guid.NewGuid()];
+
+        var themeService = new Mock<IThemeService>();
+        themeService.Setup(s => s.DeleteThemes(themeIds, It.IsAny<CancellationToken>())).ReturnsAsync(Unit.Instance);
+
+        var controller = new ThemeController(themeService.Object);
+
+        var result = await controller.DeleteThemes(themeIds, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        themeService.Verify(s => s.DeleteThemes(themeIds, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteThemes_Failure_ReturnsForbidden()
+    {
+        List<Guid> themeIds = [Guid.NewGuid()];
+
+        var themeService = new Mock<IThemeService>();
+        themeService
+            .Setup(s => s.DeleteThemes(themeIds, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ForbidResult());
+
+        var controller = new ThemeController(themeService.Object);
+
+        var result = await controller.DeleteThemes(themeIds, CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ThemeControllerTests.cs
@@ -2,6 +2,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -69,6 +70,6 @@ public class ThemeControllerTests
 
         var result = await controller.DeleteThemes(themeIds, CancellationToken.None);
 
-        Assert.IsType<ForbidResult>(result);
+        result.AssertForbidden();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="MockQueryable.EntityFrameworkCore" />
     <PackageReference Include="RichardSzalay.MockHttp" />
     <PackageReference Include="Testcontainers.Azurite" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Fixtures/SqliteContentDbContextFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Fixtures/SqliteContentDbContextFixture.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Fixtures;
+
+/// <summary>
+/// Backs <see cref="ContentDbContext"/> instances with a shared, open in-memory SQLite
+/// connection.
+/// <para>
+/// Unlike the EF Core in-memory provider, SQLite is a real relational provider that supports
+/// transactions, execution strategies and commit/rollback. This lets us exercise the genuine
+/// transactional code path in services which the in-memory provider cannot run.
+/// </para>
+/// <para>
+/// The database exists only while the connection is open, so the fixture keeps a single
+/// connection open for its lifetime and must be disposed at the end of the test.
+/// </para>
+/// </summary>
+public sealed class SqliteContentDbContextFixture : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<ContentDbContext> _options;
+
+    public SqliteContentDbContextFixture()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:;Foreign Keys=False"); // Disable foreign keys until all tests have been updated to include related entities
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<ContentDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using var context = CreateContext();
+        context.Database.EnsureCreated();
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ContentDbContext"/> bound to the shared connection. Use separate
+    /// contexts for the seed, act and assert phases just as the in-memory tests use separate
+    /// context ids, so that assertions read persisted rather than tracked state.
+    /// </summary>
+    public ContentDbContext CreateContext(bool updateTimestamps = true) =>
+        new SqliteContentDbContext(_options, updateTimestamps);
+
+    public void Dispose() => _connection.Dispose();
+
+    /// <summary>
+    /// Applies the SQLite specific model tweaks that the production <see cref="ContentDbContext"/> has no reason
+    /// to know about. SQL Server column types such as <c>nvarchar(max)</c> are declared in the model but cannot be
+    /// parsed by SQLite, which only accepts a numeric length, so they are rewritten to <c>TEXT</c>.
+    /// <para>
+    /// This runs after <c>base.OnModelCreating</c>, so it also catches column types applied by the
+    /// <c>IEntityTypeConfiguration</c> classes picked up via <c>ApplyConfigurationsFromAssembly</c>.
+    /// </para>
+    /// </summary>
+    private sealed class SqliteContentDbContext(DbContextOptions<ContentDbContext> options, bool updateTimestamps)
+        : ContentDbContext(options, updateTimestamps)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            var properties = modelBuilder.Model.GetEntityTypes().SelectMany(entityType => entityType.GetProperties());
+
+            foreach (var property in properties.Where(property => property.GetColumnType() == "nvarchar(max)"))
+            {
+                property.SetColumnType("TEXT");
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Fixtures/SqliteContentDbContextFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Fixtures/SqliteContentDbContextFixture.cs
@@ -23,9 +23,18 @@ public sealed class SqliteContentDbContextFixture : IDisposable
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<ContentDbContext> _options;
 
-    public SqliteContentDbContextFixture()
+    /// <param name="enforceForeignKeys">
+    /// Foreign keys are enforced by default, so that tests surface the referential integrity failures that a
+    /// real database would raise.
+    /// <para>
+    /// Only pass <c>false</c> where a test's data does not yet include the related entities that the model
+    /// requires, and prefer completing the entity graph over opting out. Opting out means the test cannot
+    /// catch a whole class of bug that only appears against a real database.
+    /// </para>
+    /// </param>
+    public SqliteContentDbContextFixture(bool enforceForeignKeys = true)
     {
-        _connection = new SqliteConnection("DataSource=:memory:;Foreign Keys=False"); // Disable foreign keys until all tests have been updated to include related entities
+        _connection = new SqliteConnection($"DataSource=:memory:;Foreign Keys={enforceForeignKeys}");
         _connection.Open();
 
         _options = new DbContextOptionsBuilder<ContentDbContext>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -1943,6 +1943,21 @@ public abstract class ReleaseVersionServiceTests
                 PublicationId = releaseVersion.Publication.Id,
             };
 
+            // A DataBlock on the ReleaseVersion being deleted, which is also used as a KeyStatistic. The
+            // KeyStatistic has to be removed before the DataBlock.
+            var dataBlockParent = _dataFixture
+                .DefaultDataBlockParent()
+                .WithLatestPublishedVersion(
+                    _dataFixture.DefaultDataBlockVersion().WithReleaseVersion(releaseVersion).Generate()
+                )
+                .Generate();
+
+            var keyStatistic = new KeyStatisticDataBlock
+            {
+                DataBlock = dataBlockParent.LatestPublishedVersion!.ContentBlock,
+                ReleaseVersionId = releaseVersion.Id,
+            };
+
             // This Methodology is scheduled to go out with the Release being deleted.
             var methodologyScheduledWithRelease = new MethodologyVersion
             {
@@ -1974,6 +1989,8 @@ public abstract class ReleaseVersionServiceTests
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.ReleaseVersions.AddRange(releaseVersion, anotherReleaseVersion);
+                context.DataBlockParents.Add(dataBlockParent);
+                context.KeyStatisticsDataBlock.Add(keyStatistic);
                 context.MethodologyVersions.AddRange(
                     methodologyScheduledWithRelease,
                     methodologyScheduledWithAnotherRelease
@@ -2120,6 +2137,17 @@ public abstract class ReleaseVersionServiceTests
                     methodologyScheduledWithAnotherRelease.ScheduledWithReleaseVersionId,
                     unrelatedMethodology.ScheduledWithReleaseVersionId
                 );
+
+                // Assert that the DataBlock and the KeyStatistic using it have both been deleted.
+                // NOTE: this does not guard the order they are deleted in. The KeyStatistic must be deleted
+                // before the DataBlock because their foreign key is configured with DeleteBehavior.NoAction,
+                // but the in-memory provider does not enforce foreign keys, and cascades the KeyStatistic away
+                // with the ReleaseVersion regardless. Only a relational provider with foreign keys enforced
+                // would catch a regression in the ordering.
+                Assert.Empty(contentDbContext.KeyStatisticsDataBlock);
+                Assert.Empty(contentDbContext.KeyStatistics);
+                Assert.Empty(contentDbContext.DataBlockVersions);
+                Assert.Empty(contentDbContext.DataBlockParents);
 
                 // We expect the Statistics ReleaseVersion to be deleted immediately for test ReleaseVersions,
                 // as they do not use Subjects large enough to warrant using the stored procedure that cleans up

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -14,6 +14,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
@@ -174,7 +175,8 @@ public class ThemeServicePermissionTests
             publishingService ?? Mock.Of<IPublishingService>(Strict),
             releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
             adminEventRaiser ?? new AdminEventRaiserMockBuilder().Build(),
-            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)
+            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
+            Mock.Of<IHostEnvironment>(e => e.EnvironmentName == Environments.Production)
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -14,7 +14,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
@@ -71,7 +70,7 @@ public class ThemeServicePermissionTests
     }
 
     [Fact]
-    public async Task CreateTheme()
+    public async Task CreateTheme_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
@@ -86,7 +85,7 @@ public class ThemeServicePermissionTests
     }
 
     [Fact]
-    public async Task UpdateTheme()
+    public async Task UpdateTheme_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
@@ -102,7 +101,7 @@ public class ThemeServicePermissionTests
     }
 
     [Fact]
-    public async Task GetTheme()
+    public async Task GetTheme_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
@@ -115,7 +114,7 @@ public class ThemeServicePermissionTests
     }
 
     [Fact]
-    public async Task DeleteTheme()
+    public async Task DeleteTheme_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
@@ -123,18 +122,23 @@ public class ThemeServicePermissionTests
             {
                 var service = SetupThemeService(userService: userService.Object);
 
-                return await service.DeleteTheme(_theme.Id);
+                return await service.DeleteThemes([_theme.Id]);
             });
     }
 
     [Fact]
-    public async Task DeleteUiTestThemes()
+    public async Task DeleteUITestThemes_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
             .AssertForbidden(async userService =>
             {
-                var service = SetupThemeService(userService: userService.Object);
+                await using var context = DbUtils.InMemoryApplicationDbContext();
+
+                context.Add(new Theme { Title = "UI test theme" });
+                await context.SaveChangesAsync();
+
+                var service = SetupThemeService(userService: userService.Object, contentDbContext: context);
 
                 return await service.DeleteUITestThemes();
             });
@@ -175,8 +179,7 @@ public class ThemeServicePermissionTests
             publishingService ?? Mock.Of<IPublishingService>(Strict),
             releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
             adminEventRaiser ?? new AdminEventRaiserMockBuilder().Build(),
-            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
-            Mock.Of<IHostEnvironment>(e => e.EnvironmentName == Environments.Production)
+            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -114,7 +114,7 @@ public class ThemeServicePermissionTests
     }
 
     [Fact]
-    public async Task DeleteTheme_DisallowedByPolicy_ReturnsForbidden()
+    public async Task DeleteThemes_DisallowedByPolicy_ReturnsForbidden()
     {
         await PolicyCheckBuilder()
             .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -26,7 +26,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Hosting;
 using Moq;
 using Moq.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -387,7 +386,7 @@ public class ThemeServiceTests
 
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
 
-            var result = await service.DeleteTheme(theme.Id);
+            var result = await service.DeleteThemes([theme.Id]);
 
             VerifyAllMocks(methodologyService, publishingService);
 
@@ -518,7 +517,7 @@ public class ThemeServiceTests
 
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
 
-            var result = await service.DeleteTheme(theme.Id);
+            var result = await service.DeleteThemes([theme.Id]);
 
             VerifyAllMocks(releaseDataFileService, publishingService, releaseVersionService);
 
@@ -609,7 +608,7 @@ public class ThemeServiceTests
 
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
 
-            var result = await service.DeleteTheme(theme.Id);
+            var result = await service.DeleteThemes([theme.Id]);
 
             VerifyAllMocks(releaseDataFileService, publishingService, releaseVersionService);
 
@@ -686,7 +685,7 @@ public class ThemeServiceTests
 
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
 
-            var result = await service.DeleteTheme(themeId);
+            var result = await service.DeleteThemes([themeId]);
 
             VerifyAllMocks(publishingService, releaseVersionService);
 
@@ -718,7 +717,7 @@ public class ThemeServiceTests
         {
             var service = SetupThemeService(context, enableThemeDeletion: false);
 
-            var result = await service.DeleteTheme(theme.Id);
+            var result = await service.DeleteThemes([theme.Id]);
             result.AssertForbidden();
 
             Assert.Equal(1, await context.Themes.CountAsync());
@@ -794,7 +793,7 @@ public class ThemeServiceTests
                 .Setup(s => s.DeleteTestReleaseVersion(releaseVersionId, CancellationToken.None))
                 .ReturnsAsync(Unit.Instance);
 
-            var result = await service.DeleteTheme(theme.Id);
+            var result = await service.DeleteThemes([theme.Id]);
 
             VerifyAllMocks(releaseDataFileService, methodologyService, publishingService, releaseVersionService);
 
@@ -977,7 +976,7 @@ public class ThemeServiceTests
 
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var service = SetupThemeService(context, environmentName: Environments.Production);
+            var service = SetupThemeService(context);
 
             var result = await service.DeleteThemes([theme.Id]);
             result.AssertForbidden();
@@ -996,8 +995,7 @@ public class ThemeServiceTests
         IReleaseVersionService? releaseVersionService = null,
         IAdminEventRaiser? adminEventRaiser = null,
         IUserPublicationRoleRepository? userPublicationRoleRepository = null,
-        bool enableThemeDeletion = true,
-        string environmentName = nameof(Environments.Development)
+        bool enableThemeDeletion = true
     )
     {
         contentDbContext ??= new Mock<ContentDbContext>().Object;
@@ -1023,8 +1021,7 @@ public class ThemeServiceTests
             publishingService ?? Mock.Of<IPublishingService>(Strict),
             releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
             adminEventRaiser ?? new AdminEventRaiserMockBuilder().Build(),
-            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
-            Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName)
+            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -357,7 +357,7 @@ public class ThemeServiceTests
         publication1.LatestPublishedReleaseVersion = null;
         publication1.LatestPublishedReleaseVersionId = null;
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -486,7 +486,7 @@ public class ThemeServiceTests
             )
             .GenerateList();
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -574,7 +574,7 @@ public class ThemeServiceTests
 
         ReleaseVersion release2Version2 = _fixture.DefaultReleaseVersion().WithVersion(1).WithRelease(release2);
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -666,7 +666,7 @@ public class ThemeServiceTests
             Contact = NewContact(),
         };
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -706,9 +706,12 @@ public class ThemeServiceTests
             VerifyAllMocks(publishingService, releaseVersionService);
 
             result.AssertRight();
+        }
 
-            Assert.Equal(0, contentContext.Publications.Count());
-            Assert.Equal(0, contentContext.Themes.Count());
+        await using (var context = fixture.CreateContext())
+        {
+            Assert.Equal(0, context.Publications.Count());
+            Assert.Equal(0, context.Themes.Count());
         }
     }
 
@@ -771,7 +774,7 @@ public class ThemeServiceTests
             .DefaultMethodology()
             .WithOwningPublication(otherReleaseVersion.Release.Publication);
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -814,9 +817,12 @@ public class ThemeServiceTests
             VerifyAllMocks(releaseDataFileService, methodologyService, publishingService, releaseVersionService);
 
             result.AssertRight();
+        }
 
-            Assert.Equal(otherReleaseVersion.Publication.Id, contentContext.Publications.Single().Id);
-            Assert.Equal(otherTheme.Id, contentContext.Themes.Single().Id);
+        await using (var context = fixture.CreateContext())
+        {
+            Assert.Equal(otherReleaseVersion.Publication.Id, context.Publications.Single().Id);
+            Assert.Equal(otherTheme.Id, context.Themes.Single().Id);
         }
     }
 
@@ -855,7 +861,7 @@ public class ThemeServiceTests
             Publications = [standardTitleThemePublication],
         };
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var context = fixture.CreateContext())
         {
@@ -880,9 +886,12 @@ public class ThemeServiceTests
             // Act
             await service.DeleteUITestThemes();
 
-            VerifyAllMocks(publishingService);
-
             // Assert
+            VerifyAllMocks(publishingService);
+        }
+
+        await using (var context = fixture.CreateContext())
+        {
             var themesResult = await context.Themes.ToListAsync();
             var publicationsResult = await context.Publications.ToListAsync();
 
@@ -927,7 +936,7 @@ public class ThemeServiceTests
         var theme2 = new Theme { Id = Guid.NewGuid(), Title = "Theme 2 to delete" };
         var otherTheme = new Theme { Id = Guid.NewGuid(), Title = "Theme to retain" };
 
-        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+        using var fixture = new SqliteContentDbContextFixture();
 
         await using (var context = fixture.CreateContext())
         {
@@ -941,13 +950,14 @@ public class ThemeServiceTests
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
 
             var service = SetupThemeService(contentDbContext: context, publishingService: publishingService.Object);
-
             var result = await service.DeleteThemes([theme1.Id, theme2.Id]);
 
             VerifyAllMocks(publishingService);
-
             result.AssertRight();
+        }
 
+        await using (var context = fixture.CreateContext())
+        {
             var remainingThemes = await context.Themes.ToListAsync();
             Assert.Single(remainingThemes);
             Assert.Equal(otherTheme.Id, remainingThemes[0].Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -357,7 +357,7 @@ public class ThemeServiceTests
         publication1.LatestPublishedReleaseVersion = null;
         publication1.LatestPublishedReleaseVersionId = null;
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -486,7 +486,7 @@ public class ThemeServiceTests
             )
             .GenerateList();
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -574,7 +574,7 @@ public class ThemeServiceTests
 
         ReleaseVersion release2Version2 = _fixture.DefaultReleaseVersion().WithVersion(1).WithRelease(release2);
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -666,7 +666,7 @@ public class ThemeServiceTests
             Contact = NewContact(),
         };
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -774,7 +774,7 @@ public class ThemeServiceTests
             .DefaultMethodology()
             .WithOwningPublication(otherReleaseVersion.Release.Publication);
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var contentContext = fixture.CreateContext())
         {
@@ -861,7 +861,7 @@ public class ThemeServiceTests
             Publications = [standardTitleThemePublication],
         };
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var context = fixture.CreateContext())
         {
@@ -936,7 +936,7 @@ public class ThemeServiceTests
         var theme2 = new Theme { Id = Guid.NewGuid(), Title = "Theme 2 to delete" };
         var otherTheme = new Theme { Id = Guid.NewGuid(), Title = "Theme to retain" };
 
-        using var fixture = new SqliteContentDbContextFixture();
+        using var fixture = new SqliteContentDbContextFixture(enforceForeignKeys: false);
 
         await using (var context = fixture.CreateContext())
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -113,9 +114,10 @@ public class ThemeServiceTests
             Title = "Test theme",
             Slug = "test-theme",
             Summary = "Test summary",
-            Publications = expectedPublicationSlugs
-                .Select(publicationSlug => new Publication { Slug = publicationSlug })
-                .ToList(),
+            Publications =
+            [
+                .. expectedPublicationSlugs.Select(publicationSlug => new Publication { Slug = publicationSlug }),
+            ],
         };
 
         var contextId = Guid.NewGuid().ToString();
@@ -348,16 +350,30 @@ public class ThemeServiceTests
 
         Methodology methodology = _fixture.DefaultMethodology().WithOwningPublication(publication1);
 
-        var contextId = Guid.NewGuid().ToString();
+        // Publication.LatestPublishedReleaseVersionId and ReleaseVersion.PublicationId reference each other,
+        // which a relational provider rejects as a circular dependency if both are inserted at once. Seed the
+        // Publication without its latest published version, then point at it once the rows exist.
+        var latestPublishedReleaseVersion = publication1.LatestPublishedReleaseVersion!;
+        publication1.LatestPublishedReleaseVersion = null;
+        publication1.LatestPublishedReleaseVersionId = null;
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
+
+        await using (var contentContext = fixture.CreateContext())
         {
             contentContext.Publications.AddRange(publications);
             contentContext.Methodologies.Add(methodology);
             await contentContext.SaveChangesAsync();
         }
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
+        {
+            var publication = await contentContext.Publications.SingleAsync(p => p.Id == publication1.Id);
+            publication.LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id;
+            await contentContext.SaveChangesAsync();
+        }
+
+        await using (var contentContext = fixture.CreateContext())
         {
             Assert.Equal(1, contentContext.Themes.Count());
             Assert.Equal(3, contentContext.Publications.Count());
@@ -372,7 +388,7 @@ public class ThemeServiceTests
         var methodologyService = new Mock<IMethodologyService>(Strict);
         var publishingService = new Mock<IPublishingService>(Strict);
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             var service = SetupThemeService(
                 contentContext,
@@ -408,7 +424,7 @@ public class ThemeServiceTests
             }
         }
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             Assert.Empty(contentContext.Themes);
             Assert.Empty(contentContext.Publications);
@@ -470,9 +486,9 @@ public class ThemeServiceTests
             )
             .GenerateList();
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             contentContext.ReleaseVersions.AddRange(releaseVersion1, releaseVersion2, releaseVersion3);
             contentContext.ReleaseFiles.AddRange(
@@ -490,7 +506,7 @@ public class ThemeServiceTests
         var publicDataDbContext = new Mock<PublicDataDbContext>();
         publicDataDbContext.SetupGet(c => c.DataSetVersions).ReturnsDbSet(dataSetVersions);
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             var service = SetupThemeService(
                 contentDbContext: contentContext,
@@ -558,9 +574,9 @@ public class ThemeServiceTests
 
         ReleaseVersion release2Version2 = _fixture.DefaultReleaseVersion().WithVersion(1).WithRelease(release2);
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             contentContext.ReleaseVersions.AddRange(
                 release1Version1,
@@ -578,7 +594,7 @@ public class ThemeServiceTests
         var publishingService = new Mock<IPublishingService>(Strict);
         var releaseVersionService = new Mock<IReleaseVersionService>(Strict);
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             var service = SetupThemeService(
                 contentDbContext: contentContext,
@@ -647,12 +663,12 @@ public class ThemeServiceTests
                 new ReleaseVersion { Id = releaseVersion4Id, PreviousVersionId = releaseVersion3Id },
                 new ReleaseVersion { Id = releaseVersion3Id, PreviousVersionId = releaseVersion2Id },
             ],
-            Contact = new Contact(),
+            Contact = NewContact(),
         };
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             contentContext.Publications.Add(publication);
             contentContext.Themes.Add(theme);
@@ -666,7 +682,7 @@ public class ThemeServiceTests
         var publishingService = new Mock<IPublishingService>(Strict);
         var releaseVersionService = new Mock<IReleaseVersionService>(Strict);
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             var service = SetupThemeService(
                 contentContext,
@@ -755,9 +771,9 @@ public class ThemeServiceTests
             .DefaultMethodology()
             .WithOwningPublication(otherReleaseVersion.Release.Publication);
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             contentContext.Methodologies.AddRange(methodology, otherMethodology);
             contentContext.ReleaseVersions.AddRange(releaseVersion, otherReleaseVersion);
@@ -776,7 +792,7 @@ public class ThemeServiceTests
         var publishingService = new Mock<IPublishingService>(Strict);
         var releaseVersionService = new Mock<IReleaseVersionService>(Strict);
 
-        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        await using (var contentContext = fixture.CreateContext())
         {
             var service = SetupThemeService(
                 contentContext,
@@ -815,13 +831,14 @@ public class ThemeServiceTests
         {
             ThemeId = uiTestTheme1Id,
             Title = "UI test theme",
-            Contact = new Contact(),
+            Contact = NewContact(),
         };
 
         var standardTitleThemePublication = new Publication
         {
             ThemeId = standardTitleThemeId,
             Title = "Standard title theme",
+            Contact = NewContact(),
         };
 
         var uiTestTheme = new Theme
@@ -838,9 +855,9 @@ public class ThemeServiceTests
             Publications = [standardTitleThemePublication],
         };
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var context = InMemoryApplicationDbContext(contextId))
+        await using (var context = fixture.CreateContext())
         {
             await context.AddRangeAsync(
                 uiTestTheme,
@@ -851,7 +868,7 @@ public class ThemeServiceTests
             await context.SaveChangesAsync();
         }
 
-        await using (var context = InMemoryApplicationDbContext(contextId))
+        await using (var context = fixture.CreateContext())
         {
             var publishingService = new Mock<IPublishingService>(Strict);
 
@@ -910,15 +927,15 @@ public class ThemeServiceTests
         var theme2 = new Theme { Id = Guid.NewGuid(), Title = "Theme 2 to delete" };
         var otherTheme = new Theme { Id = Guid.NewGuid(), Title = "Theme to retain" };
 
-        var contextId = Guid.NewGuid().ToString();
+        using var fixture = new SqliteContentDbContextFixture(); // Required for transaction support
 
-        await using (var context = InMemoryApplicationDbContext(contextId))
+        await using (var context = fixture.CreateContext())
         {
             context.Themes.AddRange(theme1, theme2, otherTheme);
             await context.SaveChangesAsync();
         }
 
-        await using (var context = InMemoryApplicationDbContext(contextId))
+        await using (var context = fixture.CreateContext())
         {
             var publishingService = new Mock<IPublishingService>(Strict);
             publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
@@ -964,26 +981,24 @@ public class ThemeServiceTests
     [Fact]
     public async Task DeleteThemes_DisallowedInProduction_ThemeNotDeleted()
     {
-        var theme = new Theme { Id = Guid.NewGuid(), Title = "Theme to delete" };
+        var service = SetupThemeService(enableThemeDeletion: false);
 
-        var contextId = Guid.NewGuid().ToString();
-
-        await using (var context = InMemoryApplicationDbContext(contextId))
-        {
-            context.Themes.Add(theme);
-            await context.SaveChangesAsync();
-        }
-
-        await using (var context = InMemoryApplicationDbContext(contextId))
-        {
-            var service = SetupThemeService(context);
-
-            var result = await service.DeleteThemes([theme.Id]);
-            result.AssertForbidden();
-
-            Assert.Equal(1, await context.Themes.CountAsync());
-        }
+        var result = await service.DeleteThemes([Guid.NewGuid()]);
+        result.AssertForbidden();
     }
+
+    /// <summary>
+    /// A <see cref="Contact"/> with all of its required fields set. Unlike the in-memory provider, a relational
+    /// provider enforces the not-null constraints on these columns.
+    /// </summary>
+    private static Contact NewContact() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            TeamName = "Team name",
+            TeamEmail = "test@example.com",
+            ContactName = "Contact name",
+        };
 
     private static ThemeService SetupThemeService(
         ContentDbContext? contentDbContext = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -26,6 +26,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using Moq.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -903,6 +904,88 @@ public class ThemeServiceTests
         }
     }
 
+    [Fact]
+    public async Task DeleteThemes_Success_DeletesAllSpecifiedThemes()
+    {
+        var theme1 = new Theme { Id = Guid.NewGuid(), Title = "Theme 1 to delete" };
+        var theme2 = new Theme { Id = Guid.NewGuid(), Title = "Theme 2 to delete" };
+        var otherTheme = new Theme { Id = Guid.NewGuid(), Title = "Theme to retain" };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Themes.AddRange(theme1, theme2, otherTheme);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publishingService = new Mock<IPublishingService>(Strict);
+            publishingService.Setup(s => s.TaxonomyChanged(CancellationToken.None)).ReturnsAsync(Unit.Instance);
+
+            var service = SetupThemeService(contentDbContext: context, publishingService: publishingService.Object);
+
+            var result = await service.DeleteThemes([theme1.Id, theme2.Id]);
+
+            VerifyAllMocks(publishingService);
+
+            result.AssertRight();
+
+            var remainingThemes = await context.Themes.ToListAsync();
+            Assert.Single(remainingThemes);
+            Assert.Equal(otherTheme.Id, remainingThemes[0].Id);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteThemes_DisallowedByConfiguration_ThemeNotDeleted()
+    {
+        var theme = new Theme { Id = Guid.NewGuid(), Title = "Theme to delete" };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Themes.Add(theme);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupThemeService(context, enableThemeDeletion: false);
+
+            var result = await service.DeleteThemes([theme.Id]);
+            result.AssertForbidden();
+
+            Assert.Equal(1, await context.Themes.CountAsync());
+        }
+    }
+
+    [Fact]
+    public async Task DeleteThemes_DisallowedInProduction_ThemeNotDeleted()
+    {
+        var theme = new Theme { Id = Guid.NewGuid(), Title = "Theme to delete" };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Themes.Add(theme);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var service = SetupThemeService(context, environmentName: Environments.Production);
+
+            var result = await service.DeleteThemes([theme.Id]);
+            result.AssertForbidden();
+
+            Assert.Equal(1, await context.Themes.CountAsync());
+        }
+    }
+
     private static ThemeService SetupThemeService(
         ContentDbContext? contentDbContext = null,
         PublicDataDbContext? publicDataDbContext = null,
@@ -913,7 +996,8 @@ public class ThemeServiceTests
         IReleaseVersionService? releaseVersionService = null,
         IAdminEventRaiser? adminEventRaiser = null,
         IUserPublicationRoleRepository? userPublicationRoleRepository = null,
-        bool enableThemeDeletion = true
+        bool enableThemeDeletion = true,
+        string environmentName = nameof(Environments.Development)
     )
     {
         contentDbContext ??= new Mock<ContentDbContext>().Object;
@@ -939,7 +1023,8 @@ public class ThemeServiceTests
             publishingService ?? Mock.Of<IPublishingService>(Strict),
             releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
             adminEventRaiser ?? new AdminEventRaiserMockBuilder().Build(),
-            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)
+            userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict),
+            Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName)
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
@@ -47,4 +47,10 @@ public class ThemeController(IThemeService themeService) : ControllerBase
     {
         return await themeService.DeleteUITestThemes(cancellationToken).HandleFailuresOrNoContent();
     }
+
+    [HttpDelete("themes/bulk")]
+    public async Task<ActionResult> DeleteThemes([FromBody] List<Guid> themeIds, CancellationToken cancellationToken)
+    {
+        return await themeService.DeleteThemes(themeIds, cancellationToken).HandleFailuresOrNoContent();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
@@ -39,7 +39,7 @@ public class ThemeController(IThemeService themeService) : ControllerBase
     [HttpDelete("themes/{themeId:guid}")]
     public async Task<ActionResult> DeleteTheme([Required] Guid themeId)
     {
-        return await themeService.DeleteTheme(themeId).HandleFailuresOrNoContent();
+        return await themeService.DeleteThemes([themeId]).HandleFailuresOrNoContent();
     }
 
     [HttpDelete("themes")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
@@ -14,8 +14,6 @@ public interface IThemeService
 
     Task<Either<ActionResult, List<ThemeViewModel>>> GetThemes();
 
-    Task<Either<ActionResult, Unit>> DeleteTheme(Guid themeId, CancellationToken cancellationToken = default);
-
     Task<Either<ActionResult, Unit>> DeleteThemes(List<Guid> themeIds, CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Unit>> DeleteUITestThemes(CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
@@ -16,5 +16,7 @@ public interface IThemeService
 
     Task<Either<ActionResult, Unit>> DeleteTheme(Guid themeId, CancellationToken cancellationToken = default);
 
+    Task<Either<ActionResult, Unit>> DeleteThemes(List<Guid> themeIds, CancellationToken cancellationToken = default);
+
     Task<Either<ActionResult, Unit>> DeleteUITestThemes(CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -313,6 +313,8 @@ public class ReleaseVersionService(
             dataBlockParent.LatestPublishedVersionId = null;
         });
 
+        await RemoveKeyStatsForDataBlocks(dataBlockVersions, cancellationToken);
+
         await context.SaveChangesAsync(cancellationToken);
 
         // Then remove the now-unreferenced DataBlockVersions.
@@ -330,6 +332,35 @@ public class ReleaseVersionService(
 
         context.DataBlockParents.RemoveRange(orphanedDataBlockParents);
         await context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Remove any KeyStatistics for the supplied DataBlockVersions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The foreign key from KeyStatisticsDataBlock to the DataBlock's ContentBlock row is deliberately
+    /// configured with DeleteBehavior.NoAction - see ContentDbContext.ConfigureKeyStatisticsDataBlock -
+    /// so unless they are removed here, removing the DataBlockVersions below fails on
+    /// FK_KeyStatisticsDataBlock_ContentBlock_DataBlockId. Removing them via the derived DbSet also
+    /// removes their base KeyStatistics rows, which must never be orphaned.
+    /// </para>
+    /// <para>
+    /// This method does NOT call DbContext.SaveChangesAsync().
+    /// </para>
+    /// </remarks>
+    private async Task RemoveKeyStatsForDataBlocks(
+        List<DataBlockVersion> dataBlockVersions,
+        CancellationToken cancellationToken
+    )
+    {
+        var dataBlockIds = dataBlockVersions.Select(dataBlockVersion => dataBlockVersion.Id).ToList();
+
+        var keyStatistics = await context
+            .KeyStatisticsDataBlock.Where(keyStatistic => dataBlockIds.Contains(keyStatistic.DataBlockId))
+            .ToListAsync(cancellationToken);
+
+        context.KeyStatisticsDataBlock.RemoveRange(keyStatistics);
     }
 
     private void UpdateMethodologies(Guid releaseVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -118,26 +118,47 @@ public class ThemeService(
         CancellationToken cancellationToken = default
     )
     {
+        // This deliberately runs without a transaction. Deleting a Theme cascades into deletions across the
+        // content and statistics databases, the Public API's PostgreSQL database, Azure blob storage and Azure
+        // storage tables, and reaches the latter three via a blocking HTTP call out to the Public Data
+        // Processor. That call reads and writes the same content database rows as this operation, so holding a
+        // transaction open across it makes the Processor wait on locks that cannot be released until the
+        // Processor itself responds, which SQL Server cannot detect as a deadlock and which therefore blocks
+        // until the command timeout expires. A transaction could not have made the operation atomic in any
+        // case, as the blob and Public API deletions are already irreversible by the time it would roll back.
+        // Instead, ReleaseVersions are deleted in a dependency-safe order so that a partial deletion can be
+        // completed by retrying.
         return await CheckCanDeleteThemes()
             .OnSuccess(async _ => await userService.CheckCanManageAllTaxonomy())
-            .OnSuccessVoid(async () =>
+            .OnSuccess<ActionResult, Unit, Unit>(async _ =>
             {
                 var themes = await contentDbContext
                     .Themes.Where(t => themeIds.Contains(t.Id))
                     .ToListAsync(cancellationToken);
 
-                await using var transaction = await contentDbContext.Database.BeginTransactionAsync(cancellationToken);
+                var failures = new List<ActionResult>();
 
                 foreach (var theme in themes)
                 {
-                    await DeletePublicationsForTheme(theme.Id, cancellationToken)
+                    var result = await DeletePublicationsForTheme(theme.Id, cancellationToken)
                         .OnSuccessDo(() => contentDbContext.Themes.Remove(theme));
+
+                    if (result.IsLeft)
+                    {
+                        failures.AddRange(result.Left);
+                    }
                 }
 
+                // Persisted before reporting any failure, so that the Themes which were deleted successfully
+                // do not have to be deleted again on a retry.
                 await contentDbContext.SaveChangesAsync(cancellationToken);
-                await transaction.CommitAsync(cancellationToken);
 
-                await publishingService.TaxonomyChanged(cancellationToken);
+                if (failures.Count > 0)
+                {
+                    return failures[0];
+                }
+
+                return await publishingService.TaxonomyChanged(cancellationToken);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Metho
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -149,16 +148,10 @@ public class ThemeService(
                     }
                 }
 
-                // Persisted before reporting any failure, so that the Themes which were deleted successfully
-                // do not have to be deleted again on a retry.
                 await contentDbContext.SaveChangesAsync(cancellationToken);
+                await publishingService.TaxonomyChanged(cancellationToken);
 
-                if (failures.Count > 0)
-                {
-                    return failures[0];
-                }
-
-                return await publishingService.TaxonomyChanged(cancellationToken);
+                return failures.Count > 0 ? failures[0] : Unit.Instance;
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -120,23 +120,21 @@ public class ThemeService(
     {
         return await CheckCanDeleteTheme()
             .OnSuccess(async _ => await userService.CheckCanManageAllTaxonomy())
-            .OnSuccess(() => contentDbContext.Themes.Where(t => themeIds.Contains(t.Id)).OrNotFound())
-            .OnSuccess(async themes =>
+            .OnSuccess(() =>
+                contentDbContext.Themes.Where(t => themeIds.Contains(t.Id)).ToListAsync(cancellationToken).OrNotFound()
+            )
+            .OnSuccessVoid(async themes =>
             {
-                await using var transaction = await contentDbContext.Database.BeginTransactionAsync();
+                await using var transaction = await contentDbContext.Database.BeginTransactionAsync(cancellationToken);
 
-                await themes.ForEachAsync(async theme =>
+                foreach (var theme in themes)
                 {
                     await DeletePublicationsForTheme(theme.Id, cancellationToken)
                         .OnSuccessDo(() => contentDbContext.Themes.Remove(theme));
-                });
+                }
 
-                return transaction;
-            })
-            .OnSuccessVoid(async transaction =>
-            {
                 await contentDbContext.SaveChangesAsync(cancellationToken);
-                await transaction.CommitAsync();
+                await transaction.CommitAsync(cancellationToken);
 
                 await publishingService.TaxonomyChanged(cancellationToken);
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -33,8 +33,7 @@ public class ThemeService(
     IPublishingService publishingService,
     IReleaseVersionService releaseVersionService,
     IAdminEventRaiser eventRaiser,
-    IUserPublicationRoleRepository userPublicationRoleRepository,
-    IHostEnvironment hostEnvironment
+    IUserPublicationRoleRepository userPublicationRoleRepository
 ) : IThemeService
 {
     private readonly bool _themeDeletionAllowed = appOptions.Value.EnableThemeDeletion;
@@ -114,41 +113,33 @@ public class ThemeService(
             .OnSuccess(list => list.Select(mapper.Map<ThemeViewModel>).OrderBy(theme => theme.Title).ToList());
     }
 
-    public async Task<Either<ActionResult, Unit>> DeleteTheme(
-        Guid themeId,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return await userService
-            .CheckCanManageAllTaxonomy()
-            .OnSuccess(() => contentDbContext.Themes.FirstOrNotFoundAsync(t => t.Id == themeId, cancellationToken))
-            .OnSuccessDo(CheckCanDeleteTheme)
-            .OnSuccessDo(() => DeletePublicationsForTheme(themeId, cancellationToken))
-            .OnSuccessVoid(async theme =>
-            {
-                contentDbContext.Themes.Remove(theme);
-                await contentDbContext.SaveChangesAsync(cancellationToken);
-
-                await publishingService.TaxonomyChanged(cancellationToken);
-            });
-    }
-
     public async Task<Either<ActionResult, Unit>> DeleteThemes(
         List<Guid> themeIds,
         CancellationToken cancellationToken = default
     )
     {
-        if (hostEnvironment.IsProduction())
-        {
-            return new ForbidResult();
-        }
+        return await CheckCanDeleteTheme()
+            .OnSuccess(async _ => await userService.CheckCanManageAllTaxonomy())
+            .OnSuccess(() => contentDbContext.Themes.Where(t => themeIds.Contains(t.Id)).OrNotFound())
+            .OnSuccess(async themes =>
+            {
+                await using var transaction = await contentDbContext.Database.BeginTransactionAsync();
 
-        var results = await themeIds
-            .ToAsyncEnumerable()
-            .Select(async (themeId, index, cancellationToken) => await DeleteTheme(themeId, cancellationToken))
-            .ToListAsync(cancellationToken);
+                await themes.ForEachAsync(async theme =>
+                {
+                    await DeletePublicationsForTheme(theme.Id, cancellationToken)
+                        .OnSuccessDo(() => contentDbContext.Themes.Remove(theme));
+                });
 
-        return results.OnSuccessAllReturnVoid();
+                return transaction;
+            })
+            .OnSuccessVoid(async transaction =>
+            {
+                await contentDbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync();
+
+                await publishingService.TaxonomyChanged(cancellationToken);
+            });
     }
 
     private async Task<Either<List<ActionResult>, Unit>> DeletePublicationsForTheme(
@@ -241,7 +232,6 @@ public class ThemeService(
             {
                 contentDbContext.Publications.Remove(publication);
                 contentDbContext.Contacts.Remove(publication.Contact);
-                await contentDbContext.SaveChangesAsync(cancellationToken);
 
                 await eventRaiser.OnPublicationDeleted(publication.Id, publication.Slug, latestPublicationRelease);
             });
@@ -249,28 +239,16 @@ public class ThemeService(
 
     public async Task<Either<ActionResult, Unit>> DeleteUITestThemes(CancellationToken cancellationToken = default)
     {
-        return !_themeDeletionAllowed
-            ? new ForbidResult()
-            : await userService
-                .CheckCanManageAllTaxonomy()
-                .OnSuccess(async _ =>
-                    (await contentDbContext.Themes.ToListAsync(cancellationToken)).Where(theme =>
-                        theme.IsTestOrSeedTheme()
-                    )
-                )
-                .OnSuccessVoid(async themes =>
-                {
-                    foreach (var theme in themes)
-                    {
-                        await DeleteTheme(theme.Id, cancellationToken);
-                    }
+        var themes = await contentDbContext.Themes.ToListAsync(cancellationToken);
 
-                    await contentDbContext.SaveChangesAsync(cancellationToken);
-                    await publishingService.TaxonomyChanged(cancellationToken);
-                });
+        var testThemeIds = themes.Where(theme => theme.IsTestOrSeedTheme()).Select(theme => theme.Id).ToList();
+
+        return themes.Count > 0
+            ? await DeleteThemes(testThemeIds, cancellationToken)
+            : new OkObjectResult("No test themes to delete.");
     }
 
-    private async Task<Either<ActionResult, Unit>> CheckCanDeleteTheme(Theme theme)
+    private async Task<Either<ActionResult, Unit>> CheckCanDeleteTheme()
     {
         if (!_themeDeletionAllowed)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -118,13 +118,14 @@ public class ThemeService(
         CancellationToken cancellationToken = default
     )
     {
-        return await CheckCanDeleteTheme()
+        return await CheckCanDeleteThemes()
             .OnSuccess(async _ => await userService.CheckCanManageAllTaxonomy())
-            .OnSuccess(() =>
-                contentDbContext.Themes.Where(t => themeIds.Contains(t.Id)).ToListAsync(cancellationToken).OrNotFound()
-            )
-            .OnSuccessVoid(async themes =>
+            .OnSuccessVoid(async () =>
             {
+                var themes = await contentDbContext
+                    .Themes.Where(t => themeIds.Contains(t.Id))
+                    .ToListAsync(cancellationToken);
+
                 await using var transaction = await contentDbContext.Database.BeginTransactionAsync(cancellationToken);
 
                 foreach (var theme in themes)
@@ -246,7 +247,7 @@ public class ThemeService(
             : new OkObjectResult("No test themes to delete.");
     }
 
-    private async Task<Either<ActionResult, Unit>> CheckCanDeleteTheme()
+    private async Task<Either<ActionResult, Unit>> CheckCanDeleteThemes()
     {
         if (!_themeDeletionAllowed)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -33,7 +33,8 @@ public class ThemeService(
     IPublishingService publishingService,
     IReleaseVersionService releaseVersionService,
     IAdminEventRaiser eventRaiser,
-    IUserPublicationRoleRepository userPublicationRoleRepository
+    IUserPublicationRoleRepository userPublicationRoleRepository,
+    IHostEnvironment hostEnvironment
 ) : IThemeService
 {
     private readonly bool _themeDeletionAllowed = appOptions.Value.EnableThemeDeletion;
@@ -130,6 +131,24 @@ public class ThemeService(
 
                 await publishingService.TaxonomyChanged(cancellationToken);
             });
+    }
+
+    public async Task<Either<ActionResult, Unit>> DeleteThemes(
+        List<Guid> themeIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (hostEnvironment.IsProduction())
+        {
+            return new ForbidResult();
+        }
+
+        var results = await themeIds
+            .ToAsyncEnumerable()
+            .Select(async (themeId, index, cancellationToken) => await DeleteTheme(themeId, cancellationToken))
+            .ToListAsync(cancellationToken);
+
+        return results.OnSuccessAllReturnVoid();
     }
 
     private async Task<Either<List<ActionResult>, Unit>> DeletePublicationsForTheme(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -288,7 +288,7 @@ public static class ReleaseVersionGeneratorExtensions
     public static InstanceSetters<ReleaseVersion> SetReleaseStatuses(
         this InstanceSetters<ReleaseVersion> setters,
         IEnumerable<ReleaseStatus> releaseStatuses
-    ) => setters.Set(releaseVersion => releaseVersion.ReleaseStatuses, releaseStatuses.ToList());
+    ) => setters.Set(releaseVersion => releaseVersion.ReleaseStatuses, [.. releaseStatuses]);
 
     public static InstanceSetters<ReleaseVersion> SetDataBlockVersions(
         this InstanceSetters<ReleaseVersion> setters,
@@ -297,7 +297,7 @@ public static class ReleaseVersionGeneratorExtensions
     {
         var dataBlockVersionsList = dataBlockVersions.ToList();
         return setters
-            .Set(releaseVersion => releaseVersion.DataBlockVersions, dataBlockVersionsList.ToList())
+            .Set(releaseVersion => releaseVersion.DataBlockVersions, [.. dataBlockVersionsList])
             .Set(
                 (_, releaseVersion, _) =>
                 {
@@ -417,7 +417,7 @@ public static class ReleaseVersionGeneratorExtensions
     public static InstanceSetters<ReleaseVersion> SetRelatedInformation(
         this InstanceSetters<ReleaseVersion> setters,
         IEnumerable<Link> relatedInformation
-    ) => setters.Set(releaseVersion => releaseVersion.RelatedInformation, relatedInformation.ToList());
+    ) => setters.Set(releaseVersion => releaseVersion.RelatedInformation, [.. relatedInformation]);
 
     public static InstanceSetters<ReleaseVersion> SetUpdates(
         this InstanceSetters<ReleaseVersion> setters,
@@ -426,7 +426,7 @@ public static class ReleaseVersionGeneratorExtensions
     {
         var updatesList = updates.ToList();
         return setters
-            .Set(releaseVersion => releaseVersion.Updates, updatesList.ToList())
+            .Set(releaseVersion => releaseVersion.Updates, [.. updatesList])
             .Set(
                 (_, releaseVersion, _) =>
                     updatesList.ForEach(update =>


### PR DESCRIPTION
This PR adds a new endpoint which handles a list of GUIDs to manage theme deletion, and moves a few of the method chains in the service layer around to avoid duplicating work.

This PR also introduces an SQLite provider for integration testing. Originally added to support a transaction spanning the various theme deletion actions (since this is unsupported by the current in-memory provider we use elsewhere), the transaction was removed due to unsuitability with the current process, but the SQLite provider was retained, as moving away from in-memory is one of the team's goals for this codebase.