### PR TITLE
EES-7507 Update ees-screener-api's docker container environment to set default `AzureWebJobsStorage` connection string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     environment:
       - STORAGE_URL=http://data-storage:10000/devstoreaccount1
       - STORAGE_CONTAINER_NAME=releases-temp
+      - AzureWebJobsStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;
       - AzureWebJobs_StartScreening=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;
       - LOG_DIR=/tmp
       - DD_CHECKS=FALSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: explore-education-statistics
+
 services:
   data-storage:
     image: mcr.microsoft.com/azure-storage/azurite:3.35.0
@@ -69,5 +71,6 @@ services:
       - DD_CHECKS=FALSE
       - LOG_SCREENING_RESULTS=TRUE
       - CONCURRENT_R_WORKERS=4
+
 volumes:
   data-storage-data:


### PR DESCRIPTION
This PR is being made in conjunction with https://github.com/dfe-analytical-services/ees-screener-api/pull/34 in the [ees-screener-api repo](https://github.com/dfe-analytical-services/ees-screener-api). That PR updates the screener's docker container to use the .NET 10 Azure Functions Isolated base image.

This PR updates the ees-screener-api's docker container environment to set the default `AzureWebJobsStorage` connection string, fixing the error 'Unable to create client for AzureWebJobsStorage' seen in the logs.

> [dataScreener]       [Tag=''] Process reporting unhealthy: Unhealthy. Health check entries are {"azure.functions.web_host.lifecycle":{"status":"Healthy","description":null},"azure.functions.script_host.lifecycle":{"status":"Healthy","description":null},"azure.functions.webjobs.storage":{"status":"Unhealthy","description":"Unable to create client for AzureWebJobsStorage"}}

### Other changes

- Give the Compose project the name `explore-education-statistics` to avoid differences seen between our local environments, such as having different default network names. Without a project name it was previously inherited from the parent directory name. My checkout directory name was `ees`, so my default network name based on the project name was `ees_default`. This was a different network name to the one mentioned in the `docker run` command in the [ees-screener-api's README](https://github.com/dfe-analytical-services/ees-screener-api/blob/407570ec5e7b2efc4634226b9d50dba1e48a59d5/README.md). Thanks to @mmyoungman for spotting this.