### PR TITLE
EES-7432 - migrating Key Vault to Core Infrastructure pipeline

### DIFF
--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -1,5 +1,5 @@
-@description('Resource prefix for legacy resources.')
-param legacyResourcePrefix string
+@description('Name of the Key Vault instance in which to store certificates.')
+param keyVaultName string
 
 @description('Name of the Azure Front Door instance.')
 param frontDoorName string
@@ -9,8 +9,6 @@ param siteHostName string
 
 @description('Name of the certificate.')
 param certificateName string
-
-var keyVaultName = '${legacyResourcePrefix}-kv-ees-01'
 
 resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorName

--- a/infrastructure/templates/common/components/front-door/frontDoor.bicep
+++ b/infrastructure/templates/common/components/front-door/frontDoor.bicep
@@ -6,8 +6,8 @@ import { FrontDoorCertificateType } from 'types.bicep'
 @description('Resource prefix for all resources.')
 param resourcePrefix string
 
-@description('Resource prefix for legacy resources.')
-param legacyResourcePrefix string
+@description('Name of the Key Vault instance in which to store certificates.')
+param keyVaultName string
 
 @description('Name of the resource.')
 param frontDoorProfileName string
@@ -120,7 +120,7 @@ resource origin 'Microsoft.Cdn/profiles/origingroups/origins@2025-04-15' = {
 module certificateModule 'byoCertificate.bicep' = if (certificateType == 'BringYourOwn') {
   name: 'certificateModuleDeploy'
   params: {
-    legacyResourcePrefix: legacyResourcePrefix
+    keyVaultName: keyVaultName
     frontDoorName: frontDoorProfileName
     siteHostName: siteHostName
     certificateName: certificateName!

--- a/infrastructure/templates/common/components/key-vault/keyVault.bicep
+++ b/infrastructure/templates/common/components/key-vault/keyVault.bicep
@@ -1,11 +1,11 @@
 @description('Specifies the name of the Key Vault')
 param keyVaultName string
 
-@description('Specifies the location for all resources.')
-param location string
+@description('Specifies the location for all resources. Defaults to the Resource Group location.')
+param location string = resourceGroup().location
 
-@description('Specifies the Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Get it by using Get-AzSubscription cmdlet.')
-param tenantId string
+@description('Specifies the Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Defaults to the Resource Group tenant.')
+param tenantId string = tenant().tenantId
 
 @description('Specifies whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault.')
 param enabledForDeployment bool = true
@@ -19,6 +19,9 @@ param enabledForTemplateDeployment bool = true
 @description('Specifies whether the key vault is a standard vault or a premium vault.')
 param skuName 'standard' | 'premium' = 'standard'
 
+@description('The number of days to retain deleted secrets and certificates. Defaults to 7 days.')
+param softDeleteRetentionInDays int = 7
+
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
@@ -29,9 +32,10 @@ resource keyvault 'Microsoft.KeyVault/vaults@2026-02-01' = {
     enabledForDeployment: enabledForDeployment
     enabledForDiskEncryption: enabledForDiskEncryption
     enabledForTemplateDeployment: enabledForTemplateDeployment
+    enablePurgeProtection: true
     tenantId: tenantId
     enableSoftDelete: true
-    softDeleteRetentionInDays: 7
+    softDeleteRetentionInDays: softDeleteRetentionInDays
     accessPolicies: []
     sku: {
       name: skuName

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -15,14 +15,14 @@ param subscription string
 @description('Resource prefix for all resources.')
 param resourcePrefix string
 
-@description('Resource prefix for legacy resources.')
-param legacyResourcePrefix string
-
 @description('URL of the public site.')
 param publicSiteUrl string
 
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
 param certificateType 'Provisioned' | 'BringYourOwn' = 'BringYourOwn'
+
+@description('Name of the Key Vault instance in which to store certificates.')
+param keyVaultName string
 
 @description('The Id of the Log Analytics Workspace.')
 param logAnalyticsWorkspaceId string
@@ -40,7 +40,7 @@ var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}
 
 var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
 
-var certificateName = '${legacyResourcePrefix}-as-ees-public-site-certificate'
+var certificateName = '${subscription}-as-ees-public-site-certificate'
 
 var nextJsRuleSetName = 'nextjsruleset'
 
@@ -49,7 +49,7 @@ module frontDoorModule '../../../common/components/front-door/frontDoor.bicep' =
   params: {
     frontDoorProfileName: frontDoorProfileName
     resourcePrefix: resourcePrefix
-    legacyResourcePrefix: legacyResourcePrefix
+    keyVaultName: keyVaultName
     siteHostName: publicSiteHostName
     originHostName: '${subscription}-as-ees-public-site.azurewebsites.net'
     customDomainName: '${resourcePrefix}-public-site-${abbreviations.frontDoorDomains}'

--- a/infrastructure/templates/core/application/keyVault/keyVault.bicep
+++ b/infrastructure/templates/core/application/keyVault/keyVault.bicep
@@ -1,0 +1,21 @@
+import { abbreviations } from '../../../common/abbreviations.bicep'
+
+@description('Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string
+
+@description('A set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+var keyVaultName = '${subscription}-${abbreviations.keyVaultVaults}-ees-01'
+
+module keyVaultModule '../../../common/components/key-vault/keyVault.bicep' = {
+  name: '${keyVaultName}ModuleDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    enabledForDiskEncryption: true
+    softDeleteRetentionInDays: 90
+    tagValues: tagValues
+  }
+}
+
+output keyVaultName string = keyVaultName 

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -56,16 +56,14 @@ var tagValues = union(resourceTags ?? {}, {
 })
 
 var resourcePrefix = '${subscription}-ees'
-var legacyResourcePrefix = subscription
 var publicApiResourcePrefix = '${subscription}-ees-papi'
 
 var resourceNames = {
   existingResources: {
     adminApp: '${subscription}-as-ees-admin'
-    keyVault: '${legacyResourcePrefix}-kv-ees-01'
     publicApiApp: '${publicApiResourcePrefix}-${abbreviations.appContainerApps}-api'
     publicApiDocsApp: '${publicApiResourcePrefix}-${abbreviations.staticWebApps}-docs'
-    publicSiteApp: '${legacyResourcePrefix}-as-ees-public-site'
+    publicSiteApp: '${subscription}-as-ees-public-site'
     publisherFunction: '${subscription}-${abbreviations.webSitesFunctions}-ees-publisher'
     vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
     alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
@@ -73,6 +71,14 @@ var resourceNames = {
       eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
       appGateway: '${resourcePrefix}-snet-${abbreviations.networkApplicationGateways}-01'
     }
+  }
+}
+
+module keyVaultModule 'application/keyVault/keyVault.bicep' = {
+  name: 'keyVaultModuleDeploy'
+  params: {
+    subscription: subscription
+    tagValues: tagValues
   }
 }
 
@@ -114,8 +120,8 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = {
   name: 'frontDoorModuleDeploy'
   params: {
     subscription: subscription
+    keyVaultName: keyVaultModule.outputs.keyVaultName
     resourcePrefix: resourcePrefix
-    legacyResourcePrefix: legacyResourcePrefix
     publicSiteUrl: publicSiteUrl
     certificateType: certificateType
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
@@ -131,7 +137,7 @@ module appGatewayModule 'application/applicationGateway/appGateway.bicep' = if (
     location: location
     subscription: subscription
     alertsGroupName: resourceNames.existingResources.alertsGroup
-    keyVaultName: resourceNames.existingResources.keyVault
+    keyVaultName: keyVaultModule.outputs.keyVaultName
     publicApiAppName: resourceNames.existingResources.publicApiApp
     publicApiDocsAppName: resourceNames.existingResources.publicApiDocsApp
     publicSiteAppServiceName: resourceNames.existingResources.publicSiteApp

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1490,7 +1490,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('dataAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
         "[variables('ees-storage-public')]"
       ],
       "properties": {
@@ -1726,7 +1725,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[variables('ees-storage-public')]"
       ],
       "properties": {
@@ -1959,7 +1957,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('adminAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[variables('ees-storage-core')]",
         "[variables('ees-storage-public')]",
         "[variables('ees-storage-publisher')]"
@@ -2454,6 +2451,17 @@
       ],
       "sku": {
         "name": "Standard_RAGRS"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "name": "[concat(variables('keyVaultName'), '/ees-storage-core')]",
+      "apiVersion": "2016-10-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('coreStorageAccountName'))]"
+      ],
+      "properties": {
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('coreStorageAccountName'), ';AccountKey=', listKeys(variables('coreStorageAccountId'),'2015-05-01-preview').key1)]"
       }
     },
     {
@@ -3479,6 +3487,17 @@
       }
     },
     {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "name": "[concat(variables('keyVaultName'), '/ees-storage-notifications')]",
+      "apiVersion": "2016-10-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('notificationsStorageAccountName'))]"
+      ],
+      "properties": {
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('notificationsStorageAccountName'), ';AccountKey=', listKeys(variables('notificationsStorageAccountId'),'2015-05-01-preview').key1)]"
+      }
+    },
+    {
       "name": "[variables('publicStorageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2023-05-01",
@@ -3526,6 +3545,17 @@
         "CreatedBy": "[parameters('createdBy')]",
         "DeploymentRepo": "[parameters('deploymentRepo')]",
         "DeploymentScript": "[parameters('deploymentScript')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "name": "[concat(variables('keyVaultName'), '/ees-storage-public')]",
+      "apiVersion": "2016-10-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('publicStorageAccountName'))]"
+      ],
+      "properties": {
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('publicStorageAccountName'), ';AccountKey=', listKeys(variables('publicStorageAccountId'),'2015-05-01-preview').key1)]"
       }
     },
     {
@@ -3724,7 +3754,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('notificationsAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[variables('ees-storage-notifications')]"
       ],
       "properties": {
@@ -3879,7 +3908,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('importerAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[variables('ees-storage-core')]"
       ],
       "properties": {
@@ -4035,7 +4063,6 @@
       "apiVersion": "2019-08-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[variables('ees-storage-core')]",
         "[variables('ees-storage-public')]",
         "[variables('ees-storage-notifications')]",
@@ -4137,6 +4164,17 @@
         "CreatedBy": "[parameters('createdBy')]",
         "DeploymentRepo": "[parameters('deploymentRepo')]",
         "DeploymentScript": "[parameters('deploymentScript')]"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/secrets",
+      "name": "[concat(variables('keyVaultName'), '/ees-storage-publisher')]",
+      "apiVersion": "2016-10-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('publisherStorageAccountName'))]"
+      ],
+      "properties": {
+        "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('publisherStorageAccountName'), ';AccountKey=', listKeys(variables('publisherStorageAccountId'),'2015-05-01-preview').key1)]"
       }
     },
     {
@@ -4586,90 +4624,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
         "[resourceId('Microsoft.Insights/actionGroups', variables('actionGroupAlerts'))]"
-      ]
-    },
-    {
-      "name": "[variables('keyVaultName')]",
-      "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2026-02-01",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "Key Vault",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "properties": {
-        "tenantId": "[subscription().tenantId]",
-        "sku": {
-          "family": "A",
-          "name": "Standard"
-        },
-        "enabledForDeployment": true,
-        "enabledForDiskEncryption": true,
-        "enabledForTemplateDeployment": true,
-        "enableSoftDelete": true,
-        "enablePurgeProtection": true,
-        "enableRbacAuthorization": true
-      },
-      "resources": [
-        {
-          "type": "secrets",
-          "name": "ees-storage-core",
-          "apiVersion": "2016-10-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
-            "[resourceId('Microsoft.Storage/storageAccounts', variables('coreStorageAccountName'))]"
-          ],
-          "properties": {
-            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('coreStorageAccountName'), ';AccountKey=', listKeys(variables('coreStorageAccountId'),'2015-05-01-preview').key1)]"
-          }
-        },
-        {
-          "type": "secrets",
-          "name": "ees-storage-notifications",
-          "apiVersion": "2016-10-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
-            "[resourceId('Microsoft.Storage/storageAccounts', variables('notificationsStorageAccountName'))]"
-          ],
-          "properties": {
-            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('notificationsStorageAccountName'), ';AccountKey=', listKeys(variables('notificationsStorageAccountId'),'2015-05-01-preview').key1)]"
-          }
-        },
-        {
-          "type": "secrets",
-          "name": "ees-storage-public",
-          "apiVersion": "2016-10-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
-            "[resourceId('Microsoft.Storage/storageAccounts', variables('publicStorageAccountName'))]"
-          ],
-          "properties": {
-            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('publicStorageAccountName'), ';AccountKey=', listKeys(variables('publicStorageAccountId'),'2015-05-01-preview').key1)]"
-          }
-        },
-        {
-          "type": "secrets",
-          "name": "ees-storage-publisher",
-          "apiVersion": "2016-10-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
-            "[resourceId('Microsoft.Storage/storageAccounts', variables('publisherStorageAccountName'))]"
-          ],
-          "properties": {
-            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('publisherStorageAccountName'), ';AccountKey=', listKeys(variables('publisherStorageAccountId'),'2015-05-01-preview').key1)]"
-          }
-        }
       ]
     },
     {
@@ -5028,10 +4983,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Insights/actionGroups",


### PR DESCRIPTION
This PR:
- moves Key Vault out of the ARM template and into Bicep, under the control of the Core Infrastructure pipeline.

The specific changes are:
- The Key Vault resource has moved out of the ARM template (and thus any "dependsOn" items that referenced KV in the ARM template have also gone).
- KV secrets that were originally child items of the KV resource template in the ARM template have now been moved to top-level resources and relocated to be next to the resources that they're reliant on for their secret values.
- KV has been added to the core infra pipeline.  It's not been made optional as its module outputs are needed, although if we externalised its name creation then we could make this optional.
- Stopped passing `subscription` / `legacyResourcePrefix` deep into Front Door components just so they can reconstruct Key Vault's name.  Instead, we now just pass the key vault name as a param.