### PR TITLE
EES-6751 Increase thresholds for alerts `s101p01PublicAppServiceRespo…

### DIFF
--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -3,7 +3,7 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Production'
 
-param averagePublicSiteResponseTimeAlertThresholdMillis = 1000
+param averagePublicSiteResponseTimeAlertThresholdMillis = 15000
 
 param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
 

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1003,7 +1003,7 @@
         "resourceId": "[resourceId('Microsoft.Web/sites', variables('publicAppName'))]",
         "resourceType": "Microsoft.Web/sites",
         "metricName": "HttpResponseTime",
-        "threshold": 10,
+        "threshold": 12,
         "operator": "GreaterThan",
         "timeAggregation": "Average",
         "criterionType": "StaticThresholdCriterion"


### PR DESCRIPTION
For this ticket, I reviewed alert activity over the last 30 days and identified two potentially noisy response-time alerts. Together, they fired 42 times (and would also have triggered 42 corresponding 'Resolved' alerts):

- `s101p01PublicAppServiceResponseTime` fired 18 times with its current 10-second threshold. Increasing the threshold to 12 seconds would have prevented 12 “Alert fired” and 12 corresponding “Alert resolved” notifications.

- `s101p01-ees-afd-response-time` fired 24 times with its current 1,000 ms (1-second) threshold. The two alerts frequently fired together for essentially the same user-facing slowdown. Increasing the AFD threshold to 15,000 ms would have prevented 15 “Alert fired” and 15 corresponding “Alert resolved” notifications.

This PR increases the respective thresholds to 12 seconds and 15 seconds to reduce noise while retaining alerts for more significant or sustained response-time degradation.