### PR TITLE
EES-7396 Allow deploying the NL Search Function app infrastructure to other environments

### DIFF
--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -58,9 +58,6 @@ param searchServiceSemanticRankerAvailability string
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
-@description('Indicates whether to deploy the Natural Language Search Function App as part of this deployment.')
-param deployNaturalLanguageSearchFunctionApp bool = false
-
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
   DateProvisioned: dateProvisioned
@@ -103,7 +100,7 @@ module monitoringModule 'application/monitoring.bicep' = {
   }
 }
 
-module nlSearchFunctionAppModule 'application/nlSearchFunctionApp.bicep' = if (deployNaturalLanguageSearchFunctionApp) {
+module nlSearchFunctionAppModule 'application/nlSearchFunctionApp.bicep' = {
   name: 'nlSearchFunctionAppApplicationModuleDeploy'
   params: {
     location: location
@@ -181,6 +178,6 @@ output searchDocsFunctionAppUrl string = searchDocsFunctionAppModule.outputs.fun
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
 output searchStorageAccountManagedIdentityConnectionString string = searchServiceModule.outputs.searchStorageAccountManagedIdentityConnectionString
 output searchDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.searchDocuments
-output nlSearchFunctionAppUrl string = deployNaturalLanguageSearchFunctionApp ? nlSearchFunctionAppModule.outputs.functionAppUrl : ''
+output nlSearchFunctionAppUrl string = nlSearchFunctionAppModule.outputs.functionAppUrl
 output nlSearchDatasetDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.nlSearchDatasetDocuments
 output nlSearchFilterDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.nlSearchFilterDocuments

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -9,5 +9,3 @@ param searchServiceSemanticRankerAvailability = 'free'
 
 // Allow API key authentication for the Azure AI Search service to support local development.
 param searchServiceLocalAuthEnabled = true
-
-param deployNaturalLanguageSearchFunctionApp = true


### PR DESCRIPTION
This PR removes the restriction on deploying the Natural language search Function app infrastructure to other environments.

It was previously restricted to only deploy to the Dev environment because the template `nlSearchFunctionApp.bicep` contains two Key vault references. These key vault secrets need to exist in all environments. 

Faffy task EES-7397 has now created the key vault secrets in all environments so the restriction can be removed.

Note: This change only deploys the application infrastructure, not the application itself which is deployed independently by a different pipeline.