### PR TITLE
EES-7399 - Add ability to unfinalise an API data set version.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
@@ -11,8 +11,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.WebUtilities;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerIndicatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerIndicatorTests.cs
@@ -716,7 +716,7 @@ static class DataSetVersionMappingControllerIndicatorTestsHelpers
         DataSetVersion nextDataSetVersion = DataFixture
             .DefaultDataSetVersion()
             .WithVersionNumber(major: 1, minor: 1)
-            .WithStatusDraft()
+            .WithStatus(DataSetVersionStatus.Mapping)
             .WithDataSet(dataSet)
             .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -929,6 +929,42 @@ public abstract class DataSetVersionMappingControllerTests(DataSetVersionMapping
             response.AssertNotFound();
         }
 
+        [Theory]
+        [InlineData(DataSetVersionStatus.Draft)]
+        [InlineData(DataSetVersionStatus.Processing)]
+        [InlineData(DataSetVersionStatus.Finalising)]
+        public async Task DataSetVersionNotInMappingStatus_Returns400(DataSetVersionStatus status)
+        {
+            var (initialDataSetVersion, nextDataSetVersion) = await CreateInitialAndNextDataSetVersion(
+                fixture.GetPublicDataDbContext(),
+                fixture.GetContentDbContext()
+            );
+            nextDataSetVersion.Status = status;
+
+            var mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(initialDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .Generate();
+
+            await fixture
+                .GetPublicDataDbContext()
+                .AddTestData(context =>
+                {
+                    context.DataSetVersions.Update(nextDataSetVersion);
+                    context.DataSetVersionMappings.Add(mapping);
+                });
+
+            var response = await ApplyBatchLocationMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: []
+            );
+
+            response
+                .AssertValidationProblem()
+                .AssertHasError("nextDataSetVersionId", ValidationMessages.DataSetVersionMappingCannotBeUpdated.Code);
+        }
+
         [Fact]
         public async Task EmptyRequiredFields_Return400()
         {
@@ -2234,7 +2270,7 @@ static class DataSetVersionMappingControllerTestsHelpers
         DataSetVersion nextDataSetVersion = DataFixture
             .DefaultDataSetVersion()
             .WithVersionNumber(major: 1, minor: 1)
-            .WithStatusDraft()
+            .WithStatus(DataSetVersionStatus.Mapping)
             .WithDataSet(dataSet)
             .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -943,6 +943,91 @@ public abstract class DataSetVersionsControllerTests(DataSetVersionsControllerTe
         }
     }
 
+    public class UnfinaliseVersionTests(DataSetVersionsControllerTestsFixture fixture)
+        : DataSetVersionsControllerTests(fixture)
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var dataSetVersion = await SetupPatchVersion();
+            var processorClientMock = fixture.GetProcessorClientMock();
+            processorClientMock
+                .Setup(client => client.UnfinaliseDataSetVersion(dataSetVersion.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Unit.Instance);
+
+            var response = await UnfinaliseVersion(dataSetVersion.Id);
+
+            response.AssertNoContent();
+            MockUtils.VerifyAllMocks(processorClientMock);
+        }
+
+        [Fact]
+        public async Task NotBauUser_Returns403()
+        {
+            var dataSetVersion = await SetupPatchVersion();
+
+            var response = await UnfinaliseVersion(dataSetVersion.Id, OptimisedTestUsers.Authenticated);
+
+            response.AssertForbidden();
+        }
+
+        [Fact]
+        public async Task ProcessorValidationFailure_IsPropagated()
+        {
+            var dataSetVersion = await SetupPatchVersion();
+            var processorClientMock = fixture.GetProcessorClientMock();
+            processorClientMock
+                .Setup(client => client.UnfinaliseDataSetVersion(dataSetVersion.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new BadRequestObjectResult(
+                        new ValidationProblemViewModel
+                        {
+                            Errors = [new ErrorViewModel { Code = "cannot_unfinalise", Path = "dataSetVersionId" }],
+                        }
+                    )
+                );
+
+            var response = await UnfinaliseVersion(dataSetVersion.Id);
+
+            response.AssertValidationProblem().AssertHasError("dataSetVersionId", "cannot_unfinalise");
+            MockUtils.VerifyAllMocks(processorClientMock);
+        }
+
+        private async Task<HttpResponseMessage> UnfinaliseVersion(Guid dataSetVersionId, ClaimsPrincipal? user = null)
+        {
+            var client = fixture.CreateClient(user: user ?? OptimisedTestUsers.Bau);
+            return await client.PostAsync(
+                new Uri($"{BaseUrl}/{dataSetVersionId}/unfinalise", UriKind.Relative),
+                content: null
+            );
+        }
+
+        private async Task<DataSetVersion> SetupPatchVersion()
+        {
+            var releaseFile = DataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(
+                    DataFixture
+                        .DefaultReleaseVersion()
+                        .WithRelease(DataFixture.DefaultRelease().WithPublication(DataFixture.DefaultPublication()))
+                )
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .Generate();
+            await fixture.GetContentDbContext().AddTestData(context => context.ReleaseFiles.Add(releaseFile));
+
+            var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
+            var dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithVersionNumber(major: 1, minor: 0, patch: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .WithRelease(DataFixture.DefaultDataSetVersionRelease().WithReleaseFileId(releaseFile.Id))
+                .Generate();
+            await fixture.GetPublicDataDbContext().AddTestData(context => context.DataSetVersions.Add(dataSetVersion));
+            return dataSetVersion;
+        }
+    }
+
     public class GetVersionChangesTests(DataSetVersionsControllerTestsFixture fixture)
         : DataSetVersionsControllerTests(fixture)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -85,6 +85,14 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
             .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
     }
 
+    [HttpPost("{dataSetVersionId:guid}/unfinalise")]
+    public async Task<ActionResult> UnfinaliseVersion(Guid dataSetVersionId, CancellationToken cancellationToken)
+    {
+        return await dataSetVersionService
+            .UnfinaliseVersion(dataSetVersionId, cancellationToken)
+            .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+    }
+
     [HttpGet("{dataSetVersionId:guid}/changes")]
     [Produces("application/json")]
     public async Task<ActionResult> GetVersionChanges(Guid dataSetVersionId, CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -40,6 +40,11 @@ public interface IDataSetVersionService
         CancellationToken cancellationToken = default
     );
 
+    Task<Either<ActionResult, Unit>> UnfinaliseVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    );
+
     Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(
         Guid releaseFileId,
         Guid dataSetId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
@@ -34,4 +34,9 @@ public interface IProcessorClient
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default
     );
+
+    Task<Either<ActionResult, Unit>> UnfinaliseDataSetVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -172,7 +172,9 @@ public class DataSetVersionMappingService(
         return await publicDataDbContext.RequireTransaction(async () =>
             await userService
                 .CheckIsBauUser()
-                .OnSuccess(() => CheckMappingExists(nextDataSetVersionId, cancellationToken))
+                .OnSuccess(() =>
+                    CheckMappingExists(nextDataSetVersionId, cancellationToken, requireMappingStatus: true)
+                )
                 .OnSuccess(_ => validateCandidatesFn())
                 .OnSuccess(validationResults =>
                 {
@@ -779,14 +781,32 @@ public class DataSetVersionMappingService(
 
     private async Task<Either<ActionResult, DataSetVersionMapping>> CheckMappingExists(
         Guid nextDataSetVersionId,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool requireMappingStatus = false
     )
     {
-        return await publicDataDbContext
+        var mapping = await publicDataDbContext
             .DataSetVersionMappings.AsNoTracking()
-            .SingleOrNotFoundAsync(
-                mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId,
-                cancellationToken
+            .Include(mapping => mapping.TargetDataSetVersion)
+            .SingleOrDefaultAsync(mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId, cancellationToken);
+
+        if (mapping is null)
+        {
+            return new NotFoundResult();
+        }
+
+        if (requireMappingStatus && mapping.TargetDataSetVersion.Status != DataSetVersionStatus.Mapping)
+        {
+            return ValidationUtils.ValidationResult(
+                new ErrorViewModel
+                {
+                    Code = ValidationMessages.DataSetVersionMappingCannotBeUpdated.Code,
+                    Message = ValidationMessages.DataSetVersionMappingCannotBeUpdated.Message,
+                    Path = "nextDataSetVersionId",
+                }
             );
+        }
+
+        return mapping;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -173,7 +173,7 @@ public class DataSetVersionMappingService(
             await userService
                 .CheckIsBauUser()
                 .OnSuccess(() =>
-                    CheckMappingExists(nextDataSetVersionId, cancellationToken, requireMappingStatus: true)
+                    CheckMappingExists(nextDataSetVersionId, cancellationToken).OnSuccess(CheckInMappingStatus)
                 )
                 .OnSuccess(_ => validateCandidatesFn())
                 .OnSuccess(validationResults =>
@@ -779,23 +779,9 @@ public class DataSetVersionMappingService(
             .OnSuccess(createSuccessfulResponseFn);
     }
 
-    private async Task<Either<ActionResult, DataSetVersionMapping>> CheckMappingExists(
-        Guid nextDataSetVersionId,
-        CancellationToken cancellationToken,
-        bool requireMappingStatus = false
-    )
+    private static Either<ActionResult, Unit> CheckInMappingStatus(DataSetVersionMapping mapping)
     {
-        var mapping = await publicDataDbContext
-            .DataSetVersionMappings.AsNoTracking()
-            .Include(mapping => mapping.TargetDataSetVersion)
-            .SingleOrDefaultAsync(mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId, cancellationToken);
-
-        if (mapping is null)
-        {
-            return new NotFoundResult();
-        }
-
-        if (requireMappingStatus && mapping.TargetDataSetVersion.Status != DataSetVersionStatus.Mapping)
+        if (mapping.TargetDataSetVersion.Status != DataSetVersionStatus.Mapping)
         {
             return ValidationUtils.ValidationResult(
                 new ErrorViewModel
@@ -807,6 +793,20 @@ public class DataSetVersionMappingService(
             );
         }
 
-        return mapping;
+        return Unit.Instance;
+    }
+
+    private async Task<Either<ActionResult, DataSetVersionMapping>> CheckMappingExists(
+        Guid nextDataSetVersionId,
+        CancellationToken cancellationToken
+    )
+    {
+        return await publicDataDbContext
+            .DataSetVersionMappings.AsNoTracking()
+            .Include(mapping => mapping.TargetDataSetVersion)
+            .SingleOrNotFoundAsync(
+                mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId,
+                cancellationToken
+            );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -211,6 +211,27 @@ public class DataSetVersionService(
             );
     }
 
+    public async Task<Either<ActionResult, Unit>> UnfinaliseVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await userService
+            .CheckIsBauUser()
+            .OnSuccess(() => GetVersion(dataSetVersionId, cancellationToken))
+            .OnSuccess(async dataSetVersion =>
+                await contentDbContext
+                    .ReleaseFiles.AsNoTracking()
+                    .Where(releaseFile => releaseFile.Id == dataSetVersion.Release.ReleaseFileId)
+                    .Select(releaseFile => releaseFile.ReleaseVersion)
+                    .SingleAsync(cancellationToken)
+            )
+            .OnSuccess(userService.CheckCanUpdateReleaseVersion)
+            .OnSuccessVoid(async _ =>
+                await processorClient.UnfinaliseDataSetVersion(dataSetVersionId, cancellationToken)
+            );
+    }
+
     public async Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -90,6 +90,23 @@ internal class ProcessorClient(
         );
     }
 
+    public async Task<Either<ActionResult, Unit>> UnfinaliseDataSetVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await SendRequest<Unit>(
+            () =>
+                httpClient.PostAsync(
+                    $"api/UnfinaliseDataSetVersion/{dataSetVersionId}",
+                    content: null,
+                    cancellationToken
+                ),
+            response => response.StatusCode == HttpStatusCode.NotFound ? new NotFoundResult() : null,
+            cancellationToken
+        );
+    }
+
     private async Task<Either<ActionResult, TResponse>> SendPost<TRequest, TResponse>(
         string url,
         TRequest request,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -929,6 +929,14 @@ internal class NoOpProcessorClient : IProcessorClient
     {
         return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
     }
+
+    public Task<Either<ActionResult, Unit>> UnfinaliseDataSetVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
+    }
 }
 
 internal class NoOpDataSetVersionService : IDataSetVersionService
@@ -982,6 +990,14 @@ internal class NoOpDataSetVersionService : IDataSetVersionService
     ) => throw new NotImplementedException();
 
     public Task<Either<ActionResult, Unit>> DeleteVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
+    }
+
+    public Task<Either<ActionResult, Unit>> UnfinaliseVersion(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default
     )

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -39,6 +39,11 @@ public static class ValidationMessages
         Message: "The data file uploaded has incomplete sections or has resulted in a major version update which is not allowed in release amendments."
     );
 
+    public static readonly LocalizableMessage DataSetVersionMappingCannotBeUpdated = new(
+        Code: nameof(DataSetVersionMappingCannotBeUpdated),
+        Message: "The data set version mapping can only be updated while the version is in 'Mapping' status."
+    );
+
     public static readonly LocalizableMessage CannotDeleteOriginalFileOfOngoingReplacement = new(
         Code: nameof(CannotDeleteOriginalFileOfOngoingReplacement),
         Message: "This must be a replacement file linked to an original file, not the original file itself."

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -60,6 +60,11 @@ public static class ValidationMessages
         Message: "The data set version must be in the 'Mapping' status."
     );
 
+    public static readonly LocalizableMessage DataSetVersionCanNotBeUnfinalised = new(
+        Code: nameof(DataSetVersionCanNotBeUnfinalised),
+        Message: "Only a finalised patch data set version can be unfinalised."
+    );
+
     public static readonly LocalizableMessage ImportInManualMappingStateNotFound = new(
         Code: nameof(ImportInManualMappingStateNotFound),
         Message: "An import in mapping state could not be found."

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -62,7 +62,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage DataSetVersionCanNotBeUnfinalised = new(
         Code: nameof(DataSetVersionCanNotBeUnfinalised),
-        Message: "Only a finalised patch data set version can be unfinalised."
+        Message: "Only a finalised data set version can be unfinalised."
     );
 
     public static readonly LocalizableMessage ImportInManualMappingStateNotFound = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Fixture/OptimisedPublicDataProcessorCollectionFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Fixture/OptimisedPublicDataProcessorCollectionFixture.cs
@@ -111,6 +111,7 @@ public class OptimisedPublicDataProcessorCollectionFixture(
         serviceModifications.AddSingleton<CompleteNextDataSetVersionImportFunction>();
         serviceModifications.AddSingleton<ProcessCompletionOfNextDataSetVersionFunctions>();
         serviceModifications.AddSingleton<DeleteDataSetVersionFunction>();
+        serviceModifications.AddSingleton<UnfinaliseDataSetVersionFunction>();
         serviceModifications.AddSingleton<CopyCsvFilesFunction>();
         serviceModifications.AddSingleton<ImportMetadataFunction>();
         serviceModifications.AddSingleton<ImportDataFunction>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
@@ -1,0 +1,169 @@
+using GovUk.Education.ExploreEducationStatistics.Common.IntegrationTests;
+using GovUk.Education.ExploreEducationStatistics.Common.IntegrationTests.FunctionApp;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Fixture;
+using Microsoft.EntityFrameworkCore;
+
+#pragma warning disable CS9107
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
+
+public class UnfinaliseDataSetVersionFunctionTestsFixture()
+    : OptimisedPublicDataProcessorCollectionFixture(
+        capabilities: [PublicDataProcessorIntegrationTestCapability.Postgres]
+    )
+{
+    public UnfinaliseDataSetVersionFunction Function = null!;
+
+    protected override async Task AfterFactoryConstructed(OptimisedServiceCollectionLookups lookups)
+    {
+        await base.AfterFactoryConstructed(lookups);
+        Function = lookups.GetService<UnfinaliseDataSetVersionFunction>();
+    }
+}
+
+[CollectionDefinition(nameof(UnfinaliseDataSetVersionFunctionTestsFixture))]
+public class UnfinaliseDataSetVersionFunctionTestsCollection
+    : ICollectionFixture<UnfinaliseDataSetVersionFunctionTestsFixture>;
+
+[Collection(nameof(UnfinaliseDataSetVersionFunctionTestsFixture))]
+public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunctionTestsFixture fixture)
+    : OptimisedFunctionAppIntegrationTestBase(fixture)
+{
+    private static readonly DataFixture DataFixture = new();
+
+    [Fact]
+    public async Task Success_PreservesVersionMappingImportSourcesAndPreviewToken()
+    {
+        var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
+        var sourceVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithDataSet(dataSet)
+            .WithVersionNumber(major: 1, minor: 0)
+            .WithStatusPublished()
+            .Generate();
+        var import = DataFixture
+            .DefaultDataSetVersionImport()
+            .WithStage(DataSetVersionImportStage.Completing)
+            .Generate();
+        import.Completed = DateTimeOffset.UtcNow;
+        var targetVersion = DataFixture
+            .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+            .WithDataSet(dataSet)
+            .WithVersionNumber(major: 1, minor: 0, patch: 1)
+            .WithStatusDraft()
+            .WithImports(() => [import])
+            .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
+            .Generate();
+        var mapping = DataFixture
+            .DefaultDataSetVersionMapping()
+            .WithSourceDataSetVersion(sourceVersion)
+            .WithTargetDataSetVersion(targetVersion)
+            .Generate();
+
+        await fixture
+            .GetPublicDataDbContext()
+            .AddTestData(context =>
+            {
+                context.DataSetVersions.AddRange(sourceVersion, targetVersion);
+                context.DataSetVersionMappings.Add(mapping);
+            });
+
+        var pathResolver = fixture.GetDataSetVersionPathResolver();
+        Directory.CreateDirectory(pathResolver.DirectoryPath(targetVersion));
+        var sourcePaths = new[]
+        {
+            pathResolver.CsvDataPath(targetVersion),
+            pathResolver.CsvMetadataPath(targetVersion),
+        };
+        var derivedPaths = new[]
+        {
+            pathResolver.DuckDbPath(targetVersion),
+            pathResolver.DuckDbLoadSqlPath(targetVersion),
+            pathResolver.DuckDbSchemaSqlPath(targetVersion),
+            pathResolver.DataPath(targetVersion),
+            pathResolver.FiltersPath(targetVersion),
+            pathResolver.IndicatorsPath(targetVersion),
+            pathResolver.LocationsPath(targetVersion),
+            pathResolver.TimePeriodsPath(targetVersion),
+        };
+        foreach (var path in sourcePaths.Concat(derivedPaths))
+        {
+            await System.IO.File.WriteAllTextAsync(path, "test");
+        }
+
+        var result = await fixture.Function.UnfinaliseDataSetVersion(null!, targetVersion.Id, CancellationToken.None);
+        result.AssertNoContent();
+
+        var updatedVersion = await fixture
+            .GetPublicDataDbContext()
+            .DataSetVersions.Include(version => version.Imports)
+            .Include(version => version.PreviewTokens)
+            .SingleAsync(version => version.Id == targetVersion.Id);
+        Assert.Equal(DataSetVersionStatus.Mapping, updatedVersion.Status);
+        Assert.Equal(0, updatedVersion.TotalResults);
+        Assert.Null(updatedVersion.MetaSummary);
+        Assert.Equal(DataSetVersionImportStage.ManualMapping, updatedVersion.Imports.Single().Stage);
+        Assert.Null(updatedVersion.Imports.Single().Completed);
+        Assert.Single(updatedVersion.PreviewTokens);
+        Assert.True(
+            await fixture
+                .GetPublicDataDbContext()
+                .DataSetVersionMappings.AnyAsync(existing => existing.Id == mapping.Id)
+        );
+        Assert.All(sourcePaths, path => Assert.True(System.IO.File.Exists(path)));
+        Assert.All(derivedPaths, path => Assert.False(System.IO.File.Exists(path)));
+        Assert.False(
+            await fixture
+                .GetPublicDataDbContext()
+                .FilterMetas.AnyAsync(meta => meta.DataSetVersionId == targetVersion.Id)
+        );
+        Assert.False(
+            await fixture
+                .GetPublicDataDbContext()
+                .IndicatorMetas.AnyAsync(meta => meta.DataSetVersionId == targetVersion.Id)
+        );
+    }
+
+    [Theory]
+    [InlineData(0, DataSetVersionStatus.Draft)]
+    [InlineData(1, DataSetVersionStatus.Mapping)]
+    [InlineData(1, DataSetVersionStatus.Processing)]
+    [InlineData(1, DataSetVersionStatus.Finalising)]
+    [InlineData(1, DataSetVersionStatus.Published)]
+    [InlineData(1, DataSetVersionStatus.Failed)]
+    [InlineData(1, DataSetVersionStatus.Cancelled)]
+    public async Task InvalidVersionTypeOrStatus_ReturnsValidationProblem(int patch, DataSetVersionStatus status)
+    {
+        var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
+        var version = DataFixture
+            .DefaultDataSetVersion()
+            .WithDataSet(dataSet)
+            .WithVersionNumber(major: 1, minor: 0, patch: patch)
+            .WithStatus(status)
+            .WithImports(() => DataFixture.DefaultDataSetVersionImport().Generate(1))
+            .Generate();
+        await fixture.GetPublicDataDbContext().AddTestData(context => context.DataSetVersions.Add(version));
+
+        var result = await fixture.Function.UnfinaliseDataSetVersion(null!, version.Id, CancellationToken.None);
+
+        var validationProblem = result.AssertBadRequestWithValidationProblem();
+        validationProblem.AssertHasError(
+            expectedPath: "dataSetVersionId",
+            expectedCode: ValidationMessages.DataSetVersionCanNotBeUnfinalised.Code
+        );
+    }
+
+    [Fact]
+    public async Task VersionDoesNotExist_ReturnsNotFound()
+    {
+        var result = await fixture.Function.UnfinaliseDataSetVersion(null!, Guid.NewGuid(), CancellationToken.None);
+
+        result.AssertNotFoundResult();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
@@ -37,8 +37,10 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
 {
     private static readonly DataFixture DataFixture = new();
 
-    [Fact]
-    public async Task Success_PreservesVersionMappingImportSourcesAndPreviewToken()
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(0, 1)]
+    public async Task Success_PreservesVersionMappingImportSourcesAndPreviewToken(int minor, int patch)
     {
         var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
         var sourceVersion = DataFixture
@@ -55,7 +57,7 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
         var targetVersion = DataFixture
             .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
             .WithDataSet(dataSet)
-            .WithVersionNumber(major: 1, minor: 0, patch: 1)
+            .WithVersionNumber(major: 1, minor: minor, patch: patch)
             .WithStatusDraft()
             .WithImports(() => [import])
             .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
@@ -131,20 +133,19 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
     }
 
     [Theory]
-    [InlineData(0, DataSetVersionStatus.Draft)]
-    [InlineData(1, DataSetVersionStatus.Mapping)]
-    [InlineData(1, DataSetVersionStatus.Processing)]
-    [InlineData(1, DataSetVersionStatus.Finalising)]
-    [InlineData(1, DataSetVersionStatus.Published)]
-    [InlineData(1, DataSetVersionStatus.Failed)]
-    [InlineData(1, DataSetVersionStatus.Cancelled)]
-    public async Task InvalidVersionTypeOrStatus_ReturnsValidationProblem(int patch, DataSetVersionStatus status)
+    [InlineData(DataSetVersionStatus.Mapping)]
+    [InlineData(DataSetVersionStatus.Processing)]
+    [InlineData(DataSetVersionStatus.Finalising)]
+    [InlineData(DataSetVersionStatus.Published)]
+    [InlineData(DataSetVersionStatus.Failed)]
+    [InlineData(DataSetVersionStatus.Cancelled)]
+    public async Task InvalidStatus_ReturnsValidationProblem(DataSetVersionStatus status)
     {
         var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
         var version = DataFixture
             .DefaultDataSetVersion()
             .WithDataSet(dataSet)
-            .WithVersionNumber(major: 1, minor: 0, patch: patch)
+            .WithVersionNumber(major: 1, minor: 1)
             .WithStatus(status)
             .WithImports(() => DataFixture.DefaultDataSetVersionImport().Generate(1))
             .Generate();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/UnfinaliseDataSetVersionFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/UnfinaliseDataSetVersionFunction.cs
@@ -1,0 +1,43 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class UnfinaliseDataSetVersionFunction(
+    IDataSetVersionService dataSetVersionService,
+    ILogger<UnfinaliseDataSetVersionFunction> logger
+)
+{
+    [Function(nameof(UnfinaliseDataSetVersion))]
+    public async Task<IActionResult> UnfinaliseDataSetVersion(
+        [HttpTrigger(
+            AuthorizationLevel.Anonymous,
+            "post",
+            Route = $"{nameof(UnfinaliseDataSetVersion)}/{{dataSetVersionId:guid}}"
+        )]
+            HttpRequest request,
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            return await dataSetVersionService
+                .UnfinaliseVersion(dataSetVersionId, cancellationToken)
+                .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Exception occurred while executing '{FunctionName}'",
+                nameof(UnfinaliseDataSetVersion)
+            );
+            return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -182,6 +182,7 @@ internal class DataSetVersionService(
 
     private async Task RemoveFinalisedVersionData(DataSetVersion dataSetVersion, CancellationToken cancellationToken)
     {
+        // TODO EES-7508: 'Unfinalise' action should use cascade deletion where possible
         var dataSetVersionId = dataSetVersion.Id;
 
         publicDataDbContext.FilterMetaChanges.RemoveRange(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -132,6 +132,164 @@ internal class DataSetVersionService(
         );
     }
 
+    public async Task<Either<ActionResult, Unit>> UnfinaliseVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await publicDataDbContext.RequireTransaction(() =>
+            publicDataDbContext
+                .DataSetVersions.Include(dsv => dsv.Imports)
+                .SingleOrNotFoundAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken)
+                .OnSuccessDo(CheckCanUnfinaliseDataSetVersion)
+                .OnSuccessDo(async dataSetVersion =>
+                    await RemoveFinalisedVersionData(dataSetVersion, cancellationToken)
+                )
+                .OnSuccessDo(async dataSetVersion =>
+                {
+                    var dataSetVersionImport = dataSetVersion.Imports.Single();
+                    dataSetVersionImport.Stage = DataSetVersionImportStage.ManualMapping;
+                    dataSetVersionImport.Completed = null;
+
+                    dataSetVersion.MetaSummary = null;
+                    dataSetVersion.TotalResults = 0;
+                    dataSetVersion.Status = DataSetVersionStatus.Mapping;
+
+                    await publicDataDbContext.SaveChangesAsync(cancellationToken);
+                })
+                .OnSuccessDo(RemoveFinalisedVersionFiles)
+                .OnSuccessVoid()
+        );
+    }
+
+    private static Either<ActionResult, Unit> CheckCanUnfinaliseDataSetVersion(DataSetVersion dataSetVersion)
+    {
+        if (dataSetVersion.VersionPatch > 0 && dataSetVersion.Status == DataSetVersionStatus.Draft)
+        {
+            return Unit.Instance;
+        }
+
+        return ValidationUtils.ValidationResult(
+            new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionCanNotBeUnfinalised.Code,
+                Message = ValidationMessages.DataSetVersionCanNotBeUnfinalised.Message,
+                Detail = new InvalidErrorDetail<Guid>(dataSetVersion.Id),
+                Path = "dataSetVersionId",
+            }
+        );
+    }
+
+    private async Task RemoveFinalisedVersionData(DataSetVersion dataSetVersion, CancellationToken cancellationToken)
+    {
+        var dataSetVersionId = dataSetVersion.Id;
+
+        publicDataDbContext.FilterMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .FilterMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.FilterOptionMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .FilterOptionMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.GeographicLevelMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .GeographicLevelMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.IndicatorMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .IndicatorMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.LocationMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .LocationMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.LocationOptionMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .LocationOptionMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        publicDataDbContext.TimePeriodMetaChanges.RemoveRange(
+            await publicDataDbContext
+                .TimePeriodMetaChanges.Where(change => change.DataSetVersionId == dataSetVersionId)
+                .ToListAsync(cancellationToken)
+        );
+        await publicDataDbContext.SaveChangesAsync(cancellationToken);
+
+        var filterOptionIds = await publicDataDbContext
+            .FilterOptionMetaLinks.Where(link => link.Meta.DataSetVersionId == dataSetVersionId)
+            .Select(link => link.OptionId)
+            .ToListAsync(cancellationToken);
+        await publicDataDbContext
+            .FilterOptionMetaLinks.Where(link => link.Meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        await publicDataDbContext
+            .FilterMetas.Where(meta => meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        var unlinkedFilterOptionIds = await publicDataDbContext
+            .FilterOptionMetas.Where(option => filterOptionIds.Contains(option.Id))
+            .Where(option => !option.MetaLinks.Any())
+            .Select(option => option.Id)
+            .ToListAsync(cancellationToken);
+        await publicDataDbContext
+            .FilterOptionMetas.Where(option => unlinkedFilterOptionIds.Contains(option.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var locationOptionIds = await publicDataDbContext
+            .LocationOptionMetaLinks.Where(link => link.Meta.DataSetVersionId == dataSetVersionId)
+            .Select(link => link.OptionId)
+            .ToListAsync(cancellationToken);
+        await publicDataDbContext
+            .LocationOptionMetaLinks.Where(link => link.Meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        await publicDataDbContext
+            .LocationMetas.Where(meta => meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        var unlinkedLocationOptionIds = await publicDataDbContext
+            .LocationOptionMetas.Where(option => locationOptionIds.Contains(option.Id))
+            .Where(option => !option.MetaLinks.Any())
+            .Select(option => option.Id)
+            .ToListAsync(cancellationToken);
+        await publicDataDbContext
+            .LocationOptionMetas.Where(option => unlinkedLocationOptionIds.Contains(option.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await publicDataDbContext
+            .GeographicLevelMetas.Where(meta => meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        await publicDataDbContext
+            .IndicatorMetas.Where(meta => meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+        await publicDataDbContext
+            .TimePeriodMetas.Where(meta => meta.DataSetVersionId == dataSetVersionId)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    private void RemoveFinalisedVersionFiles(DataSetVersion dataSetVersion)
+    {
+        var paths = new[]
+        {
+            dataSetVersionPathResolver.DuckDbPath(dataSetVersion),
+            dataSetVersionPathResolver.DuckDbLoadSqlPath(dataSetVersion),
+            dataSetVersionPathResolver.DuckDbSchemaSqlPath(dataSetVersion),
+            dataSetVersionPathResolver.DataPath(dataSetVersion),
+            dataSetVersionPathResolver.FiltersPath(dataSetVersion),
+            dataSetVersionPathResolver.IndicatorsPath(dataSetVersion),
+            dataSetVersionPathResolver.LocationsPath(dataSetVersion),
+            dataSetVersionPathResolver.TimePeriodsPath(dataSetVersion),
+        };
+
+        foreach (var path in paths)
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
     private async Task<Either<ActionResult, IReadOnlyList<DataSetVersion>>> GetDataSetVersions(
         IReadOnlyList<ReleaseFile> releaseFiles,
         CancellationToken cancellationToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -164,7 +164,7 @@ internal class DataSetVersionService(
 
     private static Either<ActionResult, Unit> CheckCanUnfinaliseDataSetVersion(DataSetVersion dataSetVersion)
     {
-        if (dataSetVersion.VersionPatch > 0 && dataSetVersion.Status == DataSetVersionStatus.Draft)
+        if (dataSetVersion.Status == DataSetVersionStatus.Draft)
         {
             return Unit.Instance;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
@@ -30,4 +30,9 @@ public interface IDataSetVersionService
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default
     );
+
+    Task<Either<ActionResult, Unit>> UnfinaliseVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -37,6 +37,8 @@ import isPatchVersion from '@common/utils/isPatchVersion';
 import InsetText from '@common/components/InsetText';
 import shouldShowDraftActions from '@admin/pages/release/data/utils/shouldShowDraftActions';
 import ApiDataSetMappingTaskListItem from '@admin/pages/release/data/components/ApiDataSetMappingTaskListItem';
+import ModalConfirm from '@common/components/ModalConfirm';
+import ButtonText from '@common/components/ButtonText';
 
 export type DataSetFinalisingStatus = 'finalising' | 'finalised' | undefined;
 
@@ -96,6 +98,14 @@ export default function ReleaseApiDataSetDetailsPage() {
     }
   };
 
+  const handleUnfinalise = async () => {
+    if (dataSet?.draftVersion) {
+      await apiDataSetVersionService.unfinaliseVersion(dataSet.draftVersion.id);
+      setFinalisingStatus(undefined);
+      await refetch();
+    }
+  };
+
   const columnSizeClassName =
     dataSet?.latestLiveVersion && dataSet?.draftVersion
       ? 'govuk-grid-column-one-half-from-desktop'
@@ -108,6 +118,27 @@ export default function ReleaseApiDataSetDetailsPage() {
     canUpdateRelease,
     dataSet,
   );
+
+  const unfinaliseAction =
+    canUpdateRelease && isPatch && dataSet?.draftVersion?.status === 'Draft' ? (
+      <ModalConfirm
+        title="Unfinalise this data set version"
+        confirmText="Unfinalise data set version"
+        triggerButton={
+          <ButtonText>Unfinalise this data set version</ButtonText>
+        }
+        onConfirm={handleUnfinalise}
+      >
+        <p>
+          Unfinalising this data set version will return it to the mapping
+          journey and allow you to edit its mappings again.
+        </p>
+        <p>
+          The data set preview will be unavailable until the version is
+          finalised again.
+        </p>
+      </ModalConfirm>
+    ) : null;
 
   const draftVersionSummary = dataSet?.draftVersion ? (
     <ApiDataSetVersionSummaryList
@@ -165,6 +196,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                     View preview token log
                   </Link>
                 </li>
+                {unfinaliseAction && <li>{unfinaliseAction}</li>}
               </>
             )}
             {canUpdateRelease &&

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -120,7 +120,7 @@ export default function ReleaseApiDataSetDetailsPage() {
   );
 
   const unfinaliseAction =
-    canUpdateRelease && isPatch && dataSet?.draftVersion?.status === 'Draft' ? (
+    canUpdateRelease && dataSet?.draftVersion?.status === 'Draft' ? (
       <ModalConfirm
         title="Unfinalise this data set version"
         confirmText="Unfinalise data set version"

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -130,8 +130,8 @@ export default function ReleaseApiDataSetDetailsPage() {
         onConfirm={handleUnfinalise}
       >
         <p>
-          Unfinalising this data set version will return it to the mapping
-          journey and allow you to edit its mappings again.
+          Unfinalising this data set version will return it to the mapping step
+          and allow you to edit its mappings again.
         </p>
         <p>
           The data set preview will be unavailable until the version is

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
@@ -335,8 +335,9 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
             <h2>{dataSet?.title}</h2>
             {isFinalised && (
               <InsetText>
-                These mappings are read-only because this data set version has
-                been finalised. Unfinalise the data set version to make changes.
+                These mappings cannot be edited because this data set version
+                has been finalised. Unfinalise the data set version to make
+                changes.
               </InsetText>
             )}
             {canUpdateMappings && !!unmappedFilterErrors.length && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
@@ -28,6 +28,7 @@ import apiDataSetVersionService, {
 } from '@admin/services/apiDataSetVersionService';
 import NotificationBanner from '@common/components/NotificationBanner';
 import Tag from '@common/components/Tag';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
@@ -88,6 +89,9 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
     ),
     enabled: !!dataSet?.draftVersion?.id,
   });
+
+  const canUpdateMappings = dataSet?.draftVersion?.status === 'Mapping';
+  const isFinalised = dataSet?.draftVersion?.status === 'Draft';
 
   useEffect(() => {
     if (filtersMapping) {
@@ -291,6 +295,10 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
 
   const handleUpdateMapping = useCallback(
     async (update: PendingMappingUpdate) => {
+      if (!canUpdateMappings) {
+        return;
+      }
+
       setPendingUpdates(current => [
         ...current,
         {
@@ -300,7 +308,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
       ]);
       handleUpdate();
     },
-    [handleUpdate],
+    [canUpdateMappings, handleUpdate],
   );
 
   return (
@@ -325,7 +333,13 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
           <div className="govuk-grid-column-three-quarters">
             <span className="govuk-caption-l">Map filters</span>
             <h2>{dataSet?.title}</h2>
-            {!!unmappedFilterErrors.length && (
+            {isFinalised && (
+              <InsetText>
+                These mappings are read-only because this data set version has
+                been finalised. Unfinalise the data set version to make changes.
+              </InsetText>
+            )}
+            {canUpdateMappings && !!unmappedFilterErrors.length && (
               <NotificationBanner title="Action required">
                 <ul className="govuk-list">
                   {unmappedFilterErrors.map(error => (
@@ -388,6 +402,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
                     mappableItems={mappableFilterOptions[filterKey]}
                     newItems={newFilterOptions[filterKey]}
                     pendingUpdates={pendingUpdates}
+                    readOnly={!canUpdateMappings}
                     renderCandidate={candidate => candidate.label}
                     renderCaptionEnd={
                       <>
@@ -519,6 +534,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
                             autoMappedItems={autoMappedFilterOptions[filterKey]}
                             newItems={newFilterOptions[filterKey]}
                             pendingUpdates={pendingUpdates}
+                            readOnly={!canUpdateMappings}
                             renderCandidate={candidate => candidate.label}
                             renderSource={source => source.label}
                             searchFilter={searchTerm =>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetIndicatorsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetIndicatorsMappingPage.tsx
@@ -234,8 +234,9 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
             <h2>{dataSet?.title}</h2>
             {isFinalised && (
               <InsetText>
-                These mappings are read-only because this data set version has
-                been finalised. Unfinalise the data set version to make changes.
+                These mappings cannot be edited because this data set version
+                has been finalised. Unfinalise the data set version to make
+                changes.
               </InsetText>
             )}
             {canUpdateMappings && !!unmappedIndicatorErrors.length && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetIndicatorsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetIndicatorsMappingPage.tsx
@@ -18,6 +18,7 @@ import PageNav, { NavItem } from '@common/components/PageNav';
 import Link from '@admin/components/Link';
 import { generatePath } from 'react-router';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import InsetText from '@common/components/InsetText';
 import Tag from '@common/components/Tag';
 import ApiDataSetMappableTable from '@admin/pages/release/data/components/ApiDataSetMappableTable';
 import Accordion from '@common/components/Accordion';
@@ -68,6 +69,9 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
     ),
     enabled: !!dataSet?.draftVersion?.id,
   });
+
+  const canUpdateMappings = dataSet?.draftVersion?.status === 'Mapping';
+  const isFinalised = dataSet?.draftVersion?.status === 'Draft';
 
   useEffect(() => {
     if (indicatorsMapping) {
@@ -193,10 +197,14 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
 
   const handleUpdateMapping = useCallback(
     async (update: PendingMappingUpdate) => {
+      if (!canUpdateMappings) {
+        return;
+      }
+
       setPendingUpdates(current => [...current, update]);
       handleUpdate();
     },
-    [handleUpdate],
+    [canUpdateMappings, handleUpdate],
   );
 
   const unmappedIndicatorErrors =
@@ -224,7 +232,13 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
           <div className="govuk-grid-column-three-quarters">
             <span className="govuk-caption-l">Map indicators</span>
             <h2>{dataSet?.title}</h2>
-            {!!unmappedIndicatorErrors.length && (
+            {isFinalised && (
+              <InsetText>
+                These mappings are read-only because this data set version has
+                been finalised. Unfinalise the data set version to make changes.
+              </InsetText>
+            )}
+            {canUpdateMappings && !!unmappedIndicatorErrors.length && (
               <NotificationBanner title="Action required">
                 <ul className="govuk-list">
                   {unmappedIndicatorErrors.map(error => (
@@ -261,6 +275,7 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
                 mappableItems={mappableIndicators}
                 newItems={newIndicators}
                 pendingUpdates={pendingUpdates}
+                readOnly={!canUpdateMappings}
                 renderCandidate={candidate => candidate.label}
                 renderSource={source => source.label}
                 onUpdate={handleUpdateMapping}
@@ -321,6 +336,7 @@ export default function ReleaseApiDataSetIndicatorsMappingPage() {
                     autoMappedItems={autoMappedIndicators}
                     newItems={newIndicators}
                     pendingUpdates={pendingUpdates}
+                    readOnly={!canUpdateMappings}
                     renderCandidate={candidate => candidate.label}
                     renderSource={source => source.label}
                     searchFilter={searchTerm =>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
@@ -25,6 +25,7 @@ import apiDataSetVersionService, {
 } from '@admin/services/apiDataSetVersionService';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import NotificationBanner from '@common/components/NotificationBanner';
 import PageNav, { NavItem } from '@common/components/PageNav';
@@ -94,6 +95,9 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
     ),
     enabled: !!dataSet?.draftVersion?.id,
   });
+
+  const canUpdateMappings = dataSet?.draftVersion?.status === 'Mapping';
+  const isFinalised = dataSet?.draftVersion?.status === 'Draft';
 
   useEffect(() => {
     if (locationsMapping) {
@@ -283,13 +287,17 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
 
   const handleUpdateMapping = useCallback(
     async (update: PendingMappingUpdate) => {
+      if (!canUpdateMappings) {
+        return;
+      }
+
       setPendingUpdates(current => [
         ...current,
         { ...update, level: update.groupKey },
       ]);
       handleUpdate();
     },
-    [handleUpdate],
+    [canUpdateMappings, handleUpdate],
   );
 
   return (
@@ -315,7 +323,13 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
           <div className="govuk-grid-column-three-quarters">
             <span className="govuk-caption-l">Map locations</span>
             <h2>{dataSet?.title}</h2>
-            {!!unmappedLocationErrors.length && (
+            {isFinalised && (
+              <InsetText>
+                These mappings are read-only because this data set version has
+                been finalised. Unfinalise the data set version to make changes.
+              </InsetText>
+            )}
+            {canUpdateMappings && !!unmappedLocationErrors.length && (
               <NotificationBanner title="Action required">
                 <ul className="govuk-list">
                   {unmappedLocationErrors.map(error => (
@@ -393,6 +407,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
                         mappableItems={levelMappableLocations}
                         newItems={newLocations[level]}
                         pendingUpdates={pendingUpdates}
+                        readOnly={!canUpdateMappings}
                         renderCandidate={candidate => (
                           <>
                             {candidate.label}
@@ -524,6 +539,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
                           autoMappedItems={levelAutoMappedLocations}
                           newItems={newLocations[level]}
                           pendingUpdates={pendingUpdates}
+                          readOnly={!canUpdateMappings}
                           renderCandidate={candidate => (
                             <>
                               {candidate.label}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
@@ -325,8 +325,9 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
             <h2>{dataSet?.title}</h2>
             {isFinalised && (
               <InsetText>
-                These mappings are read-only because this data set version has
-                been finalised. Unfinalise the data set version to make changes.
+                These mappings cannot be edited because this data set version
+                has been finalised. Unfinalise the data set version to make
+                changes.
               </InsetText>
             )}
             {canUpdateMappings && !!unmappedLocationErrors.length && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1329,9 +1329,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     apiDataSetService.getDataSet
       .mockResolvedValueOnce({
         ...testDataSet,
-        draftVersion: {
-          ...draftVersion,
-        },
+        draftVersion,
       })
       .mockResolvedValue({
         ...testDataSet,
@@ -1368,7 +1366,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     const dialog = within(screen.getByRole('dialog'));
     expect(
-      dialog.getByText(/return it to the mapping journey/),
+      dialog.getByText(/return it to the mapping step/),
     ).toBeInTheDocument();
 
     await user.click(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1322,18 +1322,21 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
   });
 
-  test('unfinalises a finalised patch version', async () => {
+  test.each([
+    ['patch', testPatchDraftVersion],
+    ['non-patch', testDraftVersion],
+  ])('unfinalises a finalised %s version', async (_, draftVersion) => {
     apiDataSetService.getDataSet
       .mockResolvedValueOnce({
         ...testDataSet,
         draftVersion: {
-          ...testPatchDraftVersion,
+          ...draftVersion,
         },
       })
       .mockResolvedValue({
         ...testDataSet,
         draftVersion: {
-          ...testPatchDraftVersion,
+          ...draftVersion,
           status: 'Mapping',
           mappingStatus: {
             filtersComplete: true,
@@ -1374,7 +1377,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     await waitFor(() => {
       expect(apiDataSetVersionService.unfinaliseVersion).toHaveBeenCalledWith(
-        testPatchDraftVersion.id,
+        draftVersion.id,
       );
       expect(screen.getByTestId('draft-version-tasks')).toBeInTheDocument();
       expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1322,6 +1322,113 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
   });
 
+  test('unfinalises a finalised patch version', async () => {
+    apiDataSetService.getDataSet
+      .mockResolvedValueOnce({
+        ...testDataSet,
+        draftVersion: {
+          ...testPatchDraftVersion,
+        },
+      })
+      .mockResolvedValue({
+        ...testDataSet,
+        draftVersion: {
+          ...testPatchDraftVersion,
+          status: 'Mapping',
+          mappingStatus: {
+            filtersComplete: true,
+            locationsComplete: true,
+            indicatorsComplete: true,
+            filtersHaveMajorChange: false,
+            locationsHaveMajorChange: false,
+            indicatorsHaveMajorChange: false,
+            isMajorVersionUpdate: false,
+          },
+        },
+      });
+    apiDataSetVersionService.unfinaliseVersion.mockResolvedValue();
+
+    const { user } = renderPage();
+
+    const finalisedDraftSummary = within(
+      await screen.findByTestId('draft-version-summary'),
+    );
+    expect(finalisedDraftSummary.getByTestId('Status')).toHaveTextContent(
+      'Ready',
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Unfinalise this data set version',
+      }),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByText(/return it to the mapping journey/),
+    ).toBeInTheDocument();
+
+    await user.click(
+      dialog.getByRole('button', { name: 'Unfinalise data set version' }),
+    );
+
+    await waitFor(() => {
+      expect(apiDataSetVersionService.unfinaliseVersion).toHaveBeenCalledWith(
+        testPatchDraftVersion.id,
+      );
+      expect(screen.getByTestId('draft-version-tasks')).toBeInTheDocument();
+      expect(
+        within(screen.getByTestId('draft-version-summary')).getByTestId(
+          'Status',
+        ),
+      ).toHaveTextContent('Action required');
+      expect(
+        screen.queryByRole('button', {
+          name: 'Unfinalise this data set version',
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: 'Finalise this data set version',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Map locations' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Map filters' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Map indicators' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('does not show the unfinalise action for an approved release', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: {
+        ...testPatchDraftVersion,
+      },
+    });
+
+    renderPage({
+      releaseVersion: {
+        ...testDraftRelease,
+        approvalStatus: 'Approved',
+      },
+    });
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Unfinalise this data set version',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   function renderPage(options?: {
     releaseVersion?: ReleaseVersion;
     dataSetId?: string;

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
@@ -88,7 +88,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
 
     expect(
       await screen.findByText(
-        /These mappings are read-only because this data set version has been finalised/,
+        /These mappings cannot be edited because this data set version has been finalised/,
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
@@ -72,6 +72,36 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
     previousReleaseIds: [],
   };
 
+  test('renders finalised mappings as read-only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: {
+        ...testDataSet.draftVersion!,
+        status: 'Draft',
+      },
+    });
+    apiDataSetVersionService.getFiltersMapping.mockResolvedValue(
+      testFiltersMapping,
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        /These mappings are read-only because this data set version has been finalised/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('columnheader', { name: 'Actions' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Map filter option/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^No mapping/ }),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders the mappings tables correctly', async () => {
     apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
     apiDataSetVersionService.getFiltersMapping.mockResolvedValue(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetIndicatorsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetIndicatorsMappingPage.test.tsx
@@ -71,6 +71,36 @@ describe('ReleaseApiDataSetIndicatorsMappingPage', () => {
     previousReleaseIds: [],
   };
 
+  test('renders finalised mappings as read-only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: {
+        ...testDataSet.draftVersion!,
+        status: 'Draft',
+      },
+    });
+    apiDataSetVersionService.getIndicatorsMapping.mockResolvedValue(
+      testIndicatorsMapping,
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        /These mappings are read-only because this data set version has been finalised/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('columnheader', { name: 'Actions' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Map indicator/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^No mapping/ }),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders the mappings tables correctly', async () => {
     apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
     apiDataSetVersionService.getIndicatorsMapping.mockResolvedValue(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetIndicatorsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetIndicatorsMappingPage.test.tsx
@@ -87,7 +87,7 @@ describe('ReleaseApiDataSetIndicatorsMappingPage', () => {
 
     expect(
       await screen.findByText(
-        /These mappings are read-only because this data set version has been finalised/,
+        /These mappings cannot be edited because this data set version has been finalised/,
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -88,7 +88,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
 
     expect(
       await screen.findByText(
-        /These mappings are read-only because this data set version has been finalised/,
+        /These mappings cannot be edited because this data set version has been finalised/,
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -72,6 +72,36 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
     previousReleaseIds: [],
   };
 
+  test('renders finalised mappings as read-only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: {
+        ...testDataSet.draftVersion!,
+        status: 'Draft',
+      },
+    });
+    apiDataSetVersionService.getLocationsMapping.mockResolvedValue(
+      testLocationsMapping,
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        /These mappings are read-only because this data set version has been finalised/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('columnheader', { name: 'Actions' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Map location/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^No mapping/ }),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders the mappings tables correctly', async () => {
     apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
     apiDataSetVersionService.getLocationsMapping.mockResolvedValue(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetAutoMappedTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetAutoMappedTable.tsx
@@ -29,6 +29,7 @@ interface Props {
   itemPluralLabel: string;
   newItems?: CandidateWithKey[];
   pendingUpdates?: PendingMappingUpdate[];
+  readOnly?: boolean;
   renderCandidate: (candidate: CandidateWithKey) => ReactNode;
   renderSource: (source: MappableSourceItem) => ReactNode;
   renderSourceDetails?: (source: MappableSourceItem) => ReactNode;
@@ -45,6 +46,7 @@ export default function ApiDataSetAutoMappedTable({
   itemPluralLabel,
   newItems = [],
   pendingUpdates = [],
+  readOnly = false,
   renderCandidate,
   renderSource,
   renderSourceDetails,
@@ -132,7 +134,9 @@ export default function ApiDataSetAutoMappedTable({
                 <th className="govuk-!-width-one-third">Current data set</th>
                 <th className="govuk-!-width-one-third">New data set</th>
                 <th>Type</th>
-                <th className="govuk-!-text-align-right">Actions</th>
+                {!readOnly && (
+                  <th className="govuk-!-text-align-right">Actions</th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -148,28 +152,30 @@ export default function ApiDataSetAutoMappedTable({
                       <td>
                         <Tag colour="grey">Minor</Tag>
                       </td>
-                      <td className="govuk-!-text-align-right">
-                        {isPendingUpdate ? (
-                          <LoadingSpinner
-                            alert
-                            hideText
-                            inline
-                            size="sm"
-                            text={`Updating auto-mapping for ${mapping.source.label}`}
-                          />
-                        ) : (
-                          <ApiDataSetMappingModal
-                            candidate={candidate}
-                            candidateHint={candidateHint}
-                            groupKey={groupKey}
-                            itemLabel={itemLabel}
-                            mapping={mapping}
-                            newItems={newItems}
-                            renderSourceDetails={renderSourceDetails}
-                            onSubmit={onUpdate}
-                          />
-                        )}
-                      </td>
+                      {!readOnly && (
+                        <td className="govuk-!-text-align-right">
+                          {isPendingUpdate ? (
+                            <LoadingSpinner
+                              alert
+                              hideText
+                              inline
+                              size="sm"
+                              text={`Updating auto-mapping for ${mapping.source.label}`}
+                            />
+                          ) : (
+                            <ApiDataSetMappingModal
+                              candidate={candidate}
+                              candidateHint={candidateHint}
+                              groupKey={groupKey}
+                              itemLabel={itemLabel}
+                              mapping={mapping}
+                              newItems={newItems}
+                              renderSourceDetails={renderSourceDetails}
+                              onSubmit={onUpdate}
+                            />
+                          )}
+                        </td>
+                      )}
                     </tr>
                   );
                 },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetMappableTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetMappableTable.tsx
@@ -29,6 +29,7 @@ interface Props {
   mappableItems: MappableItem[];
   newItems?: CandidateWithKey[];
   pendingUpdates?: PendingMappingUpdate[];
+  readOnly?: boolean;
   renderCandidate: (candidate: CandidateWithKey) => ReactNode;
   renderCaptionEnd?: ReactNode;
   renderSource: (source: MappableSourceItem) => ReactNode;
@@ -46,6 +47,7 @@ export default function ApiDataSetMappableTable({
   mappableItems,
   newItems = [],
   pendingUpdates = [],
+  readOnly = false,
   renderCandidate,
   renderCaptionEnd,
   renderSource,
@@ -91,7 +93,7 @@ export default function ApiDataSetMappableTable({
             <th className="govuk-!-width-one-third">Current data set</th>
             <th className="govuk-!-width-one-third">New data set</th>
             <th>Type</th>
-            <th className="govuk-!-text-align-right">Actions</th>
+            {!readOnly && <th className="govuk-!-text-align-right">Actions</th>}
           </tr>
         </thead>
         <tbody>
@@ -132,50 +134,52 @@ export default function ApiDataSetMappableTable({
                     {getUpdateTagText(mapping.type, isMajorMapping)}
                   </Tag>
                 </td>
-                <td className="govuk-!-text-align-right">
-                  {isPendingUpdate ? (
-                    <LoadingSpinner
-                      alert
-                      hideText
-                      inline
-                      size="sm"
-                      text={`Updating mapping for ${mapping.source.label}`}
-                    />
-                  ) : (
-                    <>
-                      {mapping.type !== 'ManualNone' && (
-                        <ButtonText
-                          onClick={async () => {
-                            await onUpdate({
-                              groupKey,
-                              previousCandidate: candidate,
-                              previousMapping: mapping,
-                              sourceKey: mapping.sourceKey,
-                              type: 'ManualNone',
-                            });
-                          }}
-                        >
-                          No mapping
-                          <VisuallyHidden>
-                            {' '}
-                            for {mapping.source.label}
-                          </VisuallyHidden>
-                        </ButtonText>
-                      )}
-
-                      <ApiDataSetMappingModal
-                        candidate={candidate}
-                        candidateHint={candidateHint}
-                        groupKey={groupKey}
-                        itemLabel={itemLabel}
-                        mapping={mapping}
-                        newItems={newItems}
-                        renderSourceDetails={renderSourceDetails}
-                        onSubmit={onUpdate}
+                {!readOnly && (
+                  <td className="govuk-!-text-align-right">
+                    {isPendingUpdate ? (
+                      <LoadingSpinner
+                        alert
+                        hideText
+                        inline
+                        size="sm"
+                        text={`Updating mapping for ${mapping.source.label}`}
                       />
-                    </>
-                  )}
-                </td>
+                    ) : (
+                      <>
+                        {mapping.type !== 'ManualNone' && (
+                          <ButtonText
+                            onClick={async () => {
+                              await onUpdate({
+                                groupKey,
+                                previousCandidate: candidate,
+                                previousMapping: mapping,
+                                sourceKey: mapping.sourceKey,
+                                type: 'ManualNone',
+                              });
+                            }}
+                          >
+                            No mapping
+                            <VisuallyHidden>
+                              {' '}
+                              for {mapping.source.label}
+                            </VisuallyHidden>
+                          </ButtonText>
+                        )}
+
+                        <ApiDataSetMappingModal
+                          candidate={candidate}
+                          candidateHint={candidateHint}
+                          groupKey={groupKey}
+                          itemLabel={itemLabel}
+                          mapping={mapping}
+                          newItems={newItems}
+                          renderSourceDetails={renderSourceDetails}
+                          onSubmit={onUpdate}
+                        />
+                      </>
+                    )}
+                  </td>
+                )}
               </tr>
             );
           })}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetPreviewTokenCreateForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetPreviewTokenCreateForm.test.tsx
@@ -194,25 +194,34 @@ describe('ApiDataSetPreviewTokenCreateForm', () => {
   });
 
   test('shows validation error when start date is more than 7 days from current time', async () => {
-    const afterTodayBy8Days = addDays(new Date(), 8);
-    const afterTodayBy10Days = addDays(new Date(), 10);
+    jest.useFakeTimers({
+      advanceTimers: true,
+      now: new Date('2026-07-30T12:00:00Z'),
+    });
 
-    const handleSubmit = jest.fn();
+    try {
+      const afterTodayBy8Days = addDays(new Date(), 8);
+      const afterTodayBy10Days = addDays(new Date(), 10);
 
-    await renderWithCustomDatesSubmitted(
-      afterTodayBy8Days,
-      afterTodayBy10Days,
-      handleSubmit,
-    );
+      const handleSubmit = jest.fn();
 
-    expect(
-      await screen.findByText(
-        'Activates date must be within 7 days from today.',
-        {
-          selector: '#apiDataSetTokenCreateForm-activates-error',
-        },
-      ),
-    ).toBeInTheDocument();
+      await renderWithCustomDatesSubmitted(
+        afterTodayBy8Days,
+        afterTodayBy10Days,
+        handleSubmit,
+      );
+
+      expect(
+        await screen.findByText(
+          'Activates date must be within 7 days from today.',
+          {
+            selector: '#apiDataSetTokenCreateForm-activates-error',
+          },
+        ),
+      ).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('shows validation error when end date is beyond 7 days from the start date', async () => {

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -11,10 +11,7 @@ import { Dictionary } from '@common/types';
 import { LocationLevelKey } from '@common/utils/locationLevelsMap';
 
 export type MappingType =
-  | 'ManualMapped'
-  | 'ManualNone'
-  | 'AutoNone'
-  | 'AutoMapped';
+  'ManualMapped' | 'ManualNone' | 'AutoNone' | 'AutoMapped';
 
 export type Mapping<TSource> = {
   candidateKey?: string;

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -11,7 +11,10 @@ import { Dictionary } from '@common/types';
 import { LocationLevelKey } from '@common/utils/locationLevelsMap';
 
 export type MappingType =
-  'ManualMapped' | 'ManualNone' | 'AutoNone' | 'AutoMapped';
+  | 'ManualMapped'
+  | 'ManualNone'
+  | 'AutoNone'
+  | 'AutoMapped';
 
 export type Mapping<TSource> = {
   candidateKey?: string;
@@ -150,6 +153,11 @@ const apiDataSetVersionService = {
   },
   deleteVersion(dataSetVersionId: string): Promise<void> {
     return client.delete(`/public-data/data-set-versions/${dataSetVersionId}`);
+  },
+  unfinaliseVersion(dataSetVersionId: string): Promise<void> {
+    return client.post(
+      `/public-data/data-set-versions/${dataSetVersionId}/unfinalise`,
+    );
   },
   listVersions(
     params?: ListVersionsParams,

--- a/tests/robot-tests/tests/public_api/public_api_patch_replacement.robot
+++ b/tests/robot-tests/tests/public_api/public_api_patch_replacement.robot
@@ -372,7 +372,7 @@ Unfinalise the patch API data set version
     ${modal}=    user waits until modal is visible    Unfinalise this data set version
     user waits until parent contains element
     ...    ${modal}
-    ...    text:Unfinalising this data set version will return it to the mapping journey and allow you to edit its mappings again.
+    ...    text:Unfinalising this data set version will return it to the mapping step and allow you to edit its mappings again.
     user clicks button    Unfinalise data set version
     user waits until modal is not visible    Unfinalise this data set version
     user waits until h3 is visible    Draft version tasks

--- a/tests/robot-tests/tests/public_api/public_api_patch_replacement.robot
+++ b/tests/robot-tests/tests/public_api/public_api_patch_replacement.robot
@@ -104,7 +104,6 @@ Validate error summary for major versions is displayed on Api Data Set Details p
     user clicks link    go to the API data sets tab
     user waits until h2 is visible
     ...    This API data set can not be published because it has major changes that are not allowed.
-    user checks element is visible    testid:cancel-replacement-link
 
 Cancel data replacement which results in major API version
     user clicks link    Data and files
@@ -141,7 +140,6 @@ Validate error summary is displayed on Api Data Set Details page
     user clicks link    go to the API data sets tab
     user waits until h2 is visible
     ...    This API data set can not be published because location, filter or indicator mappings are not yet complete.
-    user checks element is visible    testid:cancel-replacement-link
 
 Validate the summary contents inside the 'Latest live version details' table
     user waits until h3 is visible    Latest live version details
@@ -368,6 +366,27 @@ Confirm finalization of this API data set version
     user waits for caches to expire
     user waits until h2 is visible    Mappings finalised
     user waits until page contains    Draft API data set version is ready to be published
+
+Unfinalise the patch API data set version
+    user clicks button    Unfinalise this data set version
+    ${modal}=    user waits until modal is visible    Unfinalise this data set version
+    user waits until parent contains element
+    ...    ${modal}
+    ...    text:Unfinalising this data set version will return it to the mapping journey and allow you to edit its mappings again.
+    user clicks button    Unfinalise data set version
+    user waits until modal is not visible    Unfinalise this data set version
+    user waits until h3 is visible    Draft version tasks
+    user waits until parent contains element    testid:map-locations-task    link:Map locations
+    user waits until parent contains element    testid:map-filters-task    link:Map filters
+    user waits until parent contains element    testid:map-indicators-task    link:Map indicators
+    user waits until page contains    Finalise this data set version
+
+Re-finalise the same patch API data set version
+    user clicks button    Finalise this data set version
+    user waits for caches to expire
+    user waits until h2 is visible    Mappings finalised
+    user waits until page contains    Draft API data set version is ready to be published
+    user waits until page contains    Unfinalise this data set version
 
 Verify that API summary tags have status OK and then press 'confirm data replacement'
     user clicks link    Back to API data sets


### PR DESCRIPTION
Adds support for "unfinalising" a finalised API data set versions, returning them from `Draft` to `Mapping` while preserving their mappings, source files, version identity, and preview tokens.

Unfinalising removes generated metadata and query artifacts so the version can be safely edited and finalised again. Mapping updates are now restricted to versions in `Mapping`/'unfinalised'. The admin journey distinguishes finalised and unfinalised versions using their status, mapping tasks, and finalise/unfinalise actions.