### PR TITLE
EES-7395 hotfix enable combined search prototype on prod

### DIFF
--- a/src/explore-education-statistics-frontend/next-sitemap.config.js
+++ b/src/explore-education-statistics-frontend/next-sitemap.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   siteUrl: process.env.PROD_PUBLIC_URL,
   sitemapSize: 5000,
-  exclude: ['/server-sitemap.xml'],
+  exclude: ['/server-sitemap.xml', '/search-data', '/search-releases'],
   generateRobotsTxt: true,
   robotsTxtOptions: {
     policies: [

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -731,7 +731,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   query,
   resolvedUrl,
 }) => {
-  if (process.env.APP_ENV === 'Production') {
+  if (process.env.APP_ENV === 'Production' && query.prototype !== 'true') {
     return {
       notFound: true,
     };


### PR DESCRIPTION
The combined search routes were only viewable on non-prod environments. This PR allows the prototype to load on prod, provided the query parameter `prototype` = 'true' (e.g. visit `/search-releases?prototype=true`)

It also makes sure that the prototype routes aren't listed in the public sitemap.