### PR TITLE
EES-6893 Update projects including the Public API to use Swashbuckle.AspNetCore v10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.6",
+      "version": "10.2.3",
       "commands": [
         "swagger"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -40,18 +40,6 @@
       "schedule": ["every 3 months"]
     },
     {
-      "description": "Disable Swashbuckle.AspNetCore.* packages which requires Microsoft.OpenApi / .NET 10 update",
-      "matchDatasources": ["nuget"],
-      "matchPackageNames": [
-        "Swashbuckle.AspNetCore",
-        "Swashbuckle.AspNetCore.Annotations",
-        "Swashbuckle.AspNetCore.Cli",
-        "Swashbuckle.AspNetCore.SwaggerGen"
-      ],
-      "matchCurrentVersion": "9.0.6",
-      "enabled": false
-    },
-    {
       "description": "Disable DuckDB.NET.Data.Full and InterpolatedSql.Dapper related to issue EES-6079",
       "matchDatasources": ["nuget"],
       "matchPackageNames": ["DuckDB.NET.Data.Full", "InterpolatedSql.Dapper"],

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -110,9 +110,9 @@
   <ItemGroup Label="Swagger / OpenAPI">
     <PackageVersion Include="MicroElements.Swashbuckle.FluentValidation" Version="7.2.1" />
     <PackageVersion Include="Namotion.Reflection" Version="3.5.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.6" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup Label="Testing">

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -75,7 +75,7 @@ using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using Notify.Client;
 using Notify.Interfaces;
@@ -730,18 +730,10 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
                         Type = SecuritySchemeType.ApiKey,
                     }
                 );
-                c.AddSecurityRequirement(
-                    new OpenApiSecurityRequirement
-                    {
-                        {
-                            new OpenApiSecurityScheme
-                            {
-                                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
-                            },
-                            [string.Empty]
-                        },
-                    }
-                );
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+                {
+                    { new OpenApiSecuritySchemeReference("Bearer", document), [string.Empty] },
+                });
             });
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -33,7 +33,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using IPublicationService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IPublicationService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -41,7 +41,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Net.Http.Headers;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Newtonsoft.Json;
 using Thinktecture;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Swagger/EnumSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Swagger/EnumSchemaFilter.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Swagger;
@@ -11,12 +10,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Swagger;
 /// </summary>
 public class EnumSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.Type.IsEnum)
+        if (context.Type.IsEnum && schema is OpenApiSchema openApiSchema)
         {
-            schema.Enum.Clear();
-            schema.Enum.AddRange(Enum.GetNames(context.Type).Select(name => new OpenApiString($"{name}")));
+            openApiSchema.Enum = Enum.GetNames(context.Type).Select(JsonNode (name) => JsonValue.Create(name)).ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Swagger;
@@ -12,14 +12,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Swagger;
 /// </summary>
 public class TimeIdentifierSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.Type == typeof(TimeIdentifier))
+        if (context.Type == typeof(TimeIdentifier) && schema is OpenApiSchema openApiSchema)
         {
-            schema.Enum.Clear();
-            var timeIdentifiers = Enum.GetValues<TimeIdentifier>();
-            var values = timeIdentifiers.Select(name => name.GetEnumValue());
-            schema.Enum.AddRange(values.Select(v => new OpenApiString($"{v}")));
+            openApiSchema.Enum = Enum.GetValues<TimeIdentifier>()
+                .Select(JsonNode (timeIdentifier) => JsonValue.Create(timeIdentifier.GetEnumValue()))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetStatusSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetStatusSchemaFilterTests.cs
@@ -1,15 +1,14 @@
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
 
 public class DataSetStatusSchemaFilterTests
 {
-    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+    private readonly SchemaGenerator _schemaGenerator = new(
         new SchemaGeneratorOptions
         {
             UseAllOfToExtendReferenceSchemas = true,
@@ -27,20 +26,16 @@ public class DataSetStatusSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        Assert.Equal("string", schema.Type);
+        Assert.Equal(JsonSchemaType.String, schema.Type);
+        Assert.NotNull(schema.Enum);
         Assert.Equal(3, schema.Enum.Count);
 
-        var enumString1 = Assert.IsType<OpenApiString>(schema.Enum[0]);
-        Assert.Equal(DataSetStatus.Published.ToString(), enumString1.Value);
-
-        var enumString2 = Assert.IsType<OpenApiString>(schema.Enum[1]);
-        Assert.Equal(DataSetStatus.Deprecated.ToString(), enumString2.Value);
-
-        var enumString3 = Assert.IsType<OpenApiString>(schema.Enum[2]);
-        Assert.Equal(DataSetStatus.Withdrawn.ToString(), enumString3.Value);
+        Assert.Equal(nameof(DataSetStatus.Published), schema.Enum[0].GetValue<string>());
+        Assert.Equal(nameof(DataSetStatus.Deprecated), schema.Enum[1].GetValue<string>());
+        Assert.Equal(nameof(DataSetStatus.Withdrawn), schema.Enum[2].GetValue<string>());
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(DataSetStatus), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetVersionStatusSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/DataSetVersionStatusSchemaFilterTests.cs
@@ -1,15 +1,14 @@
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
 
 public class DataSetVersionStatusSchemaFilterTests
 {
-    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+    private readonly SchemaGenerator _schemaGenerator = new(
         new SchemaGeneratorOptions
         {
             UseAllOfToExtendReferenceSchemas = true,
@@ -27,20 +26,16 @@ public class DataSetVersionStatusSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        Assert.Equal("string", schema.Type);
+        Assert.Equal(JsonSchemaType.String, schema.Type);
+        Assert.NotNull(schema.Enum);
         Assert.Equal(3, schema.Enum.Count);
 
-        var enumString1 = Assert.IsType<OpenApiString>(schema.Enum[0]);
-        Assert.Equal(DataSetVersionStatus.Published.ToString(), enumString1.Value);
-
-        var enumString2 = Assert.IsType<OpenApiString>(schema.Enum[1]);
-        Assert.Equal(DataSetVersionStatus.Deprecated.ToString(), enumString2.Value);
-
-        var enumString3 = Assert.IsType<OpenApiString>(schema.Enum[2]);
-        Assert.Equal(DataSetVersionStatus.Withdrawn.ToString(), enumString3.Value);
+        Assert.Equal(nameof(DataSetVersionStatus.Published), schema.Enum[0].GetValue<string>());
+        Assert.Equal(nameof(DataSetVersionStatus.Deprecated), schema.Enum[1].GetValue<string>());
+        Assert.Equal(nameof(DataSetVersionStatus.Withdrawn), schema.Enum[2].GetValue<string>());
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(DataSetVersionStatus), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/ErrorViewModelSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/ErrorViewModelSchemaFilterTests.cs
@@ -1,7 +1,8 @@
 using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -26,12 +27,16 @@ public class ErrorViewModelSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        Assert.False(schema.Properties["code"].Nullable);
+        Assert.NotNull(schema.Properties);
+        // Code is nullable so ensure the JsonSchemaType.Null flag is not set on the type bitmask
+        Assert.False(schema.Properties[nameof(ErrorViewModel.Code).ToLowerFirst()].Type?.HasFlag(JsonSchemaType.Null));
+
+        Assert.NotNull(schema.Required);
         Assert.Contains("message", schema.Required);
         Assert.Contains("code", schema.Required);
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(ErrorViewModel), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/GeographicLevelSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/GeographicLevelSchemaFilterTests.cs
@@ -2,15 +2,14 @@ using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
 
 public class GeographicLevelSchemaFilterTests
 {
-    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+    private readonly SchemaGenerator _schemaGenerator = new(
         new SchemaGeneratorOptions
         {
             UseAllOfToExtendReferenceSchemas = true,
@@ -29,20 +28,20 @@ public class GeographicLevelSchemaFilterTests
         var schema = GenerateSchema();
         var geographicLevels = EnumUtil.GetEnumValues<GeographicLevel>().ToHashSet();
 
-        Assert.Equal("string", schema.Type);
+        Assert.Equal(JsonSchemaType.String, schema.Type);
+        Assert.NotNull(schema.Enum);
         Assert.Equal(geographicLevels.Count, schema.Enum.Count);
 
         Assert.All(
             schema.Enum,
-            e =>
+            jsonNode =>
             {
-                var enumString = Assert.IsType<OpenApiString>(e);
-                Assert.Contains(enumString.Value, geographicLevels);
+                Assert.Contains(jsonNode.GetValue<string>(), geographicLevels);
             }
         );
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(GeographicLevel), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/IndicatorUnitSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/IndicatorUnitSchemaFilterTests.cs
@@ -2,8 +2,7 @@ using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -29,20 +28,20 @@ public class IndicatorUnitSchemaFilterTests
         var schema = GenerateSchema();
         var indicatorUnits = EnumUtil.GetEnumLabels<IndicatorUnit>().ToHashSet();
 
-        Assert.Equal("string", schema.Type);
+        Assert.Equal(JsonSchemaType.String, schema.Type);
+        Assert.NotNull(schema.Enum);
         Assert.Equal(indicatorUnits.Count, schema.Enum.Count);
 
         Assert.All(
             schema.Enum,
-            e =>
+            jsonNode =>
             {
-                var enumString = Assert.IsType<OpenApiString>(e);
-                Assert.Contains(enumString.Value, indicatorUnits);
+                Assert.Contains(jsonNode.GetValue<string>(), indicatorUnits);
             }
         );
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(IndicatorUnit), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/JsonConverterSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/JsonConverterSchemaFilterTests.cs
@@ -7,8 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -20,6 +19,7 @@ public class JsonConverterSchemaFilterTests
         {
             UseAllOfToExtendReferenceSchemas = true,
             SchemaFilters = [new JsonConverterSchemaFilter()],
+            SupportNonNullableReferenceTypes = true,
         },
         new JsonSerializerDataContractResolver(
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
@@ -36,19 +36,17 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestEnumConverters>();
 
         var schemaPropertyName = propertyName.CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
-        Assert.Null(propertySchema.Reference);
+        Assert.NotNull(propertySchema.AllOf);
         Assert.Empty(propertySchema.AllOf);
 
-        Assert.Equal("string", propertySchema.Type);
+        Assert.Equal(JsonSchemaType.String, propertySchema.Type);
+        Assert.NotNull(propertySchema.Enum);
         Assert.Equal(2, propertySchema.Enum.Count);
 
-        var enumString1 = Assert.IsType<OpenApiString>(propertySchema.Enum[0]);
-        Assert.Equal(nameof(TestEnum.Sample1), enumString1.Value);
-
-        var enumString2 = Assert.IsType<OpenApiString>(propertySchema.Enum[1]);
-        Assert.Equal(nameof(TestEnum.Sample2), enumString2.Value);
+        Assert.Equal(nameof(TestEnum.Sample1), propertySchema.Enum[0].GetValue<string>());
+        Assert.Equal(nameof(TestEnum.Sample2), propertySchema.Enum[1].GetValue<string>());
     }
 
     [Fact]
@@ -57,19 +55,17 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestEnumConverters>();
 
         var schemaPropertyName = nameof(TestEnumConverters.EnumToEnumLabel).CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
-        Assert.Null(propertySchema.Reference);
+        Assert.NotNull(propertySchema.AllOf);
         Assert.Empty(propertySchema.AllOf);
 
-        Assert.Equal("string", propertySchema.Type);
+        Assert.Equal(JsonSchemaType.String, propertySchema.Type);
+        Assert.NotNull(propertySchema.Enum);
         Assert.Equal(2, propertySchema.Enum.Count);
 
-        var enumString1 = Assert.IsType<OpenApiString>(propertySchema.Enum[0]);
-        Assert.Equal(TestEnum.Sample1.GetEnumLabel(), enumString1.Value);
-
-        var enumString2 = Assert.IsType<OpenApiString>(propertySchema.Enum[1]);
-        Assert.Equal(TestEnum.Sample2.GetEnumLabel(), enumString2.Value);
+        Assert.Equal(TestEnum.Sample1.GetEnumLabel(), propertySchema.Enum[0].GetValue<string>());
+        Assert.Equal(TestEnum.Sample2.GetEnumLabel(), propertySchema.Enum[1].GetValue<string>());
     }
 
     [Fact]
@@ -78,19 +74,17 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestEnumConverters>();
 
         var schemaPropertyName = nameof(TestEnumConverters.EnumToEnumValue).CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
-        Assert.Null(propertySchema.Reference);
+        Assert.NotNull(propertySchema.AllOf);
         Assert.Empty(propertySchema.AllOf);
 
-        Assert.Equal("string", propertySchema.Type);
+        Assert.Equal(JsonSchemaType.String, propertySchema.Type);
+        Assert.NotNull(propertySchema.Enum);
         Assert.Equal(2, propertySchema.Enum.Count);
 
-        var enumString1 = Assert.IsType<OpenApiString>(propertySchema.Enum[0]);
-        Assert.Equal(TestEnum.Sample1.GetEnumValue(), enumString1.Value);
-
-        var enumString2 = Assert.IsType<OpenApiString>(propertySchema.Enum[1]);
-        Assert.Equal(TestEnum.Sample2.GetEnumValue(), enumString2.Value);
+        Assert.Equal(TestEnum.Sample1.GetEnumValue(), propertySchema.Enum[0].GetValue<string>());
+        Assert.Equal(TestEnum.Sample2.GetEnumValue(), propertySchema.Enum[1].GetValue<string>());
     }
 
     [Fact]
@@ -99,18 +93,18 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestReadOnlyListEnumConverters>();
 
         var schemaPropertyName = nameof(TestReadOnlyListEnumConverters.GeographicLevelEnumLabels).CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
-        Assert.Null(propertySchema.Reference);
-        Assert.Empty(propertySchema.AllOf);
+        Assert.Null(propertySchema.AllOf);
 
-        Assert.Equal("array", propertySchema.Type);
+        Assert.Equal(JsonSchemaType.Array, propertySchema.Type);
 
-        Assert.Null(propertySchema.Items.Reference);
-        Assert.Empty(propertySchema.Items.AllOf);
+        Assert.NotNull(propertySchema.Items);
+        var items = Assert.IsType<OpenApiSchema>(propertySchema.Items);
 
-        var enumStrings = propertySchema.Items.Enum.Cast<OpenApiString>().Select(e => e.Value).ToList();
+        Assert.Null(items.AllOf);
 
+        var enumStrings = GetSchemaEnumValues<string>(items);
         Assert.Equal(EnumUtil.GetEnumLabels<GeographicLevel>(), enumStrings);
     }
 
@@ -120,18 +114,18 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestReadOnlyListEnumConverters>();
 
         var schemaPropertyName = nameof(TestReadOnlyListEnumConverters.GeographicLevelEnumValues).CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
-        Assert.Null(propertySchema.Reference);
-        Assert.Empty(propertySchema.AllOf);
+        Assert.Null(propertySchema.AllOf);
 
-        Assert.Equal("array", propertySchema.Type);
+        Assert.Equal(JsonSchemaType.Array, propertySchema.Type);
 
-        Assert.Null(propertySchema.Items.Reference);
-        Assert.Empty(propertySchema.Items.AllOf);
+        Assert.NotNull(propertySchema.Items);
+        var items = Assert.IsType<OpenApiSchema>(propertySchema.Items);
 
-        var enumStrings = propertySchema.Items.Enum.Cast<OpenApiString>().Select(e => e.Value).ToList();
+        Assert.Null(items.AllOf);
 
+        var enumStrings = GetSchemaEnumValues<string>(items);
         Assert.Equal(EnumUtil.GetEnumValues<GeographicLevel>(), enumStrings);
     }
 
@@ -145,12 +139,13 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestIgnoredGeographicLevelConverters>();
 
         var schemaPropertyName = propertyName.CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
+        Assert.NotNull(propertySchema.AllOf);
         Assert.NotEmpty(propertySchema.AllOf);
 
         Assert.Null(propertySchema.Type);
-        Assert.Empty(propertySchema.Enum);
+        Assert.Null(propertySchema.Enum);
     }
 
     [Theory]
@@ -163,12 +158,13 @@ public class JsonConverterSchemaFilterTests
         var schema = GenerateSchema<TestIgnoredIndicatorUnitConverters>();
 
         var schemaPropertyName = propertyName.CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
+        Assert.NotNull(propertySchema.AllOf);
         Assert.NotEmpty(propertySchema.AllOf);
 
         Assert.Null(propertySchema.Type);
-        Assert.Empty(propertySchema.Enum);
+        Assert.Null(propertySchema.Enum);
     }
 
     [Theory]
@@ -178,18 +174,19 @@ public class JsonConverterSchemaFilterTests
     [InlineData(nameof(TestIgnoredTimeIdentifierConverters.EnumToEnumValue))]
     public void TimeIdentifier_Ignored(string propertyName)
     {
-        var schema = GenerateSchema<TestIgnoredGeographicLevelConverters>();
+        var schema = GenerateSchema<TestIgnoredTimeIdentifierConverters>();
 
         var schemaPropertyName = propertyName.CamelCase();
-        var propertySchema = schema.Properties[schemaPropertyName];
+        var propertySchema = GetPropertySchema(schema, schemaPropertyName);
 
+        Assert.NotNull(propertySchema.AllOf);
         Assert.NotEmpty(propertySchema.AllOf);
 
         Assert.Null(propertySchema.Type);
-        Assert.Empty(propertySchema.Enum);
+        Assert.Null(propertySchema.Enum);
     }
 
-    private OpenApiSchema GenerateSchema<TConverters>()
+    private IOpenApiSchema GenerateSchema<TConverters>()
     {
         _schemaGenerator.GenerateSchema(typeof(TestEnum), _schemaRepository);
         _schemaGenerator.GenerateSchema(typeof(TConverters), _schemaRepository);
@@ -197,6 +194,21 @@ public class JsonConverterSchemaFilterTests
         return _schemaRepository.Schemas[typeof(TConverters).Name];
     }
 
+    private static IOpenApiSchema GetPropertySchema(IOpenApiSchema schema, string name)
+    {
+        Assert.NotNull(schema.Properties);
+        Assert.True(schema.Properties.TryGetValue(name, out var property), $"Schema has no property '{name}'.");
+        return property;
+    }
+
+    private static IReadOnlyList<T> GetSchemaEnumValues<T>(IOpenApiSchema? schema)
+    {
+        Assert.NotNull(schema);
+        Assert.NotNull(schema.Enum);
+        return [.. schema.Enum.Select(e => e.GetValue<T>())];
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class TestEnumConverters
     {
         [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -212,6 +224,7 @@ public class JsonConverterSchemaFilterTests
         public TestEnum EnumToEnumValue { get; init; }
     }
 
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class TestIgnoredGeographicLevelConverters
     {
         [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -227,6 +240,7 @@ public class JsonConverterSchemaFilterTests
         public GeographicLevel EnumToEnumValue { get; init; }
     }
 
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class TestIgnoredIndicatorUnitConverters
     {
         [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -242,6 +256,7 @@ public class JsonConverterSchemaFilterTests
         public IndicatorUnit EnumToEnumValue { get; init; }
     }
 
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class TestIgnoredTimeIdentifierConverters
     {
         [JsonConverter(typeof(JsonStringEnumConverter))]
@@ -257,6 +272,7 @@ public class JsonConverterSchemaFilterTests
         public TimeIdentifier EnumToEnumValue { get; init; }
     }
 
+    // ReSharper disable once ClassNeverInstantiated.Local
     private class TestReadOnlyListEnumConverters
     {
         [JsonConverter(
@@ -270,6 +286,7 @@ public class JsonConverterSchemaFilterTests
         public IReadOnlyList<GeographicLevel> GeographicLevelEnumValues { get; init; } = [];
     }
 
+    // ReSharper disable once ClassNeverInstantiated.Local
     private enum TestEnum
     {
         [EnumLabelValue("Sample 1", "sample-1")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/RequiredPropertySchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/RequiredPropertySchemaFilterTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -29,7 +29,9 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassAllRequired>();
 
+        Assert.NotNull(schema.Required);
         Assert.Equal(3, schema.Required.Count);
+
         Assert.Contains(nameof(TestClassAllRequired.FirstName).ToLowerFirst(), schema.Required);
         Assert.Contains(nameof(TestClassAllRequired.LastName).ToLowerFirst(), schema.Required);
         Assert.Contains(nameof(TestClassAllRequired.Age).ToLowerFirst(), schema.Required);
@@ -40,7 +42,9 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassSomeRequired>();
 
+        Assert.NotNull(schema.Required);
         Assert.Single(schema.Required);
+
         Assert.Contains(nameof(TestClassSomeRequired.FirstName).ToLowerFirst(), schema.Required);
     }
 
@@ -49,7 +53,9 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassReferenceTypes>();
 
+        Assert.NotNull(schema.Required);
         Assert.Equal(2, schema.Required.Count);
+
         Assert.Contains(nameof(TestClassReferenceTypes.RequiredNonNullable).ToLowerFirst(), schema.Required);
         Assert.Contains(nameof(TestClassReferenceTypes.RequiredNullable).ToLowerFirst(), schema.Required);
     }
@@ -59,8 +65,12 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassReferenceTypes>();
 
-        Assert.True(schema.Properties[nameof(TestClassReferenceTypes.RequiredNullable).ToLowerFirst()].Nullable);
-        Assert.False(schema.Properties[nameof(TestClassReferenceTypes.RequiredNonNullable).ToLowerFirst()].Nullable);
+        Assert.NotNull(schema.Properties);
+        Assert.Equal(
+            JsonSchemaType.Null,
+            schema.Properties[nameof(TestClassReferenceTypes.RequiredNullable).ToLowerFirst()].Type
+        );
+        Assert.Null(schema.Properties[nameof(TestClassReferenceTypes.RequiredNonNullable).ToLowerFirst()].Type);
     }
 
     [Fact]
@@ -68,6 +78,7 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassJsonIgnored>();
 
+        Assert.NotNull(schema.Required);
         Assert.Empty(schema.Required);
     }
 
@@ -76,13 +87,14 @@ public class RequiredPropertySchemaFilterTests
     {
         var schema = GenerateSchema<TestClassJsonPropertyName>();
 
+        Assert.NotNull(schema.Required);
         Assert.Equal(2, schema.Required.Count);
 
         Assert.Contains("GivenName", schema.Required);
         Assert.Contains("AgeYears", schema.Required);
     }
 
-    private OpenApiSchema GenerateSchema<T>()
+    private IOpenApiSchema GenerateSchema<T>()
     {
         _schemaGenerator.GenerateSchema(typeof(T), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/SwaggerEnumSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/SwaggerEnumSchemaFilterTests.cs
@@ -5,8 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -26,9 +25,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var allOf = Assert.Single(schema.Properties[nameof(TestClass.Ref)].AllOf);
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.Ref));
+        var allOfRef = GetAllOfSchemaReference(propertySchema);
 
-        Assert.Equal(nameof(TestEnum), allOf.Reference.Id);
+        Assert.Equal(nameof(TestEnum), allOfRef.Reference.Id);
     }
 
     [Fact]
@@ -47,7 +47,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        Assert.Equal(nameof(TestEnum), schema.Properties[nameof(TestClass.RefList)].Items.Reference.Id);
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.RefList));
+        var itemsRef = GetItemsSchemaReference(propertySchema);
+
+        Assert.Equal(nameof(TestEnum), itemsRef.Reference.Id);
     }
 
     [Fact]
@@ -55,11 +58,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.String)].Enum.Cast<OpenApiString>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.String));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal(TestEnum.Sample1.ToString(), enums[0].Value);
-        Assert.Equal(TestEnum.Sample2.ToString(), enums[1].Value);
+        Assert.Equal([nameof(TestEnum.Sample1), nameof(TestEnum.Sample2)], stringValues);
     }
 
     [Fact]
@@ -78,11 +80,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.StringList)].Items.Enum.Cast<OpenApiString>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.StringList));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema.Items);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal(TestEnum.Sample1.ToString(), enums[0].Value);
-        Assert.Equal(TestEnum.Sample2.ToString(), enums[1].Value);
+        Assert.Equal([nameof(TestEnum.Sample1), nameof(TestEnum.Sample2)], stringValues);
     }
 
     [Fact]
@@ -90,11 +91,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.Int)].Enum.Cast<OpenApiInteger>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.Int));
+        var intValues = GetSchemaEnumValues<int>(propertySchema);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal((int)TestEnum.Sample1, enums[0].Value);
-        Assert.Equal((int)TestEnum.Sample2, enums[1].Value);
+        Assert.Equal([(int)TestEnum.Sample1, (int)TestEnum.Sample2], intValues);
     }
 
     [Fact]
@@ -102,11 +102,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.EnumLabel)].Enum.Cast<OpenApiString>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.EnumLabel));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal(TestEnum.Sample1.GetEnumLabel(), enums[0].Value);
-        Assert.Equal(TestEnum.Sample2.GetEnumLabel(), enums[1].Value);
+        Assert.Equal([TestEnum.Sample1.GetEnumLabel(), TestEnum.Sample2.GetEnumLabel()], stringValues);
     }
 
     [Fact]
@@ -114,11 +113,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.EnumValue)].Enum.Cast<OpenApiString>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.EnumValue));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal(TestEnum.Sample1.GetEnumValue(), enums[0].Value);
-        Assert.Equal(TestEnum.Sample2.GetEnumValue(), enums[1].Value);
+        Assert.Equal([TestEnum.Sample1.GetEnumValue(), TestEnum.Sample2.GetEnumValue()], stringValues);
     }
 
     [Fact]
@@ -126,11 +124,10 @@ public class SwaggerEnumSchemaFilterTests
     {
         var schema = GenerateSchema();
 
-        var enums = schema.Properties[nameof(TestClass.Schema)].Enum.Cast<OpenApiString>().ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClass.Schema));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema);
 
-        Assert.Equal(2, enums.Count);
-        Assert.Equal(TestEnum.Sample1.ToString(), enums[0].Value);
-        Assert.Equal(TestEnum.Sample2.ToString(), enums[1].Value);
+        Assert.Equal([nameof(TestEnum.Sample1), nameof(TestEnum.Sample2)], stringValues);
     }
 
     [Fact]
@@ -145,15 +142,12 @@ public class SwaggerEnumSchemaFilterTests
 
         var schema = _schemaRepository.Schemas[nameof(TestClassWithGeographicLevel)];
 
-        var enums = schema
-            .Properties[nameof(TestClassWithGeographicLevel.GeographicLevel)]
-            .Enum.Cast<OpenApiString>()
-            .Select(e => e.Value)
-            .ToList();
+        var propertySchema = GetPropertySchema(schema, nameof(TestClassWithGeographicLevel.GeographicLevel));
+        var stringValues = GetSchemaEnumValues<string>(propertySchema);
 
         var geographicLevels = EnumUtil.GetEnumValues<GeographicLevel>();
 
-        Assert.Equal(enums.Order(), geographicLevels.Order());
+        Assert.Equal(stringValues.Order(), geographicLevels.Order());
     }
 
     [Fact]
@@ -162,7 +156,7 @@ public class SwaggerEnumSchemaFilterTests
         Assert.Throws<InvalidOperationException>(GenerateInvalidSchema);
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         var schemaGenerator = BuildSchemaGenerator();
 
@@ -172,7 +166,7 @@ public class SwaggerEnumSchemaFilterTests
         return _schemaRepository.Schemas[nameof(TestClass)];
     }
 
-    private OpenApiSchema GenerateInvalidSchema()
+    private IOpenApiSchema GenerateInvalidSchema()
     {
         var schemaGenerator = BuildSchemaGenerator();
 
@@ -187,6 +181,34 @@ public class SwaggerEnumSchemaFilterTests
             _schemaGeneratorOptions,
             new JsonSerializerDataContractResolver(new JsonSerializerOptions())
         );
+    }
+
+    private static IOpenApiSchema GetPropertySchema(IOpenApiSchema schema, string name)
+    {
+        Assert.NotNull(schema.Properties);
+        Assert.True(schema.Properties.TryGetValue(name, out var property), $"Schema has no property '{name}'.");
+        return property;
+    }
+
+    private static OpenApiSchemaReference GetAllOfSchemaReference(IOpenApiSchema? schema)
+    {
+        Assert.NotNull(schema);
+        Assert.NotNull(schema.AllOf);
+        return Assert.IsType<OpenApiSchemaReference>(Assert.Single(schema.AllOf));
+    }
+
+    private static OpenApiSchemaReference GetItemsSchemaReference(IOpenApiSchema? schema)
+    {
+        Assert.NotNull(schema);
+        Assert.NotNull(schema.Items);
+        return Assert.IsType<OpenApiSchemaReference>(schema.Items);
+    }
+
+    private static IReadOnlyList<T> GetSchemaEnumValues<T>(IOpenApiSchema? schema)
+    {
+        Assert.NotNull(schema);
+        Assert.NotNull(schema.Enum);
+        return [.. schema.Enum.Select(e => e.GetValue<T>())];
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter<TestEnum>))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/TimeIdentifierSchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/TimeIdentifierSchemaFilterTests.cs
@@ -2,15 +2,14 @@ using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
 
 public class TimeIdentifierSchemaFilterTests
 {
-    private readonly ISchemaGenerator _schemaGenerator = new SchemaGenerator(
+    private readonly SchemaGenerator _schemaGenerator = new(
         new SchemaGeneratorOptions
         {
             UseAllOfToExtendReferenceSchemas = true,
@@ -30,20 +29,20 @@ public class TimeIdentifierSchemaFilterTests
 
         var codes = TimeIdentifierUtils.Codes.ToHashSet();
 
-        Assert.Equal("string", schema.Type);
+        Assert.Equal(JsonSchemaType.String, schema.Type);
+        Assert.NotNull(schema.Enum);
         Assert.Equal(codes.Count, schema.Enum.Count);
 
         Assert.All(
             schema.Enum,
-            e =>
+            jsonNode =>
             {
-                var enumString = Assert.IsType<OpenApiString>(e);
-                Assert.Contains(enumString.Value, codes);
+                Assert.Contains(jsonNode.GetValue<string>(), codes);
             }
         );
     }
 
-    private OpenApiSchema GenerateSchema()
+    private IOpenApiSchema GenerateSchema()
     {
         _schemaGenerator.GenerateSchema(typeof(TimeIdentifier), _schemaRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/VersionedPathsDocumentFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/VersionedPathsDocumentFilterTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
@@ -43,12 +43,9 @@ public class VersionedPathsDocumentFilterTests
                     new OpenApiPathItem
                     {
                         Parameters = [new OpenApiParameter { Name = "version" }],
-                        Operations =
+                        Operations = new Dictionary<HttpMethod, OpenApiOperation>
                         {
-                            {
-                                OperationType.Get,
-                                new OpenApiOperation { Parameters = [new OpenApiParameter { Name = "version" }] }
-                            },
+                            [HttpMethod.Get] = new() { Parameters = [new OpenApiParameter { Name = "version" }] },
                         },
                     }
                 },
@@ -57,18 +54,15 @@ public class VersionedPathsDocumentFilterTests
                     new OpenApiPathItem
                     {
                         Parameters = [new OpenApiParameter { Name = "version" }, new OpenApiParameter { Name = "id" }],
-                        Operations =
+                        Operations = new Dictionary<HttpMethod, OpenApiOperation>
                         {
+                            [HttpMethod.Get] = new()
                             {
-                                OperationType.Get,
-                                new OpenApiOperation
-                                {
-                                    Parameters =
-                                    [
-                                        new OpenApiParameter { Name = "version" },
-                                        new OpenApiParameter { Name = "id" },
-                                    ],
-                                }
+                                Parameters =
+                                [
+                                    new OpenApiParameter { Name = "version" },
+                                    new OpenApiParameter { Name = "id" },
+                                ],
                             },
                         },
                     }
@@ -85,16 +79,25 @@ public class VersionedPathsDocumentFilterTests
 
         var endpoint1Paths = document.Paths["/v1/endpoint-1"];
 
+        Assert.NotNull(endpoint1Paths.Parameters);
         Assert.Empty(endpoint1Paths.Parameters);
-        Assert.Empty(endpoint1Paths.Operations[OperationType.Get].Parameters);
+
+        Assert.NotNull(endpoint1Paths.Operations);
+        var endpoint1GetOperationParameters = endpoint1Paths.Operations[HttpMethod.Get].Parameters;
+        Assert.NotNull(endpoint1GetOperationParameters);
+        Assert.Empty(endpoint1GetOperationParameters);
 
         var endpoint2Paths = document.Paths["/v1/endpoint-2/{id}"];
 
+        Assert.NotNull(endpoint2Paths.Parameters);
         Assert.Single(endpoint2Paths.Parameters);
         Assert.Equal("id", endpoint2Paths.Parameters[0].Name);
 
-        Assert.Single(endpoint2Paths.Operations[OperationType.Get].Parameters);
-        Assert.Equal("id", endpoint2Paths.Parameters[0].Name);
+        Assert.NotNull(endpoint2Paths.Operations);
+        var endpoint2GetOperationParameters = endpoint2Paths.Operations[HttpMethod.Get].Parameters;
+        Assert.NotNull(endpoint2GetOperationParameters);
+        Assert.Single(endpoint2GetOperationParameters);
+        Assert.Equal("id", endpoint2GetOperationParameters[0].Name);
     }
 
     private static DocumentFilterContext CreateDocumentFilterContext()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/JsonSchemaTypeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/JsonSchemaTypeExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;
+
+public static class JsonSchemaTypeExtensions
+{
+    /// <summary>
+    /// Returns the type with the specified flag cleared.
+    /// </summary>
+    /// <param name="type">The <see cref="JsonSchemaType"/> to modify.</param>
+    /// <param name="flags">The <see cref="JsonSchemaType"/> flags to clear.</param>
+    /// <returns>The <see cref="JsonSchemaType"/> with the specified flags cleared.</returns>
+    [return: NotNullIfNotNull(nameof(type))]
+    public static JsonSchemaType? WithoutFlags(this JsonSchemaType? type, JsonSchemaType flags) => type & ~flags;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetStatusSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetStatusSchemaFilter.cs
@@ -1,7 +1,7 @@
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
@@ -15,17 +15,21 @@ public class DataSetStatusSchemaFilter : ISchemaFilter
         DataSetStatus.Withdrawn,
     ];
 
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo == null && context.Type == typeof(DataSetStatus))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(DataSetStatus)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            schema.Type = "string";
+            openApiSchema.Type = JsonSchemaType.String;
 
-            schema.Enum = EnumUtil
+            openApiSchema.Enum = EnumUtil
                 .GetEnums<DataSetStatus>()
                 .Where(_publicStatuses.Contains)
-                .Select(e => new OpenApiString(e.ToString()))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (dataSetStatus) => JsonValue.Create(dataSetStatus.ToString()))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetVersionStatusSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DataSetVersionStatusSchemaFilter.cs
@@ -1,7 +1,7 @@
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
@@ -15,17 +15,21 @@ public class DataSetVersionStatusSchemaFilter : ISchemaFilter
         DataSetVersionStatus.Withdrawn,
     ];
 
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo == null && context.Type == typeof(DataSetVersionStatus))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(DataSetVersionStatus)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            schema.Type = "string";
+            openApiSchema.Type = JsonSchemaType.String;
 
-            schema.Enum = EnumUtil
+            openApiSchema.Enum = EnumUtil
                 .GetEnums<DataSetVersionStatus>()
                 .Where(_publicStatuses.Contains)
-                .Select(e => new OpenApiString(e.ToString()))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (dataSetVersionStatus) => JsonValue.Create(dataSetVersionStatus.ToString()))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DefaultValuesOperationFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/DefaultValuesOperationFilter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
@@ -40,13 +41,20 @@ internal class DefaultValuesOperationFilter : IOperationFilter
 
             parameter.Description ??= description.ModelMetadata?.Description;
 
-            if (parameter.Schema.Default == null && description.DefaultValue != null)
+            if (
+                parameter.Schema is OpenApiSchema openApiSchema
+                && openApiSchema.Default == null
+                && description.DefaultValue != null
+            )
             {
                 var json = JsonSerializer.Serialize(description.DefaultValue, description.ModelMetadata!.ModelType);
-                parameter.Schema.Default = OpenApiAnyFactory.CreateFromJson(json);
+                openApiSchema.Default = JsonNode.Parse(json);
             }
 
-            parameter.Required |= description.IsRequired;
+            if (parameter is OpenApiParameter openApiParameter)
+            {
+                openApiParameter.Required |= description.IsRequired;
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/ErrorViewModelSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/ErrorViewModelSchemaFilter.cs
@@ -1,25 +1,37 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
-using Microsoft.OpenApi.Models;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class ErrorViewModelSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo is not null || context.Type != typeof(ErrorViewModel))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(ErrorViewModel)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            return;
+            if (
+                openApiSchema.Properties?.TryGetValue(
+                    nameof(ErrorViewModel.Code).ToLowerFirst(),
+                    out var codePropertySchema
+                ) == true
+                && codePropertySchema is OpenApiSchema openApiCodePropertySchema
+            )
+            {
+                openApiCodePropertySchema.Type = openApiCodePropertySchema.Type.WithoutFlags(JsonSchemaType.Null);
+            }
+
+            openApiSchema.Required = new HashSet<string>
+            {
+                nameof(ErrorViewModel.Code).ToLowerFirst(),
+                nameof(ErrorViewModel.Message).ToLowerFirst(),
+            };
         }
-
-        schema.Properties[nameof(ErrorViewModel.Code).ToLowerFirst()].Nullable = false;
-
-        schema.Required = new HashSet<string>
-        {
-            nameof(ErrorViewModel.Code).ToLowerFirst(),
-            nameof(ErrorViewModel.Message).ToLowerFirst(),
-        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeneralResponseOperationFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeneralResponseOperationFilter.cs
@@ -1,4 +1,4 @@
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeographicLevelSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/GeographicLevelSchemaFilter.cs
@@ -1,21 +1,25 @@
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class GeographicLevelSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo == null && context.Type == typeof(GeographicLevel))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(GeographicLevel)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            schema.Type = "string";
-            schema.Format = null;
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Format = null;
 
-            schema.Description = """
+            openApiSchema.Description = """
                 The code for a geographic level that locations are grouped by.
 
                 The allowed values are:
@@ -41,11 +45,11 @@ public class GeographicLevelSchemaFilter : ISchemaFilter
                 - `PFA` - Police Force Area
                 """;
 
-            schema.Example = new OpenApiString("NAT");
+            openApiSchema.Example = JsonValue.Create("NAT");
 
-            schema.Enum = GeographicLevelUtils
-                .OrderedCodes.Select(code => new OpenApiString(code))
-                .ToList<IOpenApiAny>();
+            openApiSchema.Enum = GeographicLevelUtils
+                .OrderedCodes.Select(JsonNode (code) => JsonValue.Create(code))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/IndicatorUnitSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/IndicatorUnitSchemaFilter.cs
@@ -1,19 +1,23 @@
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class IndicatorUnitSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo == null && context.Type == typeof(IndicatorUnit))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(IndicatorUnit)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            schema.Type = "string";
-            schema.Description = """
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Description = """
                 The recommended unit to format an indicator with.
 
                 The allowed values are:
@@ -26,12 +30,12 @@ public class IndicatorUnitSchemaFilter : ISchemaFilter
                 - `string` - String with no units and no numeric formatting e.g. `123500600`
                 """;
 
-            schema.Example = new OpenApiString("%");
+            openApiSchema.Example = JsonValue.Create("%");
 
-            schema.Enum = EnumUtil
+            openApiSchema.Enum = EnumUtil
                 .GetEnumLabels<IndicatorUnit>()
-                .Select(unit => new OpenApiString(unit))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (unit) => JsonValue.Create(unit))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/JsonConverterSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/JsonConverterSchemaFilter.cs
@@ -1,11 +1,11 @@
 using System.Reflection;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters.SystemJson;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
@@ -26,7 +26,7 @@ internal class JsonConverterSchemaFilter : ISchemaFilter
         typeof(TimeIdentifier),
     ];
 
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
         if (context.Type is { IsClass: false })
         {
@@ -53,7 +53,10 @@ internal class JsonConverterSchemaFilter : ISchemaFilter
                 continue;
             }
 
-            if (!schema.Properties.TryGetValue(property.Name.CamelCase(), out var propertySchema))
+            if (
+                schema.Properties is null
+                || !schema.Properties.TryGetValue(property.Name.CamelCase(), out var propertySchema)
+            )
             {
                 continue;
             }
@@ -84,11 +87,16 @@ internal class JsonConverterSchemaFilter : ISchemaFilter
 
     private void ApplyEnumConverter(
         Type enumType,
-        OpenApiSchema propertySchema,
+        IOpenApiSchema propertySchema,
         Type converterType,
         SchemaRepository schemaRepository
     )
     {
+        if (propertySchema is not OpenApiSchema openApiSchema)
+        {
+            return;
+        }
+
         var hasEnumConverter = false;
 
         var converterBaseType = converterType.IsGenericType ? converterType.GetGenericTypeDefinition() : converterType;
@@ -100,52 +108,57 @@ internal class JsonConverterSchemaFilter : ISchemaFilter
         {
             hasEnumConverter = true;
 
-            propertySchema.Type = "string";
-            propertySchema.Enum = Enum.GetNames(enumType).Select(name => new OpenApiString(name)).ToList<IOpenApiAny>();
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Enum = Enum.GetNames(enumType).Select(JsonNode (name) => JsonValue.Create(name)).ToList();
         }
         else if (converterBaseType == typeof(EnumToEnumLabelJsonConverter<>))
         {
             hasEnumConverter = true;
 
-            propertySchema.Type = "string";
-            propertySchema.Enum = Enum.GetValues(enumType)
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Enum = Enum.GetValues(enumType)
                 .Cast<Enum>()
-                .Select(name => new OpenApiString(name.GetEnumLabel()))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (name) => JsonValue.Create(name.GetEnumLabel()))
+                .ToList();
         }
         else if (converterBaseType == typeof(EnumToEnumValueJsonConverter<>))
         {
             hasEnumConverter = true;
 
-            propertySchema.Type = "string";
-            propertySchema.Enum = Enum.GetValues(enumType)
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Enum = Enum.GetValues(enumType)
                 .Cast<Enum>()
-                .Select(name => new OpenApiString(name.GetEnumValue()))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (name) => JsonValue.Create(name.GetEnumValue()))
+                .ToList();
         }
 
-        if (hasEnumConverter && schemaRepository.TryLookupByType(enumType, out var enumSchema))
+        if (hasEnumConverter && schemaRepository.TryLookupByType(enumType, out var enumSchemaRef))
         {
             // Clear any references to the enum schema as this would get merged together
             // with the property in the final document and produce incorrect enum values.
-
-            if (propertySchema.Reference is not null && propertySchema.Reference.Id == enumSchema.Reference.Id)
+            if (openApiSchema.AllOf is not null)
             {
-                propertySchema.Reference = null;
+                openApiSchema.AllOf = openApiSchema
+                    .AllOf.Where(s =>
+                        s is not OpenApiSchemaReference openApiSchemaReference
+                        || openApiSchemaReference.Reference.Id != enumSchemaRef.Reference.Id
+                    )
+                    .ToList();
             }
-
-            propertySchema.AllOf = propertySchema
-                .AllOf.Where(s => s.Reference is null || s.Reference.Id != enumSchema.Reference.Id)
-                .ToList();
         }
     }
 
     private void ApplyReadOnlyListEnumConverter(
-        OpenApiSchema propertySchema,
+        IOpenApiSchema propertySchema,
         Type converterType,
         SchemaRepository schemaRepository
     )
     {
+        if (propertySchema is not OpenApiSchema openApiSchema)
+        {
+            return;
+        }
+
         if (converterType.GetGenericTypeDefinition() != typeof(ReadOnlyListJsonConverter<,>))
         {
             return;
@@ -158,6 +171,14 @@ internal class JsonConverterSchemaFilter : ISchemaFilter
             return;
         }
 
-        ApplyEnumConverter(enumType, propertySchema.Items, converterType.GenericTypeArguments[1], schemaRepository);
+        if (openApiSchema.Items is not null)
+        {
+            // Items may be a $ref to the enum's shared component schema. Replace it
+            // with a new inline schema so ApplyEnumConverter can set Type and Enum on it
+            // without mutating the shared component schema used elsewhere in the document.
+            var itemsSchema = new OpenApiSchema();
+            openApiSchema.Items = itemsSchema;
+            ApplyEnumConverter(enumType, itemsSchema, converterType.GenericTypeArguments[1], schemaRepository);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/RequiredPropertySchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/RequiredPropertySchemaFilter.cs
@@ -1,15 +1,20 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class RequiredPropertySchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
+        if (schema is not OpenApiSchema openApiSchema)
+        {
+            return;
+        }
+
         var nullabilityContext = new NullabilityInfoContext();
         var properties = context.Type.GetProperties();
 
@@ -22,7 +27,7 @@ public class RequiredPropertySchemaFilter : ISchemaFilter
 
             var jsonName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
 
-            var jsonKey = schema.Properties.Keys.SingleOrDefault(key =>
+            var jsonKey = openApiSchema.Properties?.Keys.SingleOrDefault(key =>
                 string.Equals(key, jsonName, StringComparison.OrdinalIgnoreCase)
             );
 
@@ -31,7 +36,7 @@ public class RequiredPropertySchemaFilter : ISchemaFilter
                 continue;
             }
 
-            var isReferenceType = schema.Properties[jsonKey].Type == null;
+            var isReferenceType = openApiSchema.Properties![jsonKey].Type == null;
 
             if (isReferenceType)
             {
@@ -48,7 +53,8 @@ public class RequiredPropertySchemaFilter : ISchemaFilter
                 }
             }
 
-            schema.Required.Add(jsonKey);
+            openApiSchema.Required ??= new HashSet<string>();
+            openApiSchema.Required.Add(jsonKey);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -4,7 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerEnumSchemaFilter.cs
@@ -1,16 +1,21 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class SwaggerEnumSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
+        if (schema is not OpenApiSchema openApiSchema)
+        {
+            return;
+        }
+
         var enumAttribute = context.MemberInfo?.GetCustomAttribute<SwaggerEnumAttribute>();
 
         if (enumAttribute is null)
@@ -23,14 +28,15 @@ public class SwaggerEnumSchemaFilter : ISchemaFilter
             throw new InvalidOperationException($"Must use an enum type for '{nameof(SwaggerEnumAttribute)}'");
         }
 
-        var schemaType = schema.Type == "array" ? schema.Items.Type : schema.Type;
+        var isArray = openApiSchema.Type.HasValue && openApiSchema.Type.Value.HasFlag(JsonSchemaType.Array);
+        var schemaType = isArray ? openApiSchema.Items?.Type : openApiSchema.Type;
 
         if (
             enumAttribute.Serializer is SwaggerEnumSerializer.Ref
             && TryGetEnumSchema(context, enumAttribute, out var enumSchema)
         )
         {
-            if (enumSchema.Type != schemaType)
+            if (enumSchema.Type.HasValue && schemaType.HasValue && !schemaType.Value.HasFlag(enumSchema.Type.Value))
             {
                 throw new InvalidOperationException(
                     $"Enum schema '{enumAttribute.Type.Name}' type must be {schemaType}, but was {enumSchema.Type}."
@@ -39,15 +45,14 @@ public class SwaggerEnumSchemaFilter : ISchemaFilter
 
             var enumSchemaId = GetEnumSchemaId(context, enumAttribute);
 
-            var enumRef = new OpenApiReference { Type = ReferenceType.Schema, Id = enumSchemaId };
-
-            if (schema.Type == "array")
+            if (isArray)
             {
-                schema.Items.Reference = enumRef;
+                openApiSchema.Items = new OpenApiSchemaReference(enumSchemaId);
             }
             else
             {
-                schema.AllOf.Add(new OpenApiSchema { Reference = enumRef });
+                openApiSchema.AllOf ??= new List<IOpenApiSchema>();
+                openApiSchema.AllOf.Add(new OpenApiSchemaReference(enumSchemaId));
             }
 
             return;
@@ -62,39 +67,42 @@ public class SwaggerEnumSchemaFilter : ISchemaFilter
 
         var enums = GetOpenApiEnums(context, enumAttribute);
 
-        if (schema.Type == "array")
+        if (isArray)
         {
-            schema.Items.Enum = enums;
+            if (openApiSchema.Items is OpenApiSchema itemsSchema)
+            {
+                itemsSchema.Enum = enums;
+            }
         }
         else
         {
-            schema.Enum = enums;
+            openApiSchema.Enum = enums;
         }
     }
 
-    private static bool IsValidEnumSerializerType(SwaggerEnumAttribute enumAttribute, string schemaType)
+    private static bool IsValidEnumSerializerType(SwaggerEnumAttribute enumAttribute, JsonSchemaType? schemaType)
     {
         return enumAttribute.Serializer switch
         {
-            SwaggerEnumSerializer.Int => schemaType == "integer",
-            _ => schemaType == "string",
+            SwaggerEnumSerializer.Int => schemaType.HasValue && schemaType.Value.HasFlag(JsonSchemaType.Integer),
+            _ => schemaType.HasValue && schemaType.Value.HasFlag(JsonSchemaType.String),
         };
     }
 
-    private static IList<IOpenApiAny> GetOpenApiEnums(SchemaFilterContext context, SwaggerEnumAttribute enumAttribute)
+    private static IList<JsonNode> GetOpenApiEnums(SchemaFilterContext context, SwaggerEnumAttribute enumAttribute)
     {
         if (
             enumAttribute.Serializer is SwaggerEnumSerializer.Schema
             && TryGetEnumSchema(context, enumAttribute, out var enumSchema)
         )
         {
-            return enumSchema.Enum;
+            return enumSchema.Enum ?? [];
         }
 
         return Enum.GetValues(enumAttribute.Type)
             .Cast<Enum>()
             .Select(e => SerializeEnum(e, enumAttribute.Serializer))
-            .ToList<IOpenApiAny>();
+            .ToList();
     }
 
     private static bool TryGetEnumSchema(
@@ -109,7 +117,17 @@ public class SwaggerEnumSchemaFilter : ISchemaFilter
             return false;
         }
 
-        return context.SchemaRepository.Schemas.TryGetValue(refSchema.Reference.Id, out enumSchema);
+        if (
+            context.SchemaRepository.Schemas.TryGetValue(refSchema.Reference.Id ?? string.Empty, out var schema)
+            && schema is OpenApiSchema concreteSchema
+        )
+        {
+            enumSchema = concreteSchema;
+            return true;
+        }
+
+        enumSchema = null;
+        return false;
     }
 
     private static string GetEnumSchemaId(SchemaFilterContext context, SwaggerEnumAttribute enumAttribute)
@@ -119,18 +137,19 @@ public class SwaggerEnumSchemaFilter : ISchemaFilter
             throw new InvalidOperationException($"Could not find enum schema ID for {enumAttribute.Type.Name}");
         }
 
-        return refSchema.Reference.Id;
+        return refSchema.Reference.Id
+            ?? throw new InvalidOperationException($"Could not find enum schema ID for {enumAttribute.Type.Name}");
     }
 
-    private static IOpenApiPrimitive SerializeEnum(Enum @enum, SwaggerEnumSerializer serializer)
+    private static JsonNode SerializeEnum(Enum @enum, SwaggerEnumSerializer serializer)
     {
         return serializer switch
         {
-            SwaggerEnumSerializer.Int => new OpenApiInteger(Convert.ToInt32(@enum)),
-            SwaggerEnumSerializer.String => new OpenApiString(@enum.ToString()),
-            SwaggerEnumSerializer.Value => new OpenApiString(@enum.GetEnumValue()),
-            SwaggerEnumSerializer.Label => new OpenApiString(@enum.GetEnumLabel()),
-            _ => new OpenApiInteger(Convert.ToInt32(@enum)),
+            SwaggerEnumSerializer.Int => JsonValue.Create(Convert.ToInt32(@enum))!,
+            SwaggerEnumSerializer.String => JsonValue.Create(@enum.ToString())!,
+            SwaggerEnumSerializer.Value => JsonValue.Create(@enum.GetEnumValue())!,
+            SwaggerEnumSerializer.Label => JsonValue.Create(@enum.GetEnumLabel())!,
+            _ => JsonValue.Create(Convert.ToInt32(@enum))!,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/TimeIdentifierSchemaFilter.cs
@@ -1,22 +1,26 @@
+using System.Text.Json.Nodes;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class TimeIdentifierSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.MemberInfo == null && context.Type == typeof(TimeIdentifier))
+        if (
+            context.MemberInfo == null
+            && context.Type == typeof(TimeIdentifier)
+            && schema is OpenApiSchema openApiSchema
+        )
         {
-            schema.Type = "string";
-            schema.Format = null;
+            openApiSchema.Type = JsonSchemaType.String;
+            openApiSchema.Format = null;
 
-            schema.Description = """
+            openApiSchema.Description = """
                 The code identifying the time period's type.
 
                 The allowed values are:
@@ -40,12 +44,12 @@ public class TimeIdentifierSchemaFilter : ISchemaFilter
                 - `M1 - M12` - month 1 to 12
                 """;
 
-            schema.Example = new OpenApiString("CY");
+            openApiSchema.Example = JsonValue.Create("CY");
 
-            schema.Enum = TimeIdentifierUtils
+            openApiSchema.Enum = TimeIdentifierUtils
                 .Codes.NaturalOrder()
-                .Select(code => new OpenApiString(code))
-                .ToList<IOpenApiAny>();
+                .Select(JsonNode (code) => JsonValue.Create(code))
+                .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/VersionedPathsDocumentFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/VersionedPathsDocumentFilter.cs
@@ -1,4 +1,4 @@
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
@@ -15,11 +15,18 @@ public class VersionedPathsDocumentFilter : IDocumentFilter
 
             newPaths[versionedPath] = path.Value;
 
-            path.Value.Parameters = path.Value.Parameters.Where(p => p.Name != "version").ToList();
-
-            foreach (var operation in path.Value.Operations.Values)
+            if (path.Value is OpenApiPathItem pathItem)
             {
-                operation.Parameters = operation.Parameters.Where(p => p.Name != "version").ToList();
+                pathItem.Parameters = pathItem.Parameters?.Where(p => p.Name != "version").ToList();
+            }
+
+            var operations = path.Value.Operations?.Values;
+            if (operations != null)
+            {
+                foreach (var operation in operations)
+                {
+                    operation.Parameters = operation.Parameters?.Where(p => p.Name != "version").ToList();
+                }
             }
         }
 

--- a/src/explore-education-statistics-api-docs/source/openapi-v1.json
+++ b/src/explore-education-statistics-api-docs/source/openapi-v1.json
@@ -519,6 +519,7 @@
             "description": "The page of results to fetch.",
             "schema": {
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The page of results to fetch.",
               "format": "int32",
@@ -531,7 +532,9 @@
             "description": "The maximum number of results per page.",
             "schema": {
               "maximum": 10000,
+              "exclusiveMaximum": false,
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The maximum number of results per page.",
               "format": "int32",
@@ -753,6 +756,7 @@
             "description": "The page of results to fetch.",
             "schema": {
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The page of results to fetch.",
               "format": "int32",
@@ -765,7 +769,9 @@
             "description": "The maximum number of results per page.",
             "schema": {
               "maximum": 20,
+              "exclusiveMaximum": false,
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The maximum number of results per page.",
               "format": "int32",
@@ -989,6 +995,7 @@
             "description": "The page of results to fetch.",
             "schema": {
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The page of results to fetch.",
               "format": "int32",
@@ -1001,7 +1008,9 @@
             "description": "The maximum number of results per page.",
             "schema": {
               "maximum": 40,
+              "exclusiveMaximum": false,
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The maximum number of results per page.",
               "format": "int32",
@@ -1098,6 +1107,7 @@
             "description": "The page of results to fetch.",
             "schema": {
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The page of results to fetch.",
               "format": "int32",
@@ -1110,7 +1120,9 @@
             "description": "The maximum number of results per page.",
             "schema": {
               "maximum": 20,
+              "exclusiveMaximum": false,
               "minimum": 1,
+              "exclusiveMinimum": false,
               "type": "integer",
               "description": "The maximum number of results per page.",
               "format": "int32",
@@ -1316,7 +1328,8 @@
             "items": {
               "type": "string"
             },
-            "description": "The indicators available in the data set."
+            "description": "The indicators available in the data set.",
+            "example": "[\"Authorised absence rate\" \"Overall absence rate\"]"
           }
         },
         "additionalProperties": false,
@@ -3069,7 +3082,8 @@
                 "$ref": "#/components/schemas/GeographicLevelViewModel"
               }
             ],
-            "description": "The geographic level of the locations in this group."
+            "description": "The geographic level of the locations in this group.",
+            "example": "NAT"
           },
           "options": {
             "type": "array",
@@ -3111,7 +3125,8 @@
                 "$ref": "#/components/schemas/GeographicLevelViewModel"
               }
             ],
-            "description": "The geographic level of the locations in this group."
+            "description": "The geographic level of the locations in this group.",
+            "example": "NAT"
           }
         },
         "additionalProperties": false,
@@ -3732,5 +3747,16 @@
         "description": "A warning that points to a potential issue. This is not a critical error,\r\nbut may require attention to get the desired response."
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "DataSets"
+    },
+    {
+      "name": "DataSetVersions"
+    },
+    {
+      "name": "Publications"
+    }
+  ]
 }


### PR DESCRIPTION
This PR updates the Public API, Admin, Content API and the Data API projects to use Swashbuckle.AspNetCore v10 which is necessary due to ASP.NET Core 10 depending on a major update to the underlying OpenAPI.NET library v2.0.

This PR blocks and targets #7212 which will fail to build until this is merged into it.

See the [Migrating to Swashbuckle.AspNetCore v10](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/docs/migrating-to-v10.md) guide for more info.

### Other changes

-- Update the Swashbuckle CLI Tool to 10.2.3.
-- Remove the `Swashbuckle.AspNetCore` restriction from `renovate.json`.