### PR TITLE
EES-7194 Update Generator.Equals package version to 4.0.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -142,7 +142,7 @@
     <PackageVersion Include="CliWrap" Version="3.10.1" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
-    <PackageVersion Include="Generator.Equals" Version="3.3.0" />
+    <PackageVersion Include="Generator.Equals" Version="4.0.1" />
     <PackageVersion Include="GeoJSON.Net" Version="1.4.1" />
     <PackageVersion Include="GovukNotify" Version="7.2.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />


### PR DESCRIPTION
This PR updates the `Generator.Equals` package from 3.3.0 to 4.0.1. It targets the #7212 PR.

This has been split from EES-7120 _Review backend major dependencies PR (July 2026)_, where @mmyoungman was unable to update this dependency due to a failing unit test.

I did not have any unit test failures at the time @mmyoungman did this work when reviewing his change, but it was abandoned and deferred to this ticket.

I later realised that the difference in unit test behaviour between us was probably because I've had the .NET 10 SDK installed since it's release, and due to a problem with the `rollForward` setting set to `latestMajor` in the `global.json`file, this was allowing the SDK in use to jump to the highest installed SDK that's at least the requested version, regardless of major version. In my case that meant jumping to .NET 10 even though the SDK version was `8.0.407`. This issue with `global.json` was resolved in #7072.

The change in this PR to update `Generator.Equals` is being made now that project is being updated to .NET 10 in #7212, and this separate PR has been raised to give @mmyoungman a chance to run the unit tests locally and check that they now pass.