### PR TITLE
EES-7432 - migrated VNet configuration from ARM to Bicep. Moved subne…

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -41,9 +41,6 @@
     "useSubnets": {
       "value": true
     },
-    "deploySubnets": {
-      "value": true
-    },
     "blobDeleteRetentionEnabled": {
       "value": true
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -38,9 +38,6 @@
     "useSubnets": {
       "value": true
     },
-    "deploySubnets": {
-      "value": true
-    },
     "autoscaleAppServices": {
       "value": false
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -41,9 +41,6 @@
     "useSubnets": {
       "value": true
     },
-    "deploySubnets": {
-      "value": true
-    },
     "autoscaleAppServices": {
       "value": true
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -35,9 +35,6 @@
     "useSubnets": {
       "value": true
     },
-    "deploySubnets": {
-      "value": true
-    },
     "domain": {
       "value": "test.explore-education-statistics.service.gov.uk"
     },

--- a/infrastructure/templates/common/components/virtual-network/subnet.bicep
+++ b/infrastructure/templates/common/components/virtual-network/subnet.bicep
@@ -1,0 +1,42 @@
+import { Subnet } from 'types.bicep'
+
+@description('Name of the owning VNet.')
+param vNetName string
+
+@description('Configuration for this subnet.')
+param config Subnet
+
+// Maintain a dictionary of simple delegation types to fully-formed config.
+var delegationDictionary = {
+  webapp: {
+    name: 'webapp'
+    properties: {
+      serviceName: 'Microsoft.Web/serverFarms'
+    }
+    type: 'Microsoft.Network/virtualNetworks/subnets/delegations'
+  }
+  environment: {
+    name: 'environment'
+    properties: {
+      serviceName: 'Microsoft.App/environments'
+    }
+    type: 'Microsoft.Network/virtualNetworks/subnets/delegations'
+  }
+}
+
+// Swap simple service endpoint names for fully-formed service endpoint config.
+var serviceEndpoints = map(config.properties.?serviceEndpoints ?? [], serviceEndpoint => {
+  service: serviceEndpoint
+})
+
+// Swap simple delegation names for fully-formed delegation config.
+var delegations = map(config.properties.?delegations ?? [], delegationType => delegationDictionary[delegationType])
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2025-07-01' = {
+  name: '${vNetName}/${config.name}'
+  properties: {
+    ...config.properties
+    serviceEndpoints: serviceEndpoints
+    delegations: delegations
+  }
+}

--- a/infrastructure/templates/common/components/virtual-network/types.bicep
+++ b/infrastructure/templates/common/components/virtual-network/types.bicep
@@ -1,0 +1,9 @@
+@export()
+type Subnet = {
+  name: string
+  properties: {
+    addressPrefix: string
+    serviceEndpoints: ('Microsoft.Sql' | 'Microsoft.Storage')[]?
+    delegations: ('webapp' | 'environment')[]?
+  }
+}

--- a/infrastructure/templates/common/components/virtual-network/virtual-network.bicep
+++ b/infrastructure/templates/common/components/virtual-network/virtual-network.bicep
@@ -1,0 +1,44 @@
+import { Subnet } from 'types.bicep'
+
+@description('Name of the VNet.')
+param vNetName string
+
+@description('Specifies the location for all resources. Defaults to the Resource Group location.')
+param location string = resourceGroup().location
+
+@description('Address space prefix e.g. 10.0.0.0/16.')
+param addressSpacePrefix string
+
+@description('Array of subnets.')
+param subnets Subnet[]?
+
+@description('A set of tags with which to tag the resource in Azure')
+param tagValues object
+
+resource vNet 'Microsoft.Network/virtualNetworks@2025-07-01' = {
+  name: vNetName
+  location: location
+  tags: tagValues
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressSpacePrefix
+      ]
+    }
+    privateEndpointVNetPolicies: 'Disabled'
+    virtualNetworkPeerings: []
+    enableDdosProtection: false
+  }
+}
+
+@batchSize(1)
+module subnetModules 'subnet.bicep' = [for subnet in (subnets ?? []): {
+  name: '${subnet.name}ModuleDeploy'
+  params: {
+    vNetName: vNetName
+    config: subnet
+  }
+  dependsOn: [
+    vNet
+  ]
+}]

--- a/infrastructure/templates/core/application/virtual-network/virtual-network.bicep
+++ b/infrastructure/templates/core/application/virtual-network/virtual-network.bicep
@@ -56,6 +56,8 @@ var searchStoragePrivateEndpointsSubnetName = '${generalSubnetNamePrefix}sa-sear
 
 // Analytics subnets. 
 var analyticsFunctionAppSubnetName = '${generalSubnetNamePrefix}fa-analytics'
+var analyticsStoragePrivateEndpointsSubnetName = '${generalSubnetNamePrefix}sa-anlyt-pep'
+    
 
 var subnets = deploySubnets ? [{
   name: adminSubnetName
@@ -187,7 +189,7 @@ var subnets = deploySubnets ? [{
   }
 }
 {
-  name: 's101d01-ees-${subnetAbbreviation}-sa-anlyt-pep'
+  name: analyticsStoragePrivateEndpointsSubnetName
   properties: {
     addressPrefix: '10.0.16.0/24'
   }

--- a/infrastructure/templates/core/application/virtual-network/virtual-network.bicep
+++ b/infrastructure/templates/core/application/virtual-network/virtual-network.bicep
@@ -1,0 +1,256 @@
+import { abbreviations } from '../../../common/abbreviations.bicep'
+
+@description('Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string
+
+@description('Whether or not to deploy the subnets.')
+param deploySubnets bool
+
+@description('A set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+var vNetName = '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
+
+var environment = 'ees'
+var subnetAbbreviation = abbreviations.networkVirtualNetworksSubnets
+
+// TODO EES-7502 - we have a number of different naming conventions for subnets.
+// Handle as part of the overall naming convention alignment.
+var generalSubnetNamePrefix = '${subscription}-${environment}-${subnetAbbreviation}-'
+var legacySubnetNamePrefix = '${subscription}-${subnetAbbreviation}-${environment}-'
+var publicApiSubnetNamePrefix = '${subscription}-${environment}-papi-${subnetAbbreviation}-'
+var screenerSubnetNamePrefix = '${subscription}-${environment}-sapi-${subnetAbbreviation}-'
+
+// Core shared infrastructure subnets.
+var applicationGatewaySubnetName = '${generalSubnetNamePrefix}agw-01'
+var eventGridCustomTopicPrivateEndpointsSubnetName = '${generalSubnetNamePrefix}evgt-pep'
+
+// Core application subnets. 
+var adminSubnetName = '${legacySubnetNamePrefix}admin'
+var importerSubnetName = '${legacySubnetNamePrefix}importer'
+var publisherSubnetName = '${legacySubnetNamePrefix}publisher'
+var notifySubnetName = '${legacySubnetNamePrefix}notify'
+var contentSubnetName = '${legacySubnetNamePrefix}content'
+var dataSubnetName = '${legacySubnetNamePrefix}data'
+var sqlServerPrivateEndpointsSubnetName = '${generalSubnetNamePrefix}sqlsvr-pep'
+
+// Screener subnets. 
+var screenerFunctionAppSubnetName = '${screenerSubnetNamePrefix}fa-screener'
+var screenerStoragePrivateEndpointsSubnetName = '${screenerSubnetNamePrefix}sa-screener-pep'
+
+// Public API subnets. 
+var publicApiDataProcessorSubnetName = '${publicApiSubnetNamePrefix}fa-processor'
+var publicApiDataProcessorPrivateEndpointsSubnetName = '${publicApiSubnetNamePrefix}fa-processor-pep'
+var publicApiStoragePrivateEndpointsSubnetName = '${publicApiSubnetNamePrefix}sa-pep'
+var containerAppEnvironmentSubnetName = '${generalSubnetNamePrefix}cae-01'
+var psqlFlexibleServerSubnetName = '${generalSubnetNamePrefix}psql-flexibleserver'
+
+// NL Search subnets. 
+var nlSearchFunctionAppSubnetName = '${generalSubnetNamePrefix}fa-nlsearch'
+var nlSearchFunctionAppPrivateEndpointsSubnetName = '${generalSubnetNamePrefix}fa-nlsearch-pep'
+
+// Search subnets. 
+var searchDocsFunctionAppSubnetName = '${generalSubnetNamePrefix}fa-searchdocs'
+var searchDocsFunctionAppPrivateEndpointsSubnetName = '${generalSubnetNamePrefix}fa-searchdocs-pep'
+var searchStoragePrivateEndpointsSubnetName = '${generalSubnetNamePrefix}sa-search-pep'
+
+// Analytics subnets. 
+var analyticsFunctionAppSubnetName = '${generalSubnetNamePrefix}fa-analytics'
+
+var subnets = deploySubnets ? [{
+  name: adminSubnetName
+  properties: {
+    addressPrefix: '10.0.0.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: importerSubnetName
+  properties: {
+    addressPrefix: '10.0.1.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: publisherSubnetName
+  properties: {
+    addressPrefix: '10.0.2.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: notifySubnetName
+  properties: {
+    addressPrefix: '10.0.3.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: contentSubnetName
+  properties: {
+    addressPrefix: '10.0.4.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: dataSubnetName
+  properties: {
+    addressPrefix: '10.0.5.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: publicApiDataProcessorSubnetName
+  properties: {
+    addressPrefix: '10.0.6.0/24'
+    serviceEndpoints: [
+      'Microsoft.Sql'
+      'Microsoft.Storage'
+    ]
+    delegations: ['webapp']
+  }
+}
+{
+  name: publicApiDataProcessorPrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.7.0/24'
+  }
+}
+{
+  name: containerAppEnvironmentSubnetName
+  properties: {
+    addressPrefix: '10.0.8.0/23'
+    serviceEndpoints: ['Microsoft.Storage']
+    delegations: ['environment']
+  }
+}
+{
+  name: applicationGatewaySubnetName
+  properties: {
+    addressPrefix: '10.0.10.0/24'
+  }
+}
+{
+  name: publicApiStoragePrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.11.0/24'
+  }
+}
+{
+  name: psqlFlexibleServerSubnetName
+  properties: {
+    addressPrefix: '10.0.12.0/24'
+  }
+}
+{
+  name: searchStoragePrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.13.0/24'
+  }
+}
+{
+  name: searchDocsFunctionAppSubnetName
+  properties: {
+    addressPrefix: '10.0.14.0/24'
+    serviceEndpoints: ['Microsoft.Storage']
+    delegations: ['webapp']
+  }
+}
+{
+  name: searchDocsFunctionAppPrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.15.0/24'
+  }
+}
+{
+  name: 's101d01-ees-${subnetAbbreviation}-sa-anlyt-pep'
+  properties: {
+    addressPrefix: '10.0.16.0/24'
+  }
+}
+{
+  name: analyticsFunctionAppSubnetName
+  properties: {
+    addressPrefix: '10.0.17.0/24'
+    serviceEndpoints: ['Microsoft.Storage']
+    delegations: ['webapp']
+  }
+}
+{
+  name: screenerStoragePrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.18.0/24'
+  }
+}
+{
+  name: screenerFunctionAppSubnetName
+  properties: {
+    addressPrefix: '10.0.19.0/24'
+    serviceEndpoints: ['Microsoft.Storage']
+    delegations: ['webapp']
+  }
+}
+{
+  name: eventGridCustomTopicPrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.20.0/24'
+  }
+}
+{
+  name: nlSearchFunctionAppPrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.21.0/24'
+  }
+}
+{
+  name: nlSearchFunctionAppSubnetName
+  properties: {
+    addressPrefix: '10.0.22.0/24'
+    serviceEndpoints: ['Microsoft.Storage']
+    delegations: ['webapp']
+  }
+}
+{
+  name: sqlServerPrivateEndpointsSubnetName
+  properties: {
+    addressPrefix: '10.0.23.0/24'
+  }
+}] : null
+
+module vNetModule '../../../common/components/virtual-network/virtual-network.bicep' = {
+  name: '${vNetName}ModuleDeploy'
+  params: {
+    vNetName: vNetName
+    addressSpacePrefix: '10.0.0.0/16'
+    subnets: subnets
+    tagValues: tagValues
+  }
+}
+
+output vNetName string = vNetName 
+output eventGridCustomTopicPrivateEndpointsSubnetName string = eventGridCustomTopicPrivateEndpointsSubnetName
+output applicationGatewaySubnetName string = applicationGatewaySubnetName

--- a/infrastructure/templates/core/ci/azure-pipelines.yml
+++ b/infrastructure/templates/core/ci/azure-pipelines.yml
@@ -12,6 +12,20 @@ trigger:
 pr: none
 
 parameters:
+  - name: deploySubnets
+    displayName: Do subnets need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
+  - name: deployAzureFrontDoor
+    displayName: Does Azure Front Door need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
   - name: deployApplicationGateway
     displayName: Does Application Gateway need creating or updating?
     type: string
@@ -50,6 +64,10 @@ variables:
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
     value: ubuntu-latest
+  - name: deploySubnets
+    value: ${{ iif(eq(parameters.deploySubnets, 'Yes'), true, false) }}
+  - name: deployAzureFrontDoor
+    value: ${{ iif(eq(parameters.deployAzureFrontDoor, 'Yes'), true, false) }}
   - name: deployApplicationGateway
     value: ${{ iif(eq(parameters.deployApplicationGateway, 'Yes'), true, false) }}
   - name: deployAlerts

--- a/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
@@ -29,6 +29,8 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deploySubnets: false
+                deployAzureFrontDoor: false
                 deployApplicationGateway: false
                 deployAlerts: false
 
@@ -38,5 +40,7 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deploySubnets: $(deploySubnets)
+                deployAzureFrontDoor: $(deployAzureFrontDoor)
                 deployApplicationGateway: $(deployApplicationGateway)
                 deployAlerts: $(deployAlerts)

--- a/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
@@ -11,6 +11,10 @@ parameters:
     type: string
   - name: parameterFile
     type: string
+  - name: deploySubnets
+    type: string
+  - name: deployAzureFrontDoor
+    type: string
   - name: deployApplicationGateway
     type: string
   - name: deployAlerts
@@ -35,6 +39,8 @@ steps:
           --parameters \
               subscription='$(subscription)' \
               publicSiteUrl='$(publicSiteUrl)' \
+              deploySubnets=${{ parameters.deploySubnets }} \
+              deployAzureFrontDoor=${{ parameters.deployAzureFrontDoor }} \
               deployApplicationGateway=${{ parameters.deployApplicationGateway }} \
               deployAlerts=${{ parameters.deployAlerts }} \
               resourceTags='$(resourceTags)'

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -28,7 +28,13 @@ param certificateType FrontDoorCertificateType = 'BringYourOwn'
 @description('Whether or not to create role assignments necessary for performing certain backup actions.')
 param deployBackupVaultReaderRoleAssignment bool = true
 
-@description('Whether or not to deploy Application Gateway and its confirmation.')
+@description('Whether or not to deploy subnets.')
+param deploySubnets bool = false
+
+@description('Whether or not to deploy Azure Front Door.')
+param deployAzureFrontDoor bool = false
+
+@description('Whether or not to deploy Application Gateway and its configuration.')
 param deployApplicationGateway bool = false
 
 @description('The minimum average response time from the public site (via Azure Front Door) before latency alerts fire.')
@@ -65,12 +71,16 @@ var resourceNames = {
     publicApiDocsApp: '${publicApiResourcePrefix}-${abbreviations.staticWebApps}-docs'
     publicSiteApp: '${subscription}-as-ees-public-site'
     publisherFunction: '${subscription}-${abbreviations.webSitesFunctions}-ees-publisher'
-    vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
     alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
-    subnets: {
-      eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
-      appGateway: '${resourcePrefix}-snet-${abbreviations.networkApplicationGateways}-01'
-    }
+  }
+}
+
+module vNetModule 'application/virtual-network/virtual-network.bicep' = {
+  name: 'vNetModuleDeploy'
+  params: {
+    subscription: subscription
+    deploySubnets: deploySubnets
+    tagValues: tagValues
   }
 }
 
@@ -106,9 +116,9 @@ module eventMessagingModule 'application/eventMessaging/eventMessaging.bicep' = 
       adminApp: resourceNames.existingResources.adminApp
       alertsGroup: resourceNames.existingResources.alertsGroup
       publisherFunction: resourceNames.existingResources.publisherFunction
-      vNet: resourceNames.existingResources.vNet
+      vNet: vNetModule.outputs.vNetName
       subnets: {
-        eventGridCustomTopicPrivateEndpoints: resourceNames.existingResources.subnets.eventGridCustomTopicPrivateEndpoints
+        eventGridCustomTopicPrivateEndpoints: vNetModule.outputs.eventGridCustomTopicPrivateEndpointsSubnetName
       }
     }
     deployAlerts: deployAlerts
@@ -116,7 +126,7 @@ module eventMessagingModule 'application/eventMessaging/eventMessaging.bicep' = 
   }
 }
 
-module frontDoorModule 'application/frontDoor/frontDoor.bicep' = {
+module frontDoorModule 'application/frontDoor/frontDoor.bicep' = if (deployAzureFrontDoor) {
   name: 'frontDoorModuleDeploy'
   params: {
     subscription: subscription
@@ -141,7 +151,7 @@ module appGatewayModule 'application/applicationGateway/appGateway.bicep' = if (
     publicApiAppName: resourceNames.existingResources.publicApiApp
     publicApiDocsAppName: resourceNames.existingResources.publicApiDocsApp
     publicSiteAppServiceName: resourceNames.existingResources.publicSiteApp
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vNetModule.outputs.vNetName
     publicApiAppGatewayFqdn: publicApiApplicationGatewayFqdn
     publicApiPublicUrl: publicApiPublicUrl
     publicSiteFqdn: replace(publicSiteUrl, 'https://', '')

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -455,10 +455,6 @@
       "type": "bool",
       "defaultValue": true
     },
-    "deploySubnets": {
-      "type": "bool",
-      "defaultValue": true
-    },
     "backupVaultAzureBlobsRegistrationsDeployed": {
       "type": "bool",
       "defaultValue": true,
@@ -1236,8 +1232,6 @@
     "vNetRef": "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]",
     "adminSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-admin')]",
     "adminSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('adminSubnetName'))]",
-    "analyticsFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-analytics')]",
-    "analyticsStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-anlyt-pep')]",
     "importerSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-importer')]",
     "importerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('importerSubnetName'))]",
     "publisherSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-publisher')]",
@@ -1250,22 +1244,10 @@
     "dataSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('dataSubnetName'))]",
     "publicApiDataProcessorSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor')]",
     "publicApiDataProcessorSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('publicApiDataProcessorSubnetName'))]",
-    "publicApiDataProcessorPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor-pep')]",
-    "publicApiStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-sa-pep')]",
-    "nlSearchFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-nlsearch')]",
-    "nlSearchFunctionAppPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-nlsearch-pep')]",
-    "searchDocsFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs')]",
-    "searchDocsFunctionAppPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs-pep')]",
-    "searchStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-search-pep')]",
     "sqlServerPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sqlsvr-pep')]",
     "sqlServerPrivateEndpointsSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('sqlServerPrivateEndpointsSubnetName'))]",
-    "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
-    "eventGridCustomTopicPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-evgt-pep')]",
-    "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
-    "psqlFlexibleServerSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-psql-flexibleserver')]",
     "screenerFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-snet-fa-screener')]",
     "screenerFunctionAppSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('screenerFunctionAppSubnetName'))]",
-    "screenerStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-snet-sa-screener-pep')]",
     "sqlAllowedSubnets": [
       {
         "name": "admin",
@@ -1440,8 +1422,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('dataAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('dataAppName'))]"
           ]
         }
       ],
@@ -1579,8 +1560,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites/slots', variables('dataAppName'), parameters('deploySlotName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites/slots', variables('dataAppName'), parameters('deploySlotName'))]"
           ]
         }
       ],
@@ -1675,8 +1655,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
           ]
         }
       ],
@@ -1809,8 +1788,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites/slots', variables('contentAppName'), parameters('deploySlotName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites/slots', variables('contentAppName'), parameters('deploySlotName'))]"
           ]
         }
       ],
@@ -1905,8 +1883,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('adminAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('adminAppName'))]"
           ]
         }
       ],
@@ -2065,8 +2042,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites/slots', variables('adminAppName'), parameters('deploySlotName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites/slots', variables('adminAppName'), parameters('deploySlotName'))]"
           ]
         }
       ],
@@ -2446,9 +2422,6 @@
         "DeploymentRepo": "[parameters('deploymentRepo')]",
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
-      "dependsOn": [
-        "[variables('vNetRef')]"
-      ],
       "sku": {
         "name": "Standard_RAGRS"
       }
@@ -3009,8 +2982,7 @@
         "ignoreMissingVnetServiceEndpoint": false
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]",
-        "[variables('vNetRef')]"
+        "[resourceId('Microsoft.Sql/servers', variables('coreSqlServerName'))]"
       ],
       "copy": {
         "name": "networkRuleLoop",
@@ -3328,8 +3300,7 @@
         "ignoreMissingVnetServiceEndpoint": false
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]",
-        "[variables('vNetRef')]"
+        "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]"
       ],
       "copy": {
         "name": "networkRuleLoop",
@@ -3715,8 +3686,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('notificationsAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('notificationsAppName'))]"
           ]
         }
       ],
@@ -3866,8 +3836,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('importerAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('importerAppName'))]"
           ]
         }
       ],
@@ -4017,8 +3986,7 @@
             "swiftSupported": true
           },
           "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
-            "[variables('vNetRef')]"
+            "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]"
           ]
         }
       ],
@@ -4218,368 +4186,6 @@
         "CreatedBy": "[parameters('createdBy')]",
         "DeploymentRepo": "[parameters('deploymentRepo')]",
         "DeploymentScript": "[parameters('deploymentScript')]"
-      }
-    },
-    {
-      "condition": "[parameters('deploySubnets')]",
-      "apiVersion": "2020-05-01",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('vNetName')]",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "Virtual network",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "10.0.0.0/16"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('adminSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.0.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('importerSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.1.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('publisherSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.2.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('notifySubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.3.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('contentSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.4.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('dataSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.5.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms",
-                    "actions": [
-                      "Microsoft.Network/virtualNetworks/subnets/action"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('publicApiDataProcessorSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.6.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Sql"
-                },
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('publicApiDataProcessorPrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.7.0/24"
-            }
-          },
-          {
-            "name": "[variables('containerAppEnvironmentSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.8.0/23",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "environment",
-                  "properties": {
-                    "serviceName": "Microsoft.App/environments"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('applicationGatewaySubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.10.0/24"
-            }
-          },
-          {
-            "name": "[variables('publicApiStoragePrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.11.0/24"
-            }
-          },
-          {
-            "name": "[variables('psqlFlexibleServerSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.12.0/24"
-            }
-          },
-          {
-            "name": "[variables('searchStoragePrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.13.0/24"
-            }
-          },
-          {
-            "name": "[variables('searchDocsFunctionAppSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.14.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('searchDocsFunctionAppPrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.15.0/24"
-            }
-          },
-          {
-            "name": "[variables('analyticsStoragePrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.16.0/24"
-            }
-          },
-          {
-            "name": "[variables('analyticsFunctionAppSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.17.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('screenerStoragePrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.18.0/24"
-            }
-          },
-          {
-            "name": "[variables('screenerFunctionAppSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.19.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('eventGridCustomTopicPrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.20.0/24"
-            }
-          },
-          {
-            "name": "[variables('nlSearchFunctionAppPrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.21.0/24"
-            }
-          },
-          {
-            "name": "[variables('nlSearchFunctionAppSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.22.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
-              "delegations": [
-                {
-                  "name": "webapp",
-                  "properties": {
-                    "serviceName": "Microsoft.Web/serverFarms"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "[variables('sqlServerPrivateEndpointsSubnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.23.0/24"
-            }
-          }
-        ]
       }
     },
     {


### PR DESCRIPTION
This PR:
- moves the VNet out of the ARM template and into Bicep, under the control of the Core Infrastructure pipeline.
- adds additional deploy flags to speed up general Core Infra deploys.

## Cleaning up the ARM template

The VNet resource is now no longer in the ARM template, and thus subnet name variables have been removed where possible.  Those remaining are still in use to create their subnet ref variables which are still used in places in the ARM template.

The "deploySubnets" parameter has also been removed.

## Top-level subnet resource creation

As part of this migration, subnets have been moved to be top-level resources rather than using the "subnets" property on the VNet resource, and so should in theory now be able to be created and maintained separately from the VNet definition itself.

This means that in the future we could co-locate subnet creation and maintenance alongside the services that actually use them if this is what we want to do, rather than manage in a central location. 