### PR TITLE
EES-7406 Render final table now client-side only. SSR returns a lightweight “Loading table” state instead of rendering thousands of rows.

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -1,6 +1,7 @@
 import TableToolWizard, {
   InitialTableToolState,
 } from '@common/modules/table-tool/components/TableToolWizard';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
 import { SelectedPublication } from '@common/modules/table-tool/types/selectedPublication';
@@ -33,8 +34,14 @@ import logger from '@common/services/logger';
 
 const defaultPageTitle = 'Create your own tables';
 
+// Pre-built tables can contain thousands of rows. Rendering them on the server
+// blocks the entire response, so defer the final table until after hydration.
 const TableToolFinalStep = dynamic(
   () => import('@frontend/modules/table-tool/components/TableToolFinalStep'),
+  {
+    loading: () => <LoadingSpinner text="Loading table" />,
+    ssr: false,
+  },
 );
 
 export interface TableToolPageProps {
@@ -368,8 +375,9 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  const publicationSummary =
-    await publicationService.getPublicationSummary(publicationSlug);
+  const publicationSummary = await publicationService.getPublicationSummary(
+    publicationSlug,
+  );
   const { latestRelease } = publicationSummary;
   const selectedReleaseVersion =
     await publicationService.getReleaseVersionSummary(

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@common/services/tableBuilderService';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import preloadAll from 'jest-next-dynamic';
 import TableToolPage from '@frontend/modules/table-tool/TableToolPage';
 import React from 'react';
 import render from '@common-test/render';
@@ -367,8 +366,6 @@ describe('TableToolPage', () => {
     },
   };
 
-  beforeAll(preloadAll);
-
   test('renders the page correctly with themes and publications', async () => {
     render(<TableToolPage themeMeta={testThemeMeta} />);
 
@@ -480,7 +477,8 @@ describe('TableToolPage', () => {
       />,
     );
 
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Loading table')).toBeInTheDocument();
+    expect(await screen.findByRole('table')).toBeInTheDocument();
   });
 
   test('renders the page correctly with pre-built table when a fast track is provided', async () => {
@@ -495,7 +493,7 @@ describe('TableToolPage', () => {
       />,
     );
 
-    expect(screen.getByRole('table')).toMatchSnapshot();
+    expect(await screen.findByRole('table')).toMatchSnapshot();
   });
 
   test('renders the page correctly when a fast track is provided and this is the latest data', async () => {


### PR DESCRIPTION
# Improve fast track speed/Prevent large data from blocking whole page render

## Summary
This PR changes the way the component `TableToolFinalStep` renders from server side to client side only in order to prevent the whole page of a fast track page from being rendered by high volume data publications. 
Please see [this comment](https://dfedigital.atlassian.net/browse/EES-7406?focusedCommentId=159309) for more info.

## Changes:
 - The expensive final table now renders client-side only.
 - SSR returns a lightweight “Loading table” state instead of rendering thousands of rows.
 - Existing tests now verify the loading state followed by the rendered table.