### PR TITLE
EES-7512/EES-7513 - Published releases now reuse an existing cached all-files ZIP regardless of age. 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -980,10 +980,11 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_CachedAllFilesZip()
+    public async Task ZipFilesToStream_NoFileIds_CachedPublishedAllFilesZipDoesNotExpire()
     {
         ReleaseVersion releaseVersion = _dataFixture
             .DefaultReleaseVersion()
+            .WithPublished(DateTimeOffset.UtcNow.AddDays(-1))
             .WithRelease(
                 _dataFixture
                     .DefaultRelease()
@@ -1010,7 +1011,7 @@ public class ReleaseFileServiceTests : IDisposable
                 path: allFilesZipPath,
                 contentType: "application/zip",
                 contentLength: 1000L,
-                updated: DateTimeOffset.UtcNow.AddMinutes(-5)
+                updated: DateTimeOffset.UtcNow.AddHours(-2)
             )
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -982,9 +982,11 @@ public class ReleaseFileServiceTests : IDisposable
     [Fact]
     public async Task ZipFilesToStream_NoFileIds_CachedPublishedAllFilesZipDoesNotExpire()
     {
+        var now = DateTimeOffset.UtcNow;
+
         ReleaseVersion releaseVersion = _dataFixture
             .DefaultReleaseVersion()
-            .WithPublished(DateTimeOffset.UtcNow.AddDays(-1))
+            .WithPublished(now.AddDays(-1))
             .WithRelease(
                 _dataFixture
                     .DefaultRelease()
@@ -1011,7 +1013,7 @@ public class ReleaseFileServiceTests : IDisposable
                 path: allFilesZipPath,
                 contentType: "application/zip",
                 contentLength: 1000L,
-                updated: DateTimeOffset.UtcNow.AddHours(-2)
+                updated: now.AddHours(-2)
             )
         );
 
@@ -1057,6 +1059,104 @@ public class ReleaseFileServiceTests : IDisposable
             await using var zip = File.OpenRead(path);
             Assert.Equal("Test cached all files zip", zip.ReadToEnd());
         }
+    }
+
+    [Fact]
+    public async Task ZipFilesToStream_NoFileIds_AmendmentZipCachedBeforePublicationIsRegenerated()
+    {
+        var published = DateTimeOffset.UtcNow.AddHours(-1);
+
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithVersion(1)
+            .WithPreviousVersionId(Guid.NewGuid())
+            .WithPublished(published)
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+
+        var allFilesZipPath = releaseVersion.AllFilesZipPath();
+
+        // The amendment zip was cached while it was still a draft.
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: "application/zip",
+                contentLength: 1000L,
+                updated: published.AddMinutes(-1)
+            )
+        );
+
+        publicBlobStorageService
+            .Setup(s =>
+                s.UploadStream(
+                    PublicReleaseFiles,
+                    allFilesZipPath,
+                    It.IsAny<Stream>(),
+                    MediaTypeNames.Application.Zip,
+                    null,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+
+        var request = new CaptureZipDownloadRequest
+        {
+            PublicationName = releaseVersion.Release.Publication.Title,
+            ReleaseVersionId = releaseVersion.Id,
+            ReleaseName = releaseVersion.Release.Title,
+            ReleaseLabel = releaseVersion.Release.Label,
+            FromPage = AnalyticsFromPage.DataCatalogue,
+        };
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        analyticsManager
+            .Setup(m => m.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var serviceDbContext = InMemoryContentDbContext(contentDbContextId);
+        var path = GenerateZipFilePath();
+        await using var stream = File.OpenWrite(path);
+
+        var service = SetupReleaseFileService(
+            contentDbContext: serviceDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object
+        );
+
+        var result = await service.ZipFilesToStream(
+            releaseVersionId: releaseVersion.Id,
+            fromPage: AnalyticsFromPage.DataCatalogue,
+            outputStream: stream
+        );
+
+        result.AssertRight();
+
+        publicBlobStorageService.Verify(
+            s =>
+                s.UploadStream(
+                    PublicReleaseFiles,
+                    allFilesZipPath,
+                    It.IsAny<Stream>(),
+                    MediaTypeNames.Application.Zip,
+                    null,
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -173,29 +173,38 @@ public class ReleaseFileService(
         // but this a chunk of work to get working properly as piping
         // the cached file to target stream isn't super trivial.
         // For now, we'll just do this manually as it's way easier.
-        var cacheIsFresh =
-            releaseVersion.Published is not null
-            || allFilesZip?.Updated?.AddSeconds(AllFilesZipTtl) >= DateTimeOffset.UtcNow;
-
-        if (allFilesZip is not null && cacheIsFresh)
+        if (allFilesZip?.Updated is null)
         {
-            var streamResult = await publicBlobStorageService.GetDownloadStream(
-                containerName: PublicReleaseFiles,
-                path: path,
-                cancellationToken: cancellationToken
-            );
-
-            if (streamResult.IsLeft)
-            {
-                return false;
-            }
-
-            await using var blobStream = streamResult.Right;
-            await blobStream.CopyToAsync(outputStream, cancellationToken);
-            return true;
+            return false;
         }
 
-        return false;
+        if (releaseVersion.Published is not null && allFilesZip.Updated < releaseVersion.Published)
+        {
+            return false;
+        }
+
+        if (
+            releaseVersion.Published is null
+            && allFilesZip.Updated.Value.AddSeconds(AllFilesZipTtl) < DateTimeOffset.UtcNow
+        )
+        {
+            return false;
+        }
+
+        var streamResult = await publicBlobStorageService.GetDownloadStream(
+            containerName: PublicReleaseFiles,
+            path: path,
+            cancellationToken: cancellationToken
+        );
+
+        if (streamResult.IsLeft)
+        {
+            return false;
+        }
+
+        await using var blobStream = streamResult.Right;
+        await blobStream.CopyToAsync(outputStream, cancellationToken);
+        return true;
     }
 
     private async Task ZipAllFilesToStream(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -173,7 +173,11 @@ public class ReleaseFileService(
         // but this a chunk of work to get working properly as piping
         // the cached file to target stream isn't super trivial.
         // For now, we'll just do this manually as it's way easier.
-        if (allFilesZip?.Updated is not null && allFilesZip.Updated.Value.AddSeconds(AllFilesZipTtl) >= DateTime.UtcNow)
+        var cacheIsFresh =
+            releaseVersion.Published is not null
+            || allFilesZip?.Updated?.AddSeconds(AllFilesZipTtl) >= DateTimeOffset.UtcNow;
+
+        if (allFilesZip is not null && cacheIsFresh)
         {
             var streamResult = await publicBlobStorageService.GetDownloadStream(
                 containerName: PublicReleaseFiles,


### PR DESCRIPTION
## Summary

Updates all-files ZIP caching so published releases reuse an existing cached ZIP regardless of its age.

Published release files should no longer change, so expiring and regenerating their cached ZIPs adds unnecessary processing and blob-storage activity. Draft releases retain the existing one-hour cache expiry because their files may still change.

## Changes

- Treat an existing all-files ZIP for a published release as permanently fresh.
- Continue applying the one-hour TTL to unpublished releases.
- Rename and update the cached ZIP test to verify that a two-hour-old ZIP is reused for a published release.
- Retain the existing stale-cache coverage for unpublished releases.
