### PR TITLE
EES-7439 Add fallback to order Supporting files by name (title).

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
@@ -760,6 +760,51 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
+        public async Task WhenSupportingFilesHaveNoOrderDefined_ReturnsSupportingFilesInTitleOrder()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            var supportingFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Ancillary))
+                .WithReleaseVersion(releaseVersion)
+                .WithOrder(0) // All files have a default order of 0
+                .ForIndex(0, s => s.SetName("Supporting file B"))
+                .ForIndex(1, s => s.SetName("Supporting file C"))
+                .ForIndex(2, s => s.SetName("Supporting file A"))
+                .GenerateArray(3);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                context.ReleaseFiles.AddRange(supportingFiles);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(releaseVersion.Id);
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.Equal(3, result.SupportingFiles.Length);
+                Assert.Equal("Supporting file A", result.SupportingFiles[0].Title);
+                Assert.Equal("Supporting file B", result.SupportingFiles[1].Title);
+                Assert.Equal("Supporting file C", result.SupportingFiles[2].Title);
+            }
+        }
+
+        [Fact]
         public async Task WhenSupportingFileHasNoSummary_ReturnsEmptySummary()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/ReleaseDataContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/ReleaseDataContentService.cs
@@ -87,6 +87,7 @@ public class ReleaseDataContentService(ContentDbContext contentDbContext, IUserS
             .Where(rf => rf.ReleaseVersionId == releaseVersion.Id)
             .Where(rf => rf.File.Type == FileType.Ancillary)
             .OrderBy(rf => rf.Order)
+            .ThenBy(rf => rf.Name)
             .ToArrayAsync(cancellationToken);
         return releaseFiles.Select(ReleaseDataContentSupportingFileDto.FromReleaseFile).ToArray();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -633,6 +633,54 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
+        public async Task WhenSupportingFilesHaveNoOrderDefined_ReturnsSupportingFilesInTitleOrder()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            var supportingFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Ancillary))
+                .WithReleaseVersion(releaseVersion)
+                .WithOrder(0) // All files have a default order of 0
+                .ForIndex(0, s => s.SetName("Supporting file B"))
+                .ForIndex(1, s => s.SetName("Supporting file C"))
+                .ForIndex(2, s => s.SetName("Supporting file A"))
+                .GenerateArray(3);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                context.ReleaseFiles.AddRange(supportingFiles);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug
+                );
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.Equal(3, result.SupportingFiles.Length);
+                Assert.Equal("Supporting file A", result.SupportingFiles[0].Title);
+                Assert.Equal("Supporting file B", result.SupportingFiles[1].Title);
+                Assert.Equal("Supporting file C", result.SupportingFiles[2].Title);
+            }
+        }
+
+        [Fact]
         public async Task WhenSupportingFileHasNoSummary_ReturnsEmptySummary()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseDataContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseDataContentService.cs
@@ -99,6 +99,7 @@ public class ReleaseDataContentService(ContentDbContext contentDbContext) : IRel
             .Where(rf => rf.ReleaseVersionId == releaseVersion.Id)
             .Where(rf => rf.File.Type == FileType.Ancillary)
             .OrderBy(rf => rf.Order)
+            .ThenBy(rf => rf.Name)
             .ToArrayAsync(cancellationToken);
         return releaseFiles.Select(ReleaseDataContentSupportingFileDto.FromReleaseFile).ToArray();
     }


### PR DESCRIPTION
This PR adds a fallback to order Supporting files files by name (title) where they have the same order.

This is currently the case for all new and existing Supporting files because they have no `Order` value (defaults to 0).

Unlike the ability to order Data set files that was added by EES-2425, Supporting files cannot currently have a custom order.

<img width="476" height="413" alt="image" src="https://github.com/user-attachments/assets/6597289f-0ab5-461e-b9f9-f03aa2e3e5e9" />
