### PR TITLE
EES-7395 Public site environment variable changes for Combined Find Stats and Natural Language search pages

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -144,9 +144,6 @@
     },
     "sqlServerPublicNetworkAccess": {
       "value": "Disabled"
-    },
-    "tableToolSearchEndpoint": {
-      "value": "https://s101d01-ees-fa-nlsearch.azurewebsites.net/api/natural_language_search_function"
     }
   }
 }

--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -142,9 +142,6 @@
     "publicAppCompressionDisable": {
       "value": true
     },
-    "datasetsSearchIndexName": {
-      "value": "nl-search-dataset-index"
-    },
     "sqlServerPublicNetworkAccess": {
       "value": "Disabled"
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -733,11 +733,11 @@
         "description": "The name of the Azure AI Search data set index used by the public frontend application"
       }
     },
-    "tableToolSearchEndpoint": {
+    "nlSearchFunctionRoute": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "/api/natural_language_search_function",
       "metadata": {
-        "description": "The endpoint of the Azure Function App used by the table tool search service"
+        "description": "The HTTP route of the Natural Language Search function, relative to the Natural Language Search Function app host."
       }
     },
     "tableToolSearchFunctionsKey": {
@@ -1394,6 +1394,7 @@
     "screenerStorageAccountConnectionStringSecret": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), variables('screenerStorageAccountConnectionStringSecretKey'))]",
     "searchServiceName": "[concat(parameters('subscription'), '-', parameters('environment'), '-srch')]",
     "searchIndexDataReaderRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1407120a-92aa-4202-b7e9-c0e197c71c8f')]",
+    "nlSearchFunctionAppName": "[concat(parameters('subscription'), '-', parameters('environment'), '-fa-nlsearch')]",
     "storageAccountBackupContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1')]",
     "baseAdminAllowedOrigins": [
       "[concat('https://', parameters('adminUri'))]"
@@ -1406,6 +1407,7 @@
     "publicAllowedOrigins": "[union(variables('basePublicAllowedOrigins'), parameters('additionalPublicAllowedOrigins'))]",
     "apiVersions": {
       "afdEndpoint": "2025-06-01",
+      "nlSearchFunctionApp": "2025-03-01",
       "searchService": "2025-05-01"
     },
     "resourceIds": {
@@ -2316,7 +2318,7 @@
         "AZURE_SEARCH_ENDPOINT": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('apiVersions').searchService).endpoint]",
         "AZURE_SEARCH_INDEX": "[parameters('searchIndexName')]",
         "AZURE_DATASETS_SEARCH_INDEX": "[parameters('datasetsSearchIndexName')]",
-        "AZURE_TABLE_TOOL_SEARCH_ENDPOINT": "[parameters('tableToolSearchEndpoint')]",
+        "AZURE_TABLE_TOOL_SEARCH_ENDPOINT": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('nlSearchFunctionAppName')), variables('apiVersions').nlSearchFunctionApp).defaultHostName, parameters('nlSearchFunctionRoute'))]",
         "AZURE_TABLE_TOOL_SEARCH_FUNCTIONS_KEY": "[parameters('tableToolSearchFunctionsKey')]",
         "BASIC_AUTH": "[parameters('publicAppBasicAuth')]",
         "BASIC_AUTH_USERNAME": "[parameters('publicAppBasicAuthUsername')]",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -728,9 +728,9 @@
     },
     "datasetsSearchIndexName": {
       "type": "string",
-      "defaultValue": "",
+      "defaultValue": "nl-search-dataset-index",
       "metadata": {
-        "description": "The name of the Azure AI data set search index used by the public frontend application"
+        "description": "The name of the Azure AI Search data set index used by the public frontend application"
       }
     },
     "tableToolSearchEndpoint": {


### PR DESCRIPTION
This PR makes an infrastructure change to the Public site frontend's environment variables.

It sets values for the following variables for **all** Azure environments. Previously these only had values set in the Dev environment.

- `AZURE_DATASETS_SEARCH_INDEX` - The name of the Azure AI Search data set index used by the public frontend application.
- `AZURE_TABLE_TOOL_SEARCH_ENDPOINT` - The HTTP endpoint of the Natural Language Search function provided by the Natural Language Search Function app.