### PR TITLE
EES-7281 Add backend endpoints to update filter mappings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataSetMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataSetMappingControllerTests.cs
@@ -1,0 +1,89 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api;
+
+public abstract class DataSetMappingControllerTests
+{
+    public class UpdateFilterMappingsTests : DataSetMappingControllerTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var releaseVersionId = Guid.NewGuid();
+            var request = new FilterMappingUpdatesRequest
+            {
+                OriginalDataFileId = Guid.NewGuid(),
+                ReplacementDataFileId = Guid.NewGuid(),
+                FilterUpdates = [],
+                FilterGroupUpdates = [],
+                FilterItemUpdates = [],
+            };
+
+            var expectedDto = new FiltersMappingDto
+            {
+                Filters = [],
+                FilterGroups = [],
+                FilterItems = [],
+            };
+
+            var dataSetMappingService = new Mock<IDataSetMappingService>(MockBehavior.Strict);
+
+            dataSetMappingService
+                .Setup(s => s.UpdateFilterMappings(releaseVersionId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedDto);
+
+            var controller = BuildController(dataSetMappingService: dataSetMappingService.Object);
+
+            var result = await controller.UpdateFilterMappings(
+                releaseVersionId: releaseVersionId,
+                request: request,
+                cancellationToken: default
+            );
+
+            MockUtils.VerifyAllMocks(dataSetMappingService);
+
+            var returnedDto = result.AssertOkResult();
+            Assert.Equal(expectedDto, returnedDto);
+        }
+
+        [Fact]
+        public async Task ValidationProblem()
+        {
+            var releaseVersionId = Guid.NewGuid();
+            var request = new FilterMappingUpdatesRequest();
+
+            var dataSetMappingService = new Mock<IDataSetMappingService>(MockBehavior.Strict);
+
+            dataSetMappingService
+                .Setup(s => s.UpdateFilterMappings(releaseVersionId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new NotFoundResult());
+
+            var controller = BuildController(dataSetMappingService: dataSetMappingService.Object);
+
+            var result = await controller.UpdateFilterMappings(
+                releaseVersionId: releaseVersionId,
+                request: request,
+                cancellationToken: default
+            );
+
+            MockUtils.VerifyAllMocks(dataSetMappingService);
+
+            result.AssertNotFoundResult();
+        }
+    }
+
+    private static DataSetMappingController BuildController(IDataSetMappingService? dataSetMappingService = null)
+    {
+        return new DataSetMappingController(
+            dataSetMappingService ?? Mock.Of<IDataSetMappingService>(MockBehavior.Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
@@ -14,6 +14,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 public class DataSetMappingServicePermissionTests
 {
     [Fact]
+    public async Task UpdateFilterMappings()
+    {
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+
+        await PermissionTestUtils
+            .PolicyCheckBuilder<SecurityPolicies>()
+            .SetupResourceCheckToFail(releaseVersion, SecurityPolicies.CanUpdateSpecificReleaseVersion)
+            .AssertForbidden(userService =>
+            {
+                var service = SetupDataSetMappingService(
+                    contentDbContext: contentDbContext,
+                    userService: userService.Object
+                );
+                return service.UpdateFilterMappings(
+                    releaseVersion.Id,
+                    new FilterMappingUpdatesRequest(),
+                    CancellationToken.None
+                );
+            });
+    }
+
+    [Fact]
     public async Task UpdateIndicatorMapping()
     {
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -186,13 +186,13 @@ public class DataSetMappingServiceTests
 
             Assert.Multiple(
                 () => Assert.Equal("replacement_indicator_4", originalIndicator1Mapping.ReplacementColumnName),
-                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator1Mapping.Status),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator1Mapping.Status),
                 () => Assert.Equal("replacement_indicator_5", originalIndicator2Mapping.ReplacementColumnName),
-                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator2Mapping.Status),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator2Mapping.Status),
                 () => Assert.Null(originalIndicator3Mapping.ReplacementColumnName),
-                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator3Mapping.Status),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator3Mapping.Status),
                 () => Assert.Equal("replacement_indicator_3", originalIndicator4Mapping.ReplacementColumnName),
-                () => Assert.Equal(nameof(MapStatus.AutoSet), originalIndicator4Mapping.Status)
+                () => Assert.Equal(MapStatus.AutoSet, originalIndicator4Mapping.Status)
             );
         }
 
@@ -665,8 +665,8 @@ public class DataSetMappingServiceTests
                     ReplacementDataFileId = replacementDataFileId,
                     Updates =
                     [
-                        new() { OriginalLocationId = loc1Id, NewReplacementLocationId = replacementLocId },
-                        new() { OriginalLocationId = loc2Id, NewReplacementLocationId = null },
+                        new() { OriginalId = loc1Id, NewReplacementId = replacementLocId },
+                        new() { OriginalId = loc2Id, NewReplacementId = null },
                     ],
                 },
                 CancellationToken.None
@@ -677,15 +677,15 @@ public class DataSetMappingServiceTests
 
             var map1 = locationMappingList.Single(m => m.OriginalId == loc1Id);
             Assert.Equal(replacementLocId, map1.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), map1.Status);
+            Assert.Equal(MapStatus.ManuallySet, map1.Status);
 
             var map2 = locationMappingList.Single(m => m.OriginalId == loc2Id);
             Assert.Null(map2.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), map2.Status);
+            Assert.Equal(MapStatus.ManuallySet, map2.Status);
 
             var map3 = locationMappingList.Single(m => m.OriginalId == loc3Id);
             Assert.Equal(loc3ReplacementId, map3.ReplacementId);
-            Assert.Equal(nameof(MapStatus.Unset), map3.Status);
+            Assert.Equal(MapStatus.Unset, map3.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -879,14 +879,14 @@ public class DataSetMappingServiceTests
                 {
                     OriginalDataFileId = originalDataFileId,
                     ReplacementDataFileId = replacementDataFileId,
-                    Updates = [new() { OriginalLocationId = badId }],
+                    Updates = [new() { OriginalId = badId }],
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.OriginalLocationId)}",
+                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
                 "LocationMatchingOriginalIdNameNotFound"
             );
         }
@@ -943,14 +943,14 @@ public class DataSetMappingServiceTests
                 {
                     OriginalDataFileId = originalDataFileId,
                     ReplacementDataFileId = replacementDataFileId,
-                    Updates = [new() { OriginalLocationId = locId, NewReplacementLocationId = Guid.NewGuid() }],
+                    Updates = [new() { OriginalId = locId, NewReplacementId = Guid.NewGuid() }],
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.NewReplacementLocationId)}",
+                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                 "UnmappedLocationMatchingReplacementLocationIdNotFound"
             );
         }
@@ -1012,14 +1012,14 @@ public class DataSetMappingServiceTests
                 {
                     OriginalDataFileId = originalDataFileId,
                     ReplacementDataFileId = replacementDataFileId,
-                    Updates = [new() { OriginalLocationId = locId, NewReplacementLocationId = replacementLocId }],
+                    Updates = [new() { OriginalId = locId, NewReplacementId = replacementLocId }],
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.NewReplacementLocationId)}",
+                $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                 "UnmappedLocationHasDifferentGeographicLevelAsOriginalLocation"
             );
         }
@@ -1206,11 +1206,11 @@ public class DataSetMappingServiceTests
             var filter1Dto = dto.Filters.Single(f => f.OriginalId == originalFilter1Id);
             Assert.Equal(replacementFilter1Id, filter1Dto.ReplacementId);
             Assert.Equal("Replacement filter 1", filter1Dto.ReplacementLabel);
-            Assert.Equal(nameof(MapStatus.ManuallySet), filter1Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, filter1Dto.Status);
 
             var filter2Dto = dto.Filters.Single(f => f.OriginalId == originalFilter2Id);
             Assert.Null(filter2Dto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), filter2Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, filter2Dto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1397,7 +1397,7 @@ public class DataSetMappingServiceTests
             Assert.Equal(newReplacementFilterId, filterDto.ReplacementId);
             Assert.Equal("New replacement filter", filterDto.ReplacementLabel);
             Assert.Equal("new_replacement_filter", filterDto.ReplacementColumnName);
-            Assert.Equal(nameof(MapStatus.ManuallySet), filterDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, filterDto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1972,11 +1972,11 @@ public class DataSetMappingServiceTests
             var group1Dto = dto.FilterGroups.Single(g => g.OriginalId == originalFilterGroup1Id);
             Assert.Equal(newReplacementFilterGroup1Id, group1Dto.ReplacementId);
             Assert.Equal("New replacement filter group 1", group1Dto.ReplacementLabel);
-            Assert.Equal(nameof(MapStatus.ManuallySet), group1Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, group1Dto.Status);
 
             var group2Dto = dto.FilterGroups.Single(g => g.OriginalId == originalFilterGroup2Id);
             Assert.Null(group2Dto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), group2Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, group2Dto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2134,7 +2134,7 @@ public class DataSetMappingServiceTests
             var groupDto = Assert.Single(dto.FilterGroups);
             Assert.Equal(newReplacementFilterGroup1Id, groupDto.ReplacementId);
             Assert.Equal("New replacement filter group 1", groupDto.ReplacementLabel);
-            Assert.Equal(nameof(MapStatus.ManuallySet), groupDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, groupDto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2438,11 +2438,11 @@ public class DataSetMappingServiceTests
             var item1Dto = dto.FilterItems.Single(i => i.OriginalId == originalFilterItem1Id);
             Assert.Equal(newReplacementFilterItem1Id, item1Dto.ReplacementId);
             Assert.Equal("New replacement filter item 1", item1Dto.ReplacementLabel);
-            Assert.Equal(nameof(MapStatus.ManuallySet), item1Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, item1Dto.Status);
 
             var item2Dto = dto.FilterItems.Single(i => i.OriginalId == originalFilterItem2Id);
             Assert.Null(item2Dto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), item2Dto.Status);
+            Assert.Equal(MapStatus.ManuallySet, item2Dto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2579,7 +2579,7 @@ public class DataSetMappingServiceTests
             var itemDto = Assert.Single(dto.FilterItems);
             Assert.Equal(newReplacementFilterItem1Id, itemDto.ReplacementId);
             Assert.Equal("New replacement filter item 1", itemDto.ReplacementLabel);
-            Assert.Equal(nameof(MapStatus.ManuallySet), itemDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, itemDto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2887,15 +2887,15 @@ public class DataSetMappingServiceTests
             var dto = result.AssertRight();
             var filterDto = Assert.Single(dto.Filters);
             Assert.Equal(replacementFilterId, filterDto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), filterDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, filterDto.Status);
 
             var groupDto = Assert.Single(dto.FilterGroups);
             Assert.Equal(replacementFilterGroupId, groupDto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), groupDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, groupDto.Status);
 
             var itemDto = Assert.Single(dto.FilterItems);
             Assert.Equal(replacementFilterItemId, itemDto.ReplacementId);
-            Assert.Equal(nameof(MapStatus.ManuallySet), itemDto.Status);
+            Assert.Equal(MapStatus.ManuallySet, itemDto.Status);
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -562,8 +562,7 @@ public class DataSetMappingServiceTests
 
             validationProblem.AssertHasError(
                 expectedPath: "Updates.NewReplacementId",
-                expectedCode: "UnmappedIndicatorMatchingReplacementIdNotFound",
-                expectedMessage: $"No available unmapped indicator matching replacement id \"{replacementIndicatorAlreadyMappedId}\""
+                expectedCode: "UnmappedIndicatorMatchingReplacementIdNotFound"
             );
         }
     }
@@ -1023,6 +1022,1900 @@ public class DataSetMappingServiceTests
                 $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.NewReplacementLocationId)}",
                 "UnmappedLocationHasDifferentGeographicLevelAsOriginalLocation"
             );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var originalFilter1Id = Guid.NewGuid();
+        var originalFilter1Group1Id = Guid.NewGuid();
+        var originalFilter1Group1Item1Id = Guid.NewGuid();
+
+        var originalFilter2Id = Guid.NewGuid();
+        var originalFilter2Group1Id = Guid.NewGuid();
+        var originalFilter2Group1Item1Id = Guid.NewGuid();
+
+        var replacementFilter1Id = Guid.NewGuid();
+        var replacementFilter1Group1Id = Guid.NewGuid();
+        var replacementFilter1Group1Item1Id = Guid.NewGuid();
+
+        var previouslyMappedReplacementFilter2Id = Guid.NewGuid();
+        var previouslyMappedReplacementFilter2Group1Id = Guid.NewGuid();
+        var previouslyMappedReplacementFilter2Group1Item1Id = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilter1Id,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilter1Id,
+                        OriginalLabel = "Original filter 1",
+                        OriginalColumnName = "original_filter_1",
+                        Status = MapStatus.Unset,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilter1Group1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilter1Group1Id,
+                                    OriginalLabel = "Original filter 1 group 1",
+                                    Status = MapStatus.ParentNotMapped,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilter1Group1Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilter1Group1Item1Id,
+                                                OriginalLabel = "Original filter 1 group 1 item 1",
+                                                Status = MapStatus.ParentNotMapped,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+                {
+                    originalFilter2Id,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilter2Id,
+                        OriginalLabel = "Original filter 2",
+                        OriginalColumnName = "original_filter_2",
+                        ReplacementId = previouslyMappedReplacementFilter2Id,
+                        ReplacementLabel = "Replacement filter 2",
+                        ReplacementColumnName = "replacement_filter_2",
+                        Status = MapStatus.AutoSet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilter2Group1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilter2Group1Id,
+                                    OriginalLabel = "Original filter 2 group 1",
+                                    ReplacementId = previouslyMappedReplacementFilter2Group1Id,
+                                    ReplacementLabel = "Replacement filter 2 group 1",
+                                    Status = MapStatus.AutoSet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilter2Group1Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilter2Group1Item1Id,
+                                                OriginalLabel = "Original filter 2 group 1 item 1",
+                                                ReplacementId = previouslyMappedReplacementFilter2Group1Item1Id,
+                                                ReplacementLabel = "Replacement filter 2 group 1 item 1",
+                                                Status = MapStatus.AutoSet,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters =
+            [
+                new UnmappedFilter
+                {
+                    Id = replacementFilter1Id,
+                    Label = "Replacement filter 1",
+                    ColumnName = "replacement_filter_1",
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = replacementFilter1Group1Id,
+                            Label = "Original filter 1 group 1",
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem
+                                {
+                                    Id = replacementFilter1Group1Item1Id,
+                                    Label = "Original filter 1 group 1 item 1",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates =
+                    [
+                        new() { OriginalId = originalFilter1Id, NewReplacementId = replacementFilter1Id },
+                        new() { OriginalId = originalFilter2Id, NewReplacementId = null },
+                    ],
+                    FilterGroupUpdates = [],
+                    FilterItemUpdates = [],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            Assert.Equal(2, dto.Filters.Count);
+            Assert.Empty(dto.FilterGroups);
+            Assert.Empty(dto.FilterItems);
+
+            var filter1Dto = dto.Filters.Single(f => f.OriginalId == originalFilter1Id);
+            Assert.Equal(replacementFilter1Id, filter1Dto.ReplacementId);
+            Assert.Equal("Replacement filter 1", filter1Dto.ReplacementLabel);
+            Assert.Equal(nameof(MapStatus.ManuallySet), filter1Dto.Status);
+
+            var filter2Dto = dto.Filters.Single(f => f.OriginalId == originalFilter2Id);
+            Assert.Null(filter2Dto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), filter2Dto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+
+            var filter1 = dbMapping.FilterMappings[originalFilter1Id];
+            Assert.Equal(replacementFilter1Id, filter1.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, filter1.Status);
+
+            var filter1Group1 = filter1.FilterGroupMappings[originalFilter1Group1Id];
+            Assert.Equal(replacementFilter1Group1Id, filter1Group1.ReplacementId);
+            Assert.Equal(MapStatus.AutoSet, filter1Group1.Status);
+
+            var filter1Group1Item1 = filter1Group1.FilterItemMappings[originalFilter1Group1Item1Id];
+            Assert.Equal(replacementFilter1Group1Item1Id, filter1Group1Item1.ReplacementId);
+            Assert.Equal(MapStatus.AutoSet, filter1Group1Item1.Status);
+
+            var filter2 = dbMapping.FilterMappings[originalFilter2Id];
+            Assert.Null(filter2.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, filter2.Status);
+
+            var filter2Group1 = filter2.FilterGroupMappings[originalFilter2Group1Id];
+            Assert.Null(filter2Group1.ReplacementId);
+            Assert.Equal(MapStatus.ParentNotMapped, filter2Group1.Status);
+
+            var filter2Group1Item1 = filter2Group1.FilterItemMappings[originalFilter2Group1Item1Id];
+            Assert.Null(filter2Group1Item1.ReplacementId);
+            Assert.Equal(MapStatus.ParentNotMapped, filter2Group1Item1.Status);
+
+            Assert.Single(dbMapping.UnmappedReplacementFilters);
+            var newlyUnmappedFilter = dbMapping.UnmappedReplacementFilters.Single();
+            Assert.Equal(previouslyMappedReplacementFilter2Id, newlyUnmappedFilter.Id);
+            Assert.Equal("Replacement filter 2", newlyUnmappedFilter.Label);
+            var newlyUnmappedGroup = Assert.Single(newlyUnmappedFilter.UnmappedReplacementFilterGroups);
+            Assert.Equal(previouslyMappedReplacementFilter2Group1Id, newlyUnmappedGroup.Id);
+            Assert.Single(newlyUnmappedGroup.UnmappedReplacementFilterItems);
+            Assert.Equal(
+                previouslyMappedReplacementFilter2Group1Item1Id,
+                newlyUnmappedGroup.UnmappedReplacementFilterItems.Single().Id
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_ChangeExistingReplacementFilter_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroup1Id = Guid.NewGuid();
+        var originalFilterGroup1Item1Id = Guid.NewGuid();
+
+        var oldReplacementFilterId = Guid.NewGuid();
+        var oldReplacementFilterGroup1Id = Guid.NewGuid();
+        var oldReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var newReplacementFilterId = Guid.NewGuid();
+        var newReplacementFilterGroup1Id = Guid.NewGuid();
+        var newReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter",
+                        OriginalColumnName = "original_filter",
+                        ReplacementId = oldReplacementFilterId,
+                        ReplacementLabel = "Old replacement filter",
+                        ReplacementColumnName = "old_replacement_filter",
+                        Status = MapStatus.ManuallySet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroup1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroup1Id,
+                                    OriginalLabel = "Original filter group 1",
+                                    ReplacementId = oldReplacementFilterGroup1Id,
+                                    ReplacementLabel = "Old replacement filter group 1",
+                                    Status = MapStatus.AutoSet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterGroup1Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterGroup1Item1Id,
+                                                OriginalLabel = "Original filter group 1 item 1",
+                                                ReplacementId = oldReplacementFilterGroup1Item1Id,
+                                                ReplacementLabel = "Old replacement filter group 1 item 1",
+                                                Status = MapStatus.AutoSet,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters =
+            [
+                new UnmappedFilter
+                {
+                    Id = newReplacementFilterId,
+                    Label = "New replacement filter",
+                    ColumnName = "new_replacement_filter",
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = newReplacementFilterGroup1Id,
+                            Label = "Original filter group 1",
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem
+                                {
+                                    Id = newReplacementFilterGroup1Item1Id,
+                                    Label = "Original filter group 1 item 1",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates =
+                    [
+                        new() { OriginalId = originalFilterId, NewReplacementId = newReplacementFilterId },
+                    ],
+                    FilterGroupUpdates = [],
+                    FilterItemUpdates = [],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            Assert.Single(dto.Filters);
+
+            var filterDto = dto.Filters.Single();
+            Assert.Equal(originalFilterId, filterDto.OriginalId);
+            Assert.Equal(newReplacementFilterId, filterDto.ReplacementId);
+            Assert.Equal("New replacement filter", filterDto.ReplacementLabel);
+            Assert.Equal("new_replacement_filter", filterDto.ReplacementColumnName);
+            Assert.Equal(nameof(MapStatus.ManuallySet), filterDto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+
+            var filter = dbMapping.FilterMappings[originalFilterId];
+            Assert.Equal(newReplacementFilterId, filter.ReplacementId);
+            Assert.Equal("New replacement filter", filter.ReplacementLabel);
+            Assert.Equal("new_replacement_filter", filter.ReplacementColumnName);
+            Assert.Equal(MapStatus.ManuallySet, filter.Status);
+
+            var group1 = filter.FilterGroupMappings[originalFilterGroup1Id];
+            Assert.Equal(newReplacementFilterGroup1Id, group1.ReplacementId);
+            Assert.Equal("Original filter group 1", group1.ReplacementLabel);
+            Assert.Equal(MapStatus.AutoSet, group1.Status);
+
+            var item1 = group1.FilterItemMappings[originalFilterGroup1Item1Id];
+            Assert.Equal(newReplacementFilterGroup1Item1Id, item1.ReplacementId);
+            Assert.Equal("Original filter group 1 item 1", item1.ReplacementLabel);
+            Assert.Equal(MapStatus.AutoSet, item1.Status);
+
+            Assert.Single(dbMapping.UnmappedReplacementFilters);
+            var unmappedFilter = dbMapping.UnmappedReplacementFilters.Single();
+            Assert.Equal(oldReplacementFilterId, unmappedFilter.Id);
+            Assert.Equal("Old replacement filter", unmappedFilter.Label);
+            Assert.Equal("old_replacement_filter", unmappedFilter.ColumnName);
+
+            var unmappedGroup = Assert.Single(unmappedFilter.UnmappedReplacementFilterGroups);
+            Assert.Equal(oldReplacementFilterGroup1Id, unmappedGroup.Id);
+            Assert.Equal("Old replacement filter group 1", unmappedGroup.Label);
+
+            var unmappedItem = Assert.Single(unmappedGroup.UnmappedReplacementFilterItems);
+            Assert.Equal(oldReplacementFilterGroup1Item1Id, unmappedItem.Id);
+            Assert.Equal("Old replacement filter group 1 item 1", unmappedItem.Label);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_NoReleaseVersion_NotFound()
+    {
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+
+        var service = SetupDataSetMappingService(contentDbContext);
+        var result = await service.UpdateFilterMappings(
+            Guid.NewGuid(),
+            new FilterMappingUpdatesRequest(),
+            CancellationToken.None
+        );
+
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_NoDataSetMapping_NotFound()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>(),
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = Guid.NewGuid(),
+                    FilterUpdates = [],
+                },
+                CancellationToken.None
+            );
+
+            result.AssertNotFound();
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_OriginalFilterNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var filterDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>(),
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates = [new() { OriginalId = filterDoesNotExistId, NewReplacementId = null }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                expectedCode: "FilterMatchingOriginalIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_UnmappedReplacementFilterNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var replacementFilterDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping { OriginalId = originalFilterId }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates =
+                    [
+                        new() { OriginalId = originalFilterId, NewReplacementId = replacementFilterDoesNotExistId },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                expectedCode: "UnmappedFilterMatchingReplacementIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_FilterGroupParentNotMapped_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalGroupId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        Status = MapStatus.Unset,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupId,
+                                    Status = MapStatus.ParentNotMapped,
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterGroupUpdates = [new() { OriginalId = originalGroupId, NewReplacementId = Guid.NewGuid() }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                expectedCode: "FilterGroupParentNotMapped"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_FilterItemParentNotMapped_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalGroupId = Guid.NewGuid();
+        var originalItemId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        Status = MapStatus.Unset,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalGroupId,
+                                    Status = MapStatus.ParentNotMapped,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalItemId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalItemId,
+                                                Status = MapStatus.ParentNotMapped,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterItemUpdates = [new() { OriginalId = originalItemId, NewReplacementId = Guid.NewGuid() }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                expectedCode: "FilterItemParentNotMapped"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_FilterGroup_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroup1Id = Guid.NewGuid();
+        var originalFilterGroup1Item1Id = Guid.NewGuid();
+
+        var originalFilterGroup2Id = Guid.NewGuid();
+        var originalFilterGroup2Item1Id = Guid.NewGuid();
+
+        var replacementFilterId = Guid.NewGuid();
+        var newReplacementFilterGroup1Id = Guid.NewGuid();
+        var newReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var oldReplacementFilterGroup2Id = Guid.NewGuid();
+        var oldReplacementFilterGroup2Item1Id = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter",
+                        ReplacementId = replacementFilterId,
+                        ReplacementLabel = "Replacement filter",
+                        Status = MapStatus.AutoSet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroup1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroup1Id,
+                                    OriginalLabel = "Original filter group 1",
+                                    Status = MapStatus.Unset,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterGroup1Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterGroup1Item1Id,
+                                                OriginalLabel = "Original filter group 1 item 1",
+                                                Status = MapStatus.ParentNotMapped,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                            {
+                                originalFilterGroup2Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroup2Id,
+                                    OriginalLabel = "Original filter group 2",
+                                    ReplacementId = oldReplacementFilterGroup2Id,
+                                    ReplacementLabel = "Old replacement filter group 2",
+                                    Status = MapStatus.AutoSet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterGroup2Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterGroup2Item1Id,
+                                                OriginalLabel = "Original filter group 2 item 1",
+                                                ReplacementId = oldReplacementFilterGroup2Item1Id,
+                                                ReplacementLabel = "Old replacement filter group 2 item 1",
+                                                Status = MapStatus.AutoSet,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                        UnmappedReplacementFilterGroups =
+                        [
+                            new UnmappedFilterGroup
+                            {
+                                Id = newReplacementFilterGroup1Id,
+                                Label = "New replacement filter group 1",
+                                UnmappedReplacementFilterItems =
+                                [
+                                    new UnmappedFilterItem
+                                    {
+                                        Id = newReplacementFilterGroup1Item1Id,
+                                        Label = "Original filter group 1 item 1",
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates = [],
+                    FilterGroupUpdates =
+                    [
+                        new() { OriginalId = originalFilterGroup1Id, NewReplacementId = newReplacementFilterGroup1Id },
+                        new() { OriginalId = originalFilterGroup2Id, NewReplacementId = null },
+                    ],
+                    FilterItemUpdates = [],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            Assert.Empty(dto.Filters);
+            Assert.Equal(2, dto.FilterGroups.Count);
+            Assert.Empty(dto.FilterItems);
+
+            var group1Dto = dto.FilterGroups.Single(g => g.OriginalId == originalFilterGroup1Id);
+            Assert.Equal(newReplacementFilterGroup1Id, group1Dto.ReplacementId);
+            Assert.Equal("New replacement filter group 1", group1Dto.ReplacementLabel);
+            Assert.Equal(nameof(MapStatus.ManuallySet), group1Dto.Status);
+
+            var group2Dto = dto.FilterGroups.Single(g => g.OriginalId == originalFilterGroup2Id);
+            Assert.Null(group2Dto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), group2Dto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var filter = dbMapping.FilterMappings[originalFilterId];
+
+            var group1 = filter.FilterGroupMappings[originalFilterGroup1Id];
+            Assert.Equal(newReplacementFilterGroup1Id, group1.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, group1.Status);
+            var item1 = group1.FilterItemMappings[originalFilterGroup1Item1Id];
+            Assert.Equal(newReplacementFilterGroup1Item1Id, item1.ReplacementId);
+            Assert.Equal(MapStatus.AutoSet, item1.Status);
+
+            var group2 = filter.FilterGroupMappings[originalFilterGroup2Id];
+            Assert.Null(group2.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, group2.Status);
+            var group2Item1 = group2.FilterItemMappings[originalFilterGroup2Item1Id];
+            Assert.Null(group2Item1.ReplacementId);
+            Assert.Equal(MapStatus.ParentNotMapped, group2Item1.Status);
+
+            Assert.Single(filter.UnmappedReplacementFilterGroups);
+            var newlyUnmappedGroup = filter.UnmappedReplacementFilterGroups.Single();
+            Assert.Equal(oldReplacementFilterGroup2Id, newlyUnmappedGroup.Id);
+            Assert.Equal("Old replacement filter group 2", newlyUnmappedGroup.Label);
+            Assert.Single(newlyUnmappedGroup.UnmappedReplacementFilterItems);
+            Assert.Equal(
+                oldReplacementFilterGroup2Item1Id,
+                newlyUnmappedGroup.UnmappedReplacementFilterItems.Single().Id
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_ChangeExistingReplacementFilterGroup_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroup1Id = Guid.NewGuid();
+        var originalFilterGroup1Item1Id = Guid.NewGuid();
+
+        var oldReplacementFilterGroup1Id = Guid.NewGuid();
+        var oldReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var newReplacementFilterGroup1Id = Guid.NewGuid();
+        var newReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter",
+                        ReplacementId = Guid.NewGuid(),
+                        ReplacementLabel = "Replacement filter",
+                        Status = MapStatus.AutoSet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroup1Id,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroup1Id,
+                                    OriginalLabel = "Original filter group 1",
+                                    ReplacementId = oldReplacementFilterGroup1Id,
+                                    ReplacementLabel = "Old replacement filter group 1",
+                                    Status = MapStatus.ManuallySet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterGroup1Item1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterGroup1Item1Id,
+                                                OriginalLabel = "Original filter group 1 item 1",
+                                                ReplacementId = oldReplacementFilterGroup1Item1Id,
+                                                ReplacementLabel = "Old replacement filter group 1 item 1",
+                                                Status = MapStatus.AutoSet,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                        UnmappedReplacementFilterGroups =
+                        [
+                            new UnmappedFilterGroup
+                            {
+                                Id = newReplacementFilterGroup1Id,
+                                Label = "New replacement filter group 1",
+                                UnmappedReplacementFilterItems =
+                                [
+                                    new UnmappedFilterItem
+                                    {
+                                        Id = newReplacementFilterGroup1Item1Id,
+                                        Label = "Original filter group 1 item 1",
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterGroupUpdates =
+                    [
+                        new() { OriginalId = originalFilterGroup1Id, NewReplacementId = newReplacementFilterGroup1Id },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            var groupDto = Assert.Single(dto.FilterGroups);
+            Assert.Equal(newReplacementFilterGroup1Id, groupDto.ReplacementId);
+            Assert.Equal("New replacement filter group 1", groupDto.ReplacementLabel);
+            Assert.Equal(nameof(MapStatus.ManuallySet), groupDto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var filter = dbMapping.FilterMappings[originalFilterId];
+
+            var group1 = filter.FilterGroupMappings[originalFilterGroup1Id];
+            Assert.Equal(newReplacementFilterGroup1Id, group1.ReplacementId);
+            Assert.Equal("New replacement filter group 1", group1.ReplacementLabel);
+            Assert.Equal(MapStatus.ManuallySet, group1.Status);
+
+            var item1 = group1.FilterItemMappings[originalFilterGroup1Item1Id];
+            Assert.Equal(newReplacementFilterGroup1Item1Id, item1.ReplacementId);
+            Assert.Equal(MapStatus.AutoSet, item1.Status);
+
+            Assert.Single(filter.UnmappedReplacementFilterGroups);
+            var unmappedGroup = filter.UnmappedReplacementFilterGroups.Single();
+            Assert.Equal(oldReplacementFilterGroup1Id, unmappedGroup.Id);
+            Assert.Equal("Old replacement filter group 1", unmappedGroup.Label);
+            Assert.Single(unmappedGroup.UnmappedReplacementFilterItems);
+            Assert.Equal(oldReplacementFilterGroup1Item1Id, unmappedGroup.UnmappedReplacementFilterItems.Single().Id);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_OriginalFilterGroupNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var groupDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>(),
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterGroupUpdates = [new() { OriginalId = groupDoesNotExistId, NewReplacementId = null }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                expectedCode: "FilterGroupMatchingOriginalIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_UnmappedReplacementFilterGroupNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroupId = Guid.NewGuid();
+        var replacementGroupDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        Status = MapStatus.AutoSet,
+                        ReplacementId = Guid.NewGuid(),
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroupId,
+                                new FilterGroupMapping { OriginalId = originalFilterGroupId, Status = MapStatus.Unset }
+                            },
+                        },
+                        UnmappedReplacementFilterGroups = [],
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterGroupUpdates =
+                    [
+                        new() { OriginalId = originalFilterGroupId, NewReplacementId = replacementGroupDoesNotExistId },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                expectedCode: "UnmappedFilterGroupMatchingReplacementIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_FilterItem_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroupId = Guid.NewGuid();
+        var originalFilterItem1Id = Guid.NewGuid();
+        var originalFilterItem2Id = Guid.NewGuid();
+
+        var replacementFilterId = Guid.NewGuid();
+        var replacementFilterGroupId = Guid.NewGuid();
+        var newReplacementFilterItem1Id = Guid.NewGuid();
+        var oldReplacementFilterItem2Id = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter",
+                        ReplacementId = replacementFilterId,
+                        ReplacementLabel = "Replacement filter",
+                        Status = MapStatus.AutoSet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroupId,
+                                    OriginalLabel = "Original filter group",
+                                    ReplacementId = replacementFilterGroupId,
+                                    ReplacementLabel = "Replacement filter group",
+                                    Status = MapStatus.AutoSet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterItem1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterItem1Id,
+                                                OriginalLabel = "Original filter item 1",
+                                                Status = MapStatus.Unset,
+                                            }
+                                        },
+                                        {
+                                            originalFilterItem2Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterItem2Id,
+                                                OriginalLabel = "Original filter item 2",
+                                                ReplacementId = oldReplacementFilterItem2Id,
+                                                ReplacementLabel = "Old replacement filter item 2",
+                                                Status = MapStatus.AutoSet,
+                                            }
+                                        },
+                                    },
+                                    UnmappedReplacementFilterItems =
+                                    [
+                                        new UnmappedFilterItem
+                                        {
+                                            Id = newReplacementFilterItem1Id,
+                                            Label = "New replacement filter item 1",
+                                        },
+                                    ],
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates = [],
+                    FilterGroupUpdates = [],
+                    FilterItemUpdates =
+                    [
+                        new() { OriginalId = originalFilterItem1Id, NewReplacementId = newReplacementFilterItem1Id },
+                        new() { OriginalId = originalFilterItem2Id, NewReplacementId = null },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            Assert.Empty(dto.Filters);
+            Assert.Empty(dto.FilterGroups);
+            Assert.Equal(2, dto.FilterItems.Count);
+
+            var item1Dto = dto.FilterItems.Single(i => i.OriginalId == originalFilterItem1Id);
+            Assert.Equal(newReplacementFilterItem1Id, item1Dto.ReplacementId);
+            Assert.Equal("New replacement filter item 1", item1Dto.ReplacementLabel);
+            Assert.Equal(nameof(MapStatus.ManuallySet), item1Dto.Status);
+
+            var item2Dto = dto.FilterItems.Single(i => i.OriginalId == originalFilterItem2Id);
+            Assert.Null(item2Dto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), item2Dto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var filter = dbMapping.FilterMappings[originalFilterId];
+            var group = filter.FilterGroupMappings[originalFilterGroupId];
+
+            var item1 = group.FilterItemMappings[originalFilterItem1Id];
+            Assert.Equal(newReplacementFilterItem1Id, item1.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, item1.Status);
+
+            var item2 = group.FilterItemMappings[originalFilterItem2Id];
+            Assert.Null(item2.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, item2.Status);
+
+            Assert.Single(group.UnmappedReplacementFilterItems);
+            var newlyUnmappedItem = group.UnmappedReplacementFilterItems.Single();
+            Assert.Equal(oldReplacementFilterItem2Id, newlyUnmappedItem.Id);
+            Assert.Equal("Old replacement filter item 2", newlyUnmappedItem.Label);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_ChangeExistingReplacementFilterItem_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroupId = Guid.NewGuid();
+        var originalFilterItem1Id = Guid.NewGuid();
+
+        var oldReplacementFilterItem1Id = Guid.NewGuid();
+        var newReplacementFilterItem1Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter",
+                        ReplacementId = Guid.NewGuid(),
+                        ReplacementLabel = "Replacement filter",
+                        Status = MapStatus.AutoSet,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroupId,
+                                    OriginalLabel = "Original filter group",
+                                    ReplacementId = Guid.NewGuid(),
+                                    ReplacementLabel = "Replacement filter group",
+                                    Status = MapStatus.AutoSet,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterItem1Id,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterItem1Id,
+                                                OriginalLabel = "Original filter item 1",
+                                                ReplacementId = oldReplacementFilterItem1Id,
+                                                ReplacementLabel = "Old replacement filter item 1",
+                                                Status = MapStatus.ManuallySet,
+                                            }
+                                        },
+                                    },
+                                    UnmappedReplacementFilterItems =
+                                    [
+                                        new UnmappedFilterItem
+                                        {
+                                            Id = newReplacementFilterItem1Id,
+                                            Label = "New replacement filter item 1",
+                                        },
+                                    ],
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterItemUpdates =
+                    [
+                        new() { OriginalId = originalFilterItem1Id, NewReplacementId = newReplacementFilterItem1Id },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            var itemDto = Assert.Single(dto.FilterItems);
+            Assert.Equal(newReplacementFilterItem1Id, itemDto.ReplacementId);
+            Assert.Equal("New replacement filter item 1", itemDto.ReplacementLabel);
+            Assert.Equal(nameof(MapStatus.ManuallySet), itemDto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var filter = dbMapping.FilterMappings[originalFilterId];
+            var group = filter.FilterGroupMappings[originalFilterGroupId];
+
+            var item1 = group.FilterItemMappings[originalFilterItem1Id];
+            Assert.Equal(newReplacementFilterItem1Id, item1.ReplacementId);
+            Assert.Equal("New replacement filter item 1", item1.ReplacementLabel);
+            Assert.Equal(MapStatus.ManuallySet, item1.Status);
+
+            Assert.Single(group.UnmappedReplacementFilterItems);
+            var unmappedItem = group.UnmappedReplacementFilterItems.Single();
+            Assert.Equal(oldReplacementFilterItem1Id, unmappedItem.Id);
+            Assert.Equal("Old replacement filter item 1", unmappedItem.Label);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_OriginalFilterItemNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var itemDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>(),
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterItemUpdates = [new() { OriginalId = itemDoesNotExistId, NewReplacementId = null }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                expectedCode: "FilterItemMatchingOriginalIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_UnmappedReplacementFilterItemNotFound_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroupId = Guid.NewGuid();
+        var originalFilterItemId = Guid.NewGuid();
+        var replacementItemDoesNotExistId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        Status = MapStatus.AutoSet,
+                        ReplacementId = Guid.NewGuid(),
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroupId,
+                                    Status = MapStatus.AutoSet,
+                                    ReplacementId = Guid.NewGuid(),
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterItemId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterItemId,
+                                                Status = MapStatus.Unset,
+                                            }
+                                        },
+                                    },
+                                    UnmappedReplacementFilterItems = [],
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterItemUpdates =
+                    [
+                        new() { OriginalId = originalFilterItemId, NewReplacementId = replacementItemDoesNotExistId },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasError(
+                expectedPath: $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                expectedCode: "UnmappedFilterItemMatchingReplacementIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateFilterMappings_MapFilterThenGroupThenItemInSingleRequest_Success()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = replacementDataFileId },
+        };
+
+        var originalFilterId = Guid.NewGuid();
+        var originalFilterGroupId = Guid.NewGuid();
+        var originalFilterItemId = Guid.NewGuid();
+
+        var replacementFilterId = Guid.NewGuid();
+        var replacementFilterGroupId = Guid.NewGuid();
+        var replacementFilterItemId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            FilterMappings = new Dictionary<Guid, FilterMapping>
+            {
+                {
+                    originalFilterId,
+                    new FilterMapping
+                    {
+                        OriginalId = originalFilterId,
+                        OriginalLabel = "Original filter label",
+                        Status = MapStatus.Unset,
+                        FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
+                        {
+                            {
+                                originalFilterGroupId,
+                                new FilterGroupMapping
+                                {
+                                    OriginalId = originalFilterGroupId,
+                                    OriginalLabel = "Original filter group label",
+                                    Status = MapStatus.ParentNotMapped,
+                                    FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
+                                    {
+                                        {
+                                            originalFilterItemId,
+                                            new FilterItemMapping
+                                            {
+                                                OriginalId = originalFilterItemId,
+                                                OriginalLabel = "Original filter item label",
+                                                Status = MapStatus.ParentNotMapped,
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+            },
+            UnmappedReplacementFilters =
+            [
+                new UnmappedFilter
+                {
+                    Id = replacementFilterId,
+                    Label = "Replacement filter label",
+                    ColumnName = "replacement_filter",
+                    UnmappedReplacementFilterGroups =
+                    [
+                        new UnmappedFilterGroup
+                        {
+                            Id = replacementFilterGroupId,
+                            Label = "Different group label",
+                            UnmappedReplacementFilterItems =
+                            [
+                                new UnmappedFilterItem { Id = replacementFilterItemId, Label = "Different item label" },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateFilterMappings(
+                releaseVersion.Id,
+                new FilterMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    FilterUpdates = [new() { OriginalId = originalFilterId, NewReplacementId = replacementFilterId }],
+                    FilterGroupUpdates =
+                    [
+                        new() { OriginalId = originalFilterGroupId, NewReplacementId = replacementFilterGroupId },
+                    ],
+                    FilterItemUpdates =
+                    [
+                        new() { OriginalId = originalFilterItemId, NewReplacementId = replacementFilterItemId },
+                    ],
+                },
+                CancellationToken.None
+            );
+
+            var dto = result.AssertRight();
+            var filterDto = Assert.Single(dto.Filters);
+            Assert.Equal(replacementFilterId, filterDto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), filterDto.Status);
+
+            var groupDto = Assert.Single(dto.FilterGroups);
+            Assert.Equal(replacementFilterGroupId, groupDto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), groupDto.Status);
+
+            var itemDto = Assert.Single(dto.FilterItems);
+            Assert.Equal(replacementFilterItemId, itemDto.ReplacementId);
+            Assert.Equal(nameof(MapStatus.ManuallySet), itemDto.Status);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var filter = dbMapping.FilterMappings[originalFilterId];
+            Assert.Equal(replacementFilterId, filter.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, filter.Status);
+
+            var group = filter.FilterGroupMappings[originalFilterGroupId];
+            Assert.Equal(replacementFilterGroupId, group.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, group.Status);
+
+            var item = group.FilterItemMappings[originalFilterItemId];
+            Assert.Equal(replacementFilterItemId, item.ReplacementId);
+            Assert.Equal(MapStatus.ManuallySet, item.Status);
+
+            Assert.Empty(dbMapping.UnmappedReplacementFilters);
+            Assert.Empty(filter.UnmappedReplacementFilterGroups);
+            Assert.Empty(group.UnmappedReplacementFilterItems);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
@@ -13,6 +13,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 [ApiController]
 public class DataSetMappingController(IDataSetMappingService dataSetMappingService) : ControllerBase
 {
+    [HttpPatch("releases/{releaseVersionId:guid}/data/replacements/mapping/filters")]
+    public async Task<ActionResult<FiltersMappingDto>> UpdateFilterMappings(
+        [FromRoute] Guid releaseVersionId,
+        [FromBody] FilterMappingUpdatesRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await dataSetMappingService
+            .UpdateFilterMappings(releaseVersionId, request, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
     [HttpPatch("releases/{releaseVersionId:guid}/data/replacements/mapping/indicators")]
     public async Task<ActionResult<List<IndicatorMappingDto>>> UpdateIndicatorMappings(
         [FromRoute] Guid releaseVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/FilterMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/FilterMappingUpdateRequest.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using FluentValidation;
+using LinqToDB.Internal.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public class FilterMappingUpdatesRequest
+{
+    public Guid OriginalDataFileId { get; init; }
+    public Guid ReplacementDataFileId { get; init; }
+
+    public List<MappingUpdateRequest> FilterUpdates { get; init; } = [];
+    public List<MappingUpdateRequest> FilterGroupUpdates { get; init; } = [];
+    public List<MappingUpdateRequest> FilterItemUpdates { get; init; } = [];
+
+    public class Validator : AbstractValidator<FilterMappingUpdatesRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.OriginalDataFileId).NotEmpty();
+
+            RuleFor(x => x.ReplacementDataFileId).NotEmpty();
+
+            RuleForEach(x => x.FilterUpdates).SetValidator(new MappingUpdateRequest.Validator());
+            RuleFor(x => x.FilterUpdates)
+                .Must(MappingUpdateRequest.HaveUniqueOriginalIds)
+                .WithMessage("Each OriginalId must be unique.")
+                .Must(MappingUpdateRequest.HaveUniqueReplacementIds)
+                .WithMessage("Each NewReplacementId must be unique (if provided).");
+
+            RuleForEach(x => x.FilterGroupUpdates).SetValidator(new MappingUpdateRequest.Validator());
+            RuleFor(x => x.FilterGroupUpdates)
+                .Must(MappingUpdateRequest.HaveUniqueOriginalIds)
+                .WithMessage("Each OriginalId must be unique.")
+                .Must(MappingUpdateRequest.HaveUniqueReplacementIds)
+                .WithMessage("Each NewReplacementId must be unique (if provided).");
+
+            RuleForEach(x => x.FilterItemUpdates).SetValidator(new MappingUpdateRequest.Validator());
+            RuleFor(x => x.FilterItemUpdates)
+                .Must(MappingUpdateRequest.HaveUniqueOriginalIds)
+                .WithMessage("Each OriginalId must be unique.")
+                .Must(MappingUpdateRequest.HaveUniqueReplacementIds)
+                .WithMessage("Each NewReplacementId must be unique (if provided).");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using FluentValidation;
-using LinqToDB.Internal.Common;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -9,7 +8,7 @@ public class IndicatorMappingUpdatesRequest
     public Guid OriginalDataFileId { get; init; }
     public Guid ReplacementDataFileId { get; init; }
 
-    public List<IndicatorMappingUpdateRequest> Updates { get; init; } = [];
+    public List<MappingUpdateRequest> Updates { get; init; } = [];
 
     public class Validator : AbstractValidator<IndicatorMappingUpdatesRequest>
     {
@@ -19,52 +18,13 @@ public class IndicatorMappingUpdatesRequest
 
             RuleFor(x => x.ReplacementDataFileId).NotEmpty();
 
-            RuleForEach(x => x.Updates).SetValidator(new IndicatorMappingUpdateRequest.Validator());
+            RuleForEach(x => x.Updates).SetValidator(new MappingUpdateRequest.Validator());
 
             RuleFor(x => x.Updates)
-                .Must(HaveUniqueOriginalNames)
+                .Must(MappingUpdateRequest.HaveUniqueOriginalIds)
                 .WithMessage("Each OriginalId must be unique.")
-                .Must(HaveUniqueReplacementNames)
+                .Must(MappingUpdateRequest.HaveUniqueReplacementIds)
                 .WithMessage("Each NewReplacementId must be unique (if provided).");
-        }
-
-        private bool HaveUniqueOriginalNames(List<IndicatorMappingUpdateRequest> updates)
-        {
-            if (updates.IsNullOrEmpty())
-            {
-                return true;
-            }
-
-            return updates.Select(u => u.OriginalId).Distinct().Count() == updates.Count;
-        }
-
-        private bool HaveUniqueReplacementNames(List<IndicatorMappingUpdateRequest> updates)
-        {
-            if (updates.IsNullOrEmpty())
-            {
-                return true;
-            }
-
-            var nonNullReplacements = updates
-                .Where(u => u.NewReplacementId != null)
-                .Select(u => u.NewReplacementId)
-                .ToList();
-
-            return nonNullReplacements.Distinct().Count() == nonNullReplacements.Count;
-        }
-    }
-}
-
-public record IndicatorMappingUpdateRequest
-{
-    public Guid OriginalId { get; init; }
-    public Guid? NewReplacementId { get; init; }
-
-    public class Validator : AbstractValidator<IndicatorMappingUpdateRequest>
-    {
-        public Validator()
-        {
-            RuleFor(x => x.OriginalId).NotEmpty().WithMessage("OriginalId cannot be an empty.");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/LocationMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/LocationMappingUpdateRequest.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using FluentValidation;
-using LinqToDB.Internal.Common;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -9,7 +8,7 @@ public class LocationMappingUpdatesRequest
     public Guid OriginalDataFileId { get; init; }
     public Guid ReplacementDataFileId { get; init; }
 
-    public List<LocationMappingUpdateRequest> Updates { get; init; } = [];
+    public List<MappingUpdateRequest> Updates { get; init; } = [];
 
     public class Validator : AbstractValidator<LocationMappingUpdatesRequest>
     {
@@ -19,54 +18,13 @@ public class LocationMappingUpdatesRequest
 
             RuleFor(x => x.ReplacementDataFileId).NotEmpty();
 
-            RuleForEach(x => x.Updates).SetValidator(new LocationMappingUpdateRequest.Validator());
+            RuleForEach(x => x.Updates).SetValidator(new MappingUpdateRequest.Validator());
 
             RuleFor(x => x.Updates)
-                .Must(HaveUniqueOriginalLocationId)
-                .WithMessage($"Each {nameof(LocationMappingUpdateRequest.OriginalLocationId)} must be unique.")
-                .Must(HaveUniqueReplacementIds)
-                .WithMessage(
-                    $"Each {nameof(LocationMappingUpdateRequest.NewReplacementLocationId)} must be unique (if provided)."
-                );
-        }
-
-        private bool HaveUniqueOriginalLocationId(List<LocationMappingUpdateRequest> updates)
-        {
-            if (updates.IsNullOrEmpty())
-            {
-                return true;
-            }
-
-            return updates.Select(u => u.OriginalLocationId).Distinct().Count() == updates.Count;
-        }
-
-        private bool HaveUniqueReplacementIds(List<LocationMappingUpdateRequest> updates)
-        {
-            if (updates.IsNullOrEmpty())
-            {
-                return true;
-            }
-
-            var nonNullReplacements = updates
-                .Where(u => u.NewReplacementLocationId != null)
-                .Select(u => u.NewReplacementLocationId)
-                .ToList();
-
-            return nonNullReplacements.Distinct().Count() == nonNullReplacements.Count;
-        }
-    }
-}
-
-public record LocationMappingUpdateRequest
-{
-    public Guid OriginalLocationId { get; init; }
-    public Guid? NewReplacementLocationId { get; init; }
-
-    public class Validator : AbstractValidator<LocationMappingUpdateRequest>
-    {
-        public Validator()
-        {
-            RuleFor(x => x.OriginalLocationId).NotEmpty().WithMessage($"{nameof(OriginalLocationId)} cannot be empty.");
+                .Must(MappingUpdateRequest.HaveUniqueOriginalIds)
+                .WithMessage("Each OriginalId must be unique.")
+                .Must(MappingUpdateRequest.HaveUniqueReplacementIds)
+                .WithMessage("Each NewReplacementId must be unique (if provided).");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/MappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/MappingUpdateRequest.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using FluentValidation;
+using LinqToDB.Internal.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public record MappingUpdateRequest
+{
+    public Guid OriginalId { get; init; }
+    public Guid? NewReplacementId { get; init; }
+
+    public class Validator : AbstractValidator<MappingUpdateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.OriginalId).NotEmpty().WithMessage("OriginalId cannot be an empty.");
+        }
+    }
+
+    public static bool HaveUniqueOriginalIds(List<MappingUpdateRequest> updates)
+    {
+        if (updates.IsNullOrEmpty())
+        {
+            return true;
+        }
+
+        return updates.Select(u => u.OriginalId).Distinct().Count() == updates.Count;
+    }
+
+    public static bool HaveUniqueReplacementIds(List<MappingUpdateRequest> updates)
+    {
+        if (updates.IsNullOrEmpty())
+        {
+            return true;
+        }
+
+        var nonNullReplacements = updates
+            .Where(u => u.NewReplacementId != null)
+            .Select(u => u.NewReplacementId)
+            .ToList();
+
+        return nonNullReplacements.Distinct().Count() == nonNullReplacements.Count;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -12,12 +12,13 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
+using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
 public class DataSetMappingService(ContentDbContext contentDbContext, IUserService userService) : IDataSetMappingService
 {
-    public async Task<Either<ActionResult, FiltersMappingDto>> UpdateFiltersMappings(
+    public async Task<Either<ActionResult, FiltersMappingDto>> UpdateFilterMappings(
         Guid releaseVersionId,
         FilterMappingUpdatesRequest request,
         CancellationToken cancellationToken = default
@@ -30,96 +31,573 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             .OnSuccess(async releaseVersion =>
                 await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
             )
-            .OnSuccess(mapping =>
+            .OnSuccess(async mapping =>
             {
+                // Filters
                 var updatedFilterMappings = request
                     .FilterUpdates.Select(filterUpdate =>
                         UpdateFilterMapping(mapping, filterUpdate.OriginalId, filterUpdate.NewReplacementId)
                     )
                     .ToList();
 
+                var filterErrors = updatedFilterMappings
+                    .Where(updated => updated.Error != null)
+                    .Select(updated => updated.Error!)
+                    .ToList();
+                if (!filterErrors.IsNullOrEmpty())
+                {
+                    return new Either<ActionResult, FiltersMappingDto>(ValidationResult(filterErrors));
+                }
+
                 var filterMappingDto = new FiltersMappingDto
                 {
-                    Filters = updatedFilterMappings.Select(FilterMappingDto.FromModel).ToList(),
+                    Filters = updatedFilterMappings
+                        .Select(updated => FilterMappingDto.FromModel(updated.FilterMapping!))
+                        .ToList(),
                 };
-                return (mapping, filterMappingDto);
-            })
-            .OnSuccess(tuple =>
-            {
-                var (mapping, filterMappingDto) = tuple;
 
-                var groupIdToGroupMap = mapping
-                    .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values, (fm, gm) => new { fm, gm })
-                    .ToDictionary();
+                // FilterGroups
+                var originalGroupIdToGroupsMap = mapping
+                    .FilterMappings.Values.SelectMany(
+                        fm => fm.FilterGroupMappings.Values,
+                        (fm, gm) => (FilterMap: fm, GroupMap: gm)
+                    )
+                    .ToDictionary(x => x.GroupMap.OriginalId);
 
                 var updatedGroupMappings = request
                     .FilterGroupUpdates.Select(groupUpdate =>
-                        UpdateFilterGroupMapping(mapping, groupUpdate.OriginalId, groupUpdate.NewReplacementId)
+                        UpdateFilterGroupMapping(
+                            mapping,
+                            originalGroupIdToGroupsMap,
+                            groupUpdate.OriginalId,
+                            groupUpdate.NewReplacementId
+                        )
                     )
                     .ToList();
 
-                filterMappingDto.FilterGroups = updatedGroupMappings.Select(FilterGroupMappingDto.FromModel).ToList();
+                var groupErrors = updatedGroupMappings
+                    .Where(updated => updated.Error != null)
+                    .Select(updated => updated.Error!)
+                    .ToList();
+                if (!groupErrors.IsNullOrEmpty())
+                {
+                    return ValidationResult(groupErrors);
+                }
 
-                return (mapping, filterMappingDto);
-            })
-            .OnSuccess(tuple =>
-            {
-                var (mapping, filterMappingDto) = tuple;
+                filterMappingDto.FilterGroups = updatedGroupMappings
+                    .Select(updated => FilterGroupMappingDto.FromModel(updated.FilterGroupMapping!))
+                    .ToList();
+
+                // FilterItems
+                var originalItemIdToItem = mapping
+                    .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
+                    .SelectMany(
+                        fg => fg.FilterItemMappings.Values,
+                        (group, item) => (FilterGroup: group, FilterItem: item)
+                    )
+                    .ToDictionary(x => x.FilterItem.OriginalId);
 
                 var updatedItemMappings = request
                     .FilterItemUpdates.Select(itemUpdate =>
-                        UpdateFilterItemMapping(mapping, itemUpdate.OriginalId, itemUpdate.NewReplacementId)
+                        UpdateFilterItemMapping(
+                            mapping,
+                            originalItemIdToItem,
+                            itemUpdate.OriginalId,
+                            itemUpdate.NewReplacementId
+                        )
                     )
                     .ToList();
 
-                filterMappingDto.FilterItems = updatedItemMappings.Select(FilterItemMappingDto.FromModel).ToList();
+                var itemErrors = updatedItemMappings
+                    .Where(updated => updated.Error != null)
+                    .Select(updated => updated.Error!)
+                    .ToList();
+                if (!itemErrors.IsNullOrEmpty())
+                {
+                    return ValidationResult(itemErrors);
+                }
+
+                filterMappingDto.FilterItems = updatedItemMappings
+                    .Select(updated => FilterItemMappingDto.FromModel(updated.FilterItemMapping!))
+                    .ToList();
+
+                await contentDbContext.SaveChangesAsync(cancellationToken);
 
                 return filterMappingDto;
             });
     }
 
-    private FilterMapping UpdateFilterMapping(
+    private (FilterMapping? FilterMapping, ErrorViewModel? Error) UpdateFilterMapping(
         DataSetMapping dataSetMapping,
         Guid originalId,
         Guid? newReplacementId = null
     )
     {
-        var filterMapping = dataSetMapping.FilterMappings.Values.SingleOrDefault(map => map.OriginalId == originalId);
+        if (!dataSetMapping.FilterMappings.TryGetValue(originalId, out var filterMapping))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
 
-        // @MarkFix do stuff here
+        if (filterMapping.ReplacementId == newReplacementId && filterMapping.Status == MapStatus.ManuallySet)
+        {
+            return (filterMapping, null); // already set, nothing to do
+        }
 
-        return filterMapping!;
+        var availableUnmappedFilter = dataSetMapping.UnmappedReplacementFilters.SingleOrDefault(unmappedFilter =>
+            unmappedFilter.Id == newReplacementId
+        );
+
+        if (newReplacementId != null && availableUnmappedFilter == null)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterMatchingReplacementIdNotFound",
+                    Message =
+                        $"No available unmapped filter matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (availableUnmappedFilter != null)
+        {
+            // remove availableUnmappedFilter from UnmappedReplacementFilters as it's about to become mapped
+            dataSetMapping.UnmappedReplacementFilters.Remove(availableUnmappedFilter);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
+        }
+
+        if (filterMapping.ReplacementId != null && filterMapping.ReplacementId != newReplacementId)
+        {
+            UnmapFilterMapping(dataSetMapping, filterMapping);
+        }
+
+        // If a replacement is set, we need to automap all child groups and items
+        var (filterGroupMappings, unmappedReplacementGroups) = AutoMapFilterGroupMappings(
+            filterMapping.FilterGroupMappings.Values.ToList(),
+            availableUnmappedFilter?.UnmappedReplacementFilterGroups
+        );
+
+        // mapping.Original* properties should never change
+        filterMapping.ReplacementId = availableUnmappedFilter?.Id;
+        filterMapping.ReplacementColumnName = availableUnmappedFilter?.ColumnName;
+        filterMapping.ReplacementLabel = availableUnmappedFilter?.Label;
+        filterMapping.Status = MapStatus.ManuallySet;
+
+        filterMapping.FilterGroupMappings = filterGroupMappings;
+        filterMapping.UnmappedReplacementFilterGroups = unmappedReplacementGroups;
+
+        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+
+        return (filterMapping, null);
     }
 
-    private FilterGroupMapping UpdateFilterGroupMapping(
+    private (FilterGroupMapping? FilterGroupMapping, ErrorViewModel? Error) UpdateFilterGroupMapping(
         DataSetMapping dataSetMapping,
+        Dictionary<Guid, (FilterMapping FilterMap, FilterGroupMapping GroupMap)> originalGroupIdToGroupMap,
         Guid originalId,
         Guid? newReplacementId = null
     )
     {
-        var filterGroupMapping = dataSetMapping
-            .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
-            .SingleOrDefault(map => map.OriginalId == originalId);
+        if (!originalGroupIdToGroupMap.TryGetValue(originalId, out var pair))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterGroupMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter group mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
 
-        // @MarkFix do stuff here
+        var filterMapping = pair.FilterMap;
+        var groupMapping = pair.GroupMap;
 
-        return filterGroupMapping!;
+        if (groupMapping.Status == MapStatus.ParentNotMapped)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterGroupParentNotMapped",
+                    Message =
+                        $"Cannot map a group whose parent filter isn't mapped. OriginalId: \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (groupMapping.ReplacementId == newReplacementId && groupMapping.Status == MapStatus.ManuallySet)
+        {
+            return (groupMapping, null); // already set, nothing to do
+        }
+
+        var availableUnmappedGroup = filterMapping.UnmappedReplacementFilterGroups.SingleOrDefault(unmappedGroup =>
+            unmappedGroup.Id == newReplacementId
+        );
+
+        if (newReplacementId != null && availableUnmappedGroup == null)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterGroupMatchingReplacementIdNotFound",
+                    Message =
+                        $"No available unmapped filter group matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (availableUnmappedGroup != null)
+        {
+            // remove availableUnmappedGroup from UnmappedReplacementFilterGroups as it's about to become mapped
+            filterMapping.UnmappedReplacementFilterGroups.Remove(availableUnmappedGroup);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+        }
+
+        if (groupMapping.ReplacementId != null && groupMapping.ReplacementId != newReplacementId)
+        {
+            UnmapFilterGroupMapping(dataSetMapping, filterMapping, groupMapping);
+        }
+
+        // If a replacement is set, we need to automap all child groups and items
+        var (filterItemMappings, unmappedReplacementItems) = AutoMapFilterItemMappings(
+            groupMapping.FilterItemMappings.Values.ToList(),
+            availableUnmappedGroup?.UnmappedReplacementFilterItems
+        );
+
+        // mapping.Original* properties should never change
+        groupMapping.ReplacementId = availableUnmappedGroup?.Id;
+        groupMapping.ReplacementLabel = availableUnmappedGroup?.Label;
+        groupMapping.Status = MapStatus.ManuallySet;
+
+        groupMapping.FilterItemMappings = filterItemMappings;
+        groupMapping.UnmappedReplacementFilterItems = unmappedReplacementItems;
+
+        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+
+        return (groupMapping, null);
     }
 
-    private FilterItemMapping UpdateFilterItemMapping(
+    private (FilterItemMapping? FilterItemMapping, ErrorViewModel? Error) UpdateFilterItemMapping(
         DataSetMapping dataSetMapping,
+        Dictionary<Guid, (FilterGroupMapping FilterGroup, FilterItemMapping FilterItem)> originalItemIdToItemMap,
         Guid originalId,
         Guid? newReplacementId = null
     )
     {
-        var filterItemMapping = dataSetMapping
-            .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
-            .SelectMany(fg => fg.FilterItemMappings.Values)
-            .SingleOrDefault(map => map.OriginalId == originalId);
+        if (!originalItemIdToItemMap.TryGetValue(originalId, out var pair))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterItemMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter item mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
 
-        // @MarkFix do stuff here
+        var filterGroupMapping = pair.FilterGroup;
+        var filterItemMapping = pair.FilterItem;
 
-        return filterItemMapping!;
+        if (filterItemMapping.Status == MapStatus.ParentNotMapped)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterItemParentNotMapped",
+                    Message =
+                        $"Cannot map a filter item whose parent group isn't mapped. OriginalId: \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (filterItemMapping.ReplacementId == newReplacementId && filterItemMapping.Status == MapStatus.ManuallySet)
+        {
+            return (filterItemMapping, null); // it is already mapped
+        }
+
+        var availableUnmappedItem = filterGroupMapping.UnmappedReplacementFilterItems.SingleOrDefault(unmappedItem =>
+            unmappedItem.Id == newReplacementId
+        );
+
+        if (newReplacementId != null && availableUnmappedItem == null)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterItemMatchingReplacementIdNotFound",
+                    Message =
+                        $"No available unmapped filter item matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (availableUnmappedItem != null)
+        {
+            filterGroupMapping.UnmappedReplacementFilterItems.Remove(availableUnmappedItem);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+        }
+
+        if (filterItemMapping.ReplacementId != null && filterItemMapping.ReplacementId != newReplacementId)
+        {
+            // We need to move the preexisting mapped item into UnmappedReplacementFilterItems, as it will be overwritten
+            var newlyUnmappedItem = new UnmappedFilterItem
+            {
+                Id = filterItemMapping.ReplacementId.Value,
+                Label = filterItemMapping.ReplacementLabel!,
+            };
+            filterGroupMapping.UnmappedReplacementFilterItems.Add(newlyUnmappedItem);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+        }
+
+        filterItemMapping.ReplacementId = availableUnmappedItem?.Id;
+        filterItemMapping.ReplacementLabel = availableUnmappedItem?.Label;
+        filterItemMapping.Status = MapStatus.ManuallySet;
+
+        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+
+        return (filterItemMapping, null);
+    }
+
+    private void UnmapFilterMapping(DataSetMapping dataSetMapping, FilterMapping filterMapping)
+    {
+        if (!filterMapping.ReplacementId.HasValue)
+        {
+            throw new Exception(
+                $"Cannot unmap replacement for filterMapping as no replacement is mapped. Filter OriginalId: {filterMapping.OriginalId}. DataSetMapping.Id: {dataSetMapping.Id}"
+            );
+        }
+
+        // We need to move the preexisting mapped filter into UnmappedReplacementFilters, as it will be overwritten
+        // and that must include
+        var newlyUnmappedFilter = new UnmappedFilter
+        {
+            Id = filterMapping.ReplacementId.Value,
+            ColumnName = filterMapping.ReplacementColumnName!,
+            Label = filterMapping.ReplacementLabel!,
+            UnmappedReplacementFilterGroups = filterMapping
+                .FilterGroupMappings.Values.Where(groupMapping => groupMapping.ReplacementId != null)
+                .Select(groupMapping => new UnmappedFilterGroup
+                {
+                    Id = groupMapping.ReplacementId!.Value,
+                    Label = groupMapping.ReplacementLabel!,
+                    UnmappedReplacementFilterItems = groupMapping
+                        .FilterItemMappings.Values.Where(itemMapping => itemMapping.ReplacementId != null)
+                        .Select(itemMapping => new UnmappedFilterItem
+                        {
+                            Id = itemMapping.ReplacementId!.Value,
+                            Label = itemMapping.ReplacementLabel!,
+                        })
+                        .Concat(groupMapping.UnmappedReplacementFilterItems)
+                        .ToList(),
+                })
+                .Concat(filterMapping.UnmappedReplacementFilterGroups)
+                .ToList(),
+        };
+        dataSetMapping.UnmappedReplacementFilters.Add(newlyUnmappedFilter);
+        contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
+
+        // Now remove it from filterMapping
+        filterMapping.ReplacementId = null;
+        filterMapping.ReplacementColumnName = null;
+        filterMapping.ReplacementLabel = null;
+        filterMapping.Status = MapStatus.Unset;
+        filterMapping.UnmappedReplacementFilterGroups = [];
+        filterMapping.FilterGroupMappings.Values.ForEach(groupMapping =>
+        {
+            groupMapping.ReplacementId = null;
+            groupMapping.ReplacementLabel = null;
+            groupMapping.Status = MapStatus.ParentNotMapped;
+            groupMapping.UnmappedReplacementFilterItems = [];
+            groupMapping.FilterItemMappings.Values.ForEach(itemMapping =>
+            {
+                itemMapping.ReplacementId = null;
+                itemMapping.ReplacementLabel = null;
+                itemMapping.Status = MapStatus.ParentNotMapped;
+            });
+        });
+        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+    }
+
+    private (
+        Dictionary<Guid, FilterGroupMapping> FilterGroupMappings,
+        List<UnmappedFilterGroup> UnmappedReplacementGroups
+    ) AutoMapFilterGroupMappings(
+        List<FilterGroupMapping> groupMappings,
+        List<UnmappedFilterGroup>? unmappedReplacementGroups
+    )
+    {
+        if (unmappedReplacementGroups == null)
+        {
+            // groups' parent filter replacement has been unset, so no automapping required, as the parent filter
+            // would have been unmapped before this method was called, and so all groups/items would be set correctly
+            // (i.e. ReplacementId == null && Status == ParentNotMapped)
+            return (groupMappings.ToDictionary(groupMap => groupMap.OriginalId, groupMap => groupMap), []);
+        }
+
+        var unmappedGroupLabelToUnmappedGroupMap = unmappedReplacementGroups.ToDictionary(
+            unmappedReplacementGroup => unmappedReplacementGroup.Label,
+            unmappedReplacementGroup => unmappedReplacementGroup
+        );
+
+        var newGroupMappings = new Dictionary<Guid, FilterGroupMapping>(groupMappings.Count);
+        foreach (var groupMapping in groupMappings)
+        {
+            if (
+                unmappedGroupLabelToUnmappedGroupMap.Remove(
+                    groupMapping.OriginalLabel,
+                    out var autoMappableReplacementGroup
+                )
+            )
+            {
+                groupMapping.ReplacementId = autoMappableReplacementGroup.Id;
+                groupMapping.ReplacementLabel = autoMappableReplacementGroup.Label;
+                groupMapping.Status = MapStatus.AutoSet;
+
+                var (autoMappedItems, unmappedReplacementItems) = AutoMapFilterItemMappings(
+                    groupMapping.FilterItemMappings.Values.ToList(),
+                    autoMappableReplacementGroup.UnmappedReplacementFilterItems
+                );
+                groupMapping.FilterItemMappings = autoMappedItems;
+                groupMapping.UnmappedReplacementFilterItems = unmappedReplacementItems;
+            }
+            else
+            {
+                groupMapping.ReplacementId = null;
+                groupMapping.ReplacementLabel = null;
+                groupMapping.Status = MapStatus.Unset;
+            }
+
+            newGroupMappings.Add(groupMapping.OriginalId, groupMapping);
+        }
+
+        // remaining replacement groups in unmappedGroupLabelToUnmappedGroupMap are unmapped
+        var newUnmappedReplacementGroups = unmappedGroupLabelToUnmappedGroupMap.Values.ToList();
+
+        return (newGroupMappings, newUnmappedReplacementGroups);
+    }
+
+    private void UnmapFilterGroupMapping(
+        DataSetMapping dataSetMapping,
+        FilterMapping filterMapping,
+        FilterGroupMapping groupMapping
+    )
+    {
+        if (!groupMapping.ReplacementId.HasValue)
+        {
+            throw new Exception(
+                $"Cannot unmap replacement for filter group mapping as no replacement is mapped. FilterGroup OriginalId: {groupMapping.OriginalId}, DataSetMapping.Id: {dataSetMapping.Id}"
+            );
+        }
+
+        // We need to move the preexisting mapped filter into UnmappedReplacementFilters, as it will be overwritten
+        var newlyUnmappedGroup = new UnmappedFilterGroup
+        {
+            Id = groupMapping.ReplacementId.Value,
+            Label = groupMapping.ReplacementLabel!,
+            UnmappedReplacementFilterItems = groupMapping
+                .FilterItemMappings.Values.Where(itemMapping => itemMapping.ReplacementId != null)
+                .Select(itemMapping => new UnmappedFilterItem
+                {
+                    Id = itemMapping.ReplacementId!.Value,
+                    Label = itemMapping.ReplacementLabel!,
+                })
+                .Concat(groupMapping.UnmappedReplacementFilterItems)
+                .ToList(),
+        };
+
+        filterMapping.UnmappedReplacementFilterGroups.Add(newlyUnmappedGroup);
+        contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
+
+        // Now remove it from groupMapping
+        groupMapping.ReplacementId = null;
+        groupMapping.ReplacementLabel = null;
+        groupMapping.Status = MapStatus.Unset;
+        groupMapping.FilterItemMappings.Values.ForEach(itemMapping =>
+        {
+            itemMapping.ReplacementId = null;
+            itemMapping.ReplacementLabel = null;
+            itemMapping.Status = MapStatus.ParentNotMapped;
+        });
+
+        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
+    }
+
+    private (
+        Dictionary<Guid, FilterItemMapping> FilterItemMappings,
+        List<UnmappedFilterItem> UnmappedReplacementItems
+    ) AutoMapFilterItemMappings(
+        List<FilterItemMapping> itemMappings,
+        List<UnmappedFilterItem>? unmappedReplacementItems
+    )
+    {
+        if (unmappedReplacementItems == null)
+        {
+            // items' parent group replacement has been unset, so no automapping required, as the parent group
+            // would have been unmapped before this method was called, and so all items would be set correctly
+            // (i.e. ReplacementId == null && Status == ParentNotMapped)
+            return (itemMappings.ToDictionary(itemMap => itemMap.OriginalId, itemMap => itemMap), []);
+        }
+
+        var unmappedItemLabelToUnmappedLabelMap = unmappedReplacementItems.ToDictionary(
+            unmappedItem => unmappedItem.Label,
+            unmappedItem => unmappedItem
+        );
+
+        var newItemMappings = new Dictionary<Guid, FilterItemMapping>(itemMappings.Count);
+        foreach (var itemMap in itemMappings)
+        {
+            if (unmappedItemLabelToUnmappedLabelMap.Remove(itemMap.OriginalLabel, out var autoMappableReplacementItem))
+            {
+                itemMap.ReplacementId = autoMappableReplacementItem.Id;
+                itemMap.ReplacementLabel = autoMappableReplacementItem.Label;
+                itemMap.Status = MapStatus.AutoSet;
+            }
+            else
+            {
+                itemMap.ReplacementId = null;
+                itemMap.ReplacementLabel = null;
+                itemMap.Status = MapStatus.Unset;
+            }
+
+            newItemMappings.Add(itemMap.OriginalId, itemMap);
+        }
+
+        // remaining replacement items are unmapped
+        var newUnmappedReplacementItems = unmappedItemLabelToUnmappedLabelMap.Values.ToList();
+
+        return (newItemMappings, newUnmappedReplacementItems);
     }
 
     public async Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
@@ -158,10 +636,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
         Guid? newReplacementId = null
     )
     {
-        var indicatorMapping = dataSetMapping.IndicatorMappings.Values.SingleOrDefault(map =>
-            map.OriginalId == originalId
-        );
-        if (indicatorMapping == null)
+        if (!dataSetMapping.IndicatorMappings.TryGetValue(originalId, out var indicatorMapping))
         {
             return ValidationResult(
                 new ErrorViewModel
@@ -191,7 +666,8 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                     Path =
                         $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                     Code = "UnmappedIndicatorMatchingReplacementIdNotFound",
-                    Message = $"No available unmapped indicator matching replacement id \"{newReplacementId}\"",
+                    Message =
+                        $"No available unmapped indicator matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
                 }
             );
         }
@@ -267,10 +743,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
         Guid? newReplacementLocationId = null
     )
     {
-        var locationMapping = dataSetMapping.LocationMappings.Values.SingleOrDefault(map =>
-            map.OriginalId == originalLocationId
-        );
-        if (locationMapping == null)
+        if (!dataSetMapping.LocationMappings.TryGetValue(originalLocationId, out var locationMapping))
         {
             return ValidationResult(
                 new ErrorViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -400,7 +400,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
         }
 
         // We need to move the preexisting mapped filter into UnmappedReplacementFilters, as it will be overwritten
-        // and that must include
+        // and that must include all child groups and items
         var newlyUnmappedFilter = new UnmappedFilter
         {
             Id = filterMapping.ReplacementId.Value,
@@ -724,7 +724,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             {
                 var updatedMappings = request
                     .Updates.Select(update =>
-                        UpdateLocationMapping(mapping, update.OriginalLocationId, update.NewReplacementLocationId)
+                        UpdateLocationMapping(mapping, update.OriginalId, update.NewReplacementId)
                     )
                     .ToList(); // cannot be async!
 
@@ -748,8 +748,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             return ValidationResult(
                 new ErrorViewModel
                 {
-                    Path =
-                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.OriginalLocationId)}",
+                    Path = $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
                     Code = "LocationMatchingOriginalIdNameNotFound",
                     Message = $"Could not find location mapping matching original location id \"{originalLocationId}\"",
                 }
@@ -774,7 +773,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.NewReplacementLocationId)}",
+                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                     Code = "UnmappedLocationMatchingReplacementLocationIdNotFound",
                     Message = $"No available unmapped location matching replacement id \"{newReplacementLocationId}\"",
                 }
@@ -791,7 +790,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(LocationMappingUpdateRequest.NewReplacementLocationId)}",
+                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                     Code = "UnmappedLocationHasDifferentGeographicLevelAsOriginalLocation",
                     Message =
                         $"The replacement location has a different geographic level than the original location. Replacement id: \"{newReplacementLocationId}\"",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -17,6 +17,111 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
 public class DataSetMappingService(ContentDbContext contentDbContext, IUserService userService) : IDataSetMappingService
 {
+    public async Task<Either<ActionResult, FiltersMappingDto>> UpdateFiltersMappings(
+        Guid releaseVersionId,
+        FilterMappingUpdatesRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await contentDbContext
+            .ReleaseVersions.Where(rv => rv.Id == releaseVersionId)
+            .SingleOrNotFound()
+            .OnSuccess(userService.CheckCanUpdateReleaseVersion)
+            .OnSuccess(async releaseVersion =>
+                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
+            )
+            .OnSuccess(mapping =>
+            {
+                var updatedFilterMappings = request
+                    .FilterUpdates.Select(filterUpdate =>
+                        UpdateFilterMapping(mapping, filterUpdate.OriginalId, filterUpdate.NewReplacementId)
+                    )
+                    .ToList();
+
+                var filterMappingDto = new FiltersMappingDto
+                {
+                    Filters = updatedFilterMappings.Select(FilterMappingDto.FromModel).ToList(),
+                };
+                return (mapping, filterMappingDto);
+            })
+            .OnSuccess(tuple =>
+            {
+                var (mapping, filterMappingDto) = tuple;
+
+                var groupIdToGroupMap = mapping
+                    .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values, (fm, gm) => new { fm, gm })
+                    .ToDictionary();
+
+                var updatedGroupMappings = request
+                    .FilterGroupUpdates.Select(groupUpdate =>
+                        UpdateFilterGroupMapping(mapping, groupUpdate.OriginalId, groupUpdate.NewReplacementId)
+                    )
+                    .ToList();
+
+                filterMappingDto.FilterGroups = updatedGroupMappings.Select(FilterGroupMappingDto.FromModel).ToList();
+
+                return (mapping, filterMappingDto);
+            })
+            .OnSuccess(tuple =>
+            {
+                var (mapping, filterMappingDto) = tuple;
+
+                var updatedItemMappings = request
+                    .FilterItemUpdates.Select(itemUpdate =>
+                        UpdateFilterItemMapping(mapping, itemUpdate.OriginalId, itemUpdate.NewReplacementId)
+                    )
+                    .ToList();
+
+                filterMappingDto.FilterItems = updatedItemMappings.Select(FilterItemMappingDto.FromModel).ToList();
+
+                return filterMappingDto;
+            });
+    }
+
+    private FilterMapping UpdateFilterMapping(
+        DataSetMapping dataSetMapping,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        var filterMapping = dataSetMapping.FilterMappings.Values.SingleOrDefault(map => map.OriginalId == originalId);
+
+        // @MarkFix do stuff here
+
+        return filterMapping!;
+    }
+
+    private FilterGroupMapping UpdateFilterGroupMapping(
+        DataSetMapping dataSetMapping,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        var filterGroupMapping = dataSetMapping
+            .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
+            .SingleOrDefault(map => map.OriginalId == originalId);
+
+        // @MarkFix do stuff here
+
+        return filterGroupMapping!;
+    }
+
+    private FilterItemMapping UpdateFilterItemMapping(
+        DataSetMapping dataSetMapping,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        var filterItemMapping = dataSetMapping
+            .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
+            .SelectMany(fg => fg.FilterItemMappings.Values)
+            .SingleOrDefault(map => map.OriginalId == originalId);
+
+        // @MarkFix do stuff here
+
+        return filterItemMapping!;
+    }
+
     public async Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
         Guid releaseVersionId,
         IndicatorMappingUpdatesRequest request,
@@ -62,7 +167,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.OriginalId)}",
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
                     Code = "IndicatorMatchingOriginalIdNotFound",
                     Message = $"Could not find indicator mapping matching original id \"{originalId}\"",
                 }
@@ -84,7 +189,7 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.NewReplacementId)}",
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
                     Code = "UnmappedIndicatorMatchingReplacementIdNotFound",
                     Message = $"No available unmapped indicator matching replacement id \"{newReplacementId}\"",
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
@@ -8,6 +8,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 
 public interface IDataSetMappingService
 {
+    Task<Either<ActionResult, FiltersMappingDto>> UpdateFilterMappings(
+        Guid releaseVersionId,
+        FilterMappingUpdatesRequest request,
+        CancellationToken cancellationToken = default
+    );
+
     Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
         Guid releaseVersionId,
         IndicatorMappingUpdatesRequest request,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserResourceRoleNotificationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserResourceRoleNotificationService.cs
@@ -246,7 +246,6 @@ public class UserResourceRoleNotificationService(
             ?? throw new KeyNotFoundException(
                 $"A non-expired pre-release role with ID {userPreReleaseRoleId} does not exist."
             );
-        ;
     }
 
     private async Task<User> FindUser(Guid userId, CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMappingDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMappingDtos.cs
@@ -1,0 +1,84 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public class FiltersMappingDto
+{
+    public List<FilterMappingDto> Filters { get; set; }
+    public List<FilterGroupMappingDto> FilterGroups { get; set; }
+    public List<FilterItemMappingDto> FilterItems { get; set; }
+}
+
+public class FilterMappingDto
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+    public string OriginalColumnName { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; }
+    public string? ReplacementColumnName { get; set; }
+
+    public string Status { get; set; } = "";
+
+    public static FilterMappingDto FromModel(FilterMapping filterMapping)
+    {
+        return new FilterMappingDto
+        {
+            OriginalId = filterMapping.OriginalId,
+            OriginalLabel = filterMapping.OriginalLabel,
+            OriginalColumnName = filterMapping.OriginalColumnName,
+            ReplacementId = filterMapping.ReplacementId,
+            ReplacementLabel = filterMapping.ReplacementLabel,
+            ReplacementColumnName = filterMapping.ReplacementColumnName,
+            Status = filterMapping.Status.ToString(),
+        };
+    }
+}
+
+public class FilterGroupMappingDto
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; }
+
+    public string Status { get; set; } = "";
+
+    public static FilterGroupMappingDto FromModel(FilterGroupMapping filterGroupMapping)
+    {
+        return new FilterGroupMappingDto
+        {
+            OriginalId = filterGroupMapping.OriginalId,
+            OriginalLabel = filterGroupMapping.OriginalLabel,
+            ReplacementId = filterGroupMapping.ReplacementId,
+            ReplacementLabel = filterGroupMapping.ReplacementLabel,
+            Status = filterGroupMapping.Status.ToString(),
+        };
+    }
+}
+
+public class FilterItemMappingDto
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; }
+
+    public string Status { get; set; } = "";
+
+    public static FilterItemMappingDto FromModel(FilterItemMapping filterItemMapping)
+    {
+        return new FilterItemMappingDto
+        {
+            OriginalId = filterItemMapping.OriginalId,
+            OriginalLabel = filterItemMapping.OriginalLabel,
+            ReplacementId = filterItemMapping.ReplacementId,
+            ReplacementLabel = filterItemMapping.ReplacementLabel,
+            Status = filterItemMapping.Status.ToString(),
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMappingDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/FilterMappingDtos.cs
@@ -1,13 +1,14 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 public class FiltersMappingDto
 {
-    public List<FilterMappingDto> Filters { get; set; }
-    public List<FilterGroupMappingDto> FilterGroups { get; set; }
-    public List<FilterItemMappingDto> FilterItems { get; set; }
+    public List<FilterMappingDto> Filters { get; set; } = null!;
+    public List<FilterGroupMappingDto> FilterGroups { get; set; } = null!;
+    public List<FilterItemMappingDto> FilterItems { get; set; } = null!;
 }
 
 public class FilterMappingDto
@@ -20,7 +21,8 @@ public class FilterMappingDto
     public string? ReplacementLabel { get; set; }
     public string? ReplacementColumnName { get; set; }
 
-    public string Status { get; set; } = "";
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public MapStatus Status { get; set; }
 
     public static FilterMappingDto FromModel(FilterMapping filterMapping)
     {
@@ -32,7 +34,7 @@ public class FilterMappingDto
             ReplacementId = filterMapping.ReplacementId,
             ReplacementLabel = filterMapping.ReplacementLabel,
             ReplacementColumnName = filterMapping.ReplacementColumnName,
-            Status = filterMapping.Status.ToString(),
+            Status = filterMapping.Status,
         };
     }
 }
@@ -45,7 +47,8 @@ public class FilterGroupMappingDto
     public Guid? ReplacementId { get; set; }
     public string? ReplacementLabel { get; set; }
 
-    public string Status { get; set; } = "";
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public MapStatus Status { get; set; }
 
     public static FilterGroupMappingDto FromModel(FilterGroupMapping filterGroupMapping)
     {
@@ -55,7 +58,7 @@ public class FilterGroupMappingDto
             OriginalLabel = filterGroupMapping.OriginalLabel,
             ReplacementId = filterGroupMapping.ReplacementId,
             ReplacementLabel = filterGroupMapping.ReplacementLabel,
-            Status = filterGroupMapping.Status.ToString(),
+            Status = filterGroupMapping.Status,
         };
     }
 }
@@ -68,7 +71,8 @@ public class FilterItemMappingDto
     public Guid? ReplacementId { get; set; }
     public string? ReplacementLabel { get; set; }
 
-    public string Status { get; set; } = "";
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public MapStatus Status { get; set; }
 
     public static FilterItemMappingDto FromModel(FilterItemMapping filterItemMapping)
     {
@@ -78,7 +82,7 @@ public class FilterItemMappingDto
             OriginalLabel = filterItemMapping.OriginalLabel,
             ReplacementId = filterItemMapping.ReplacementId,
             ReplacementLabel = filterItemMapping.ReplacementLabel,
-            Status = filterItemMapping.Status.ToString(),
+            Status = filterItemMapping.Status,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/IndicatorMappingDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/IndicatorMappingDto.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
@@ -17,7 +18,8 @@ public class IndicatorMappingDto
     public Guid? ReplacementGroupId { get; set; }
     public string? ReplacementGroupLabel { get; set; }
 
-    public string Status { get; set; } = "";
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public MapStatus Status { get; set; }
 
     public static IndicatorMappingDto FromModel(IndicatorMapping indicatorMapping)
     {
@@ -33,7 +35,7 @@ public class IndicatorMappingDto
             ReplacementColumnName = indicatorMapping.ReplacementColumnName,
             ReplacementGroupId = indicatorMapping.ReplacementGroupId,
             ReplacementGroupLabel = indicatorMapping.ReplacementGroupLabel,
-            Status = indicatorMapping.Status.ToString(),
+            Status = indicatorMapping.Status,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/LocationMappingDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/LocationMappingDto.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
@@ -16,7 +17,8 @@ public class LocationMappingDto
     public string? ReplacementCode { get; set; }
     public string? ReplacementName { get; set; }
 
-    public string Status { get; set; } = "";
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public MapStatus Status { get; set; }
 
     public static LocationMappingDto FromModel(LocationMapping locationMapping)
     {
@@ -30,7 +32,7 @@ public class LocationMappingDto
             ReplacementGeographicLevel = locationMapping.ReplacementGeographicLevel?.GetEnumValue(),
             ReplacementCode = locationMapping.ReplacementCode,
             ReplacementName = locationMapping.ReplacementName,
-            Status = locationMapping.Status.ToString(),
+            Status = locationMapping.Status,
         };
     }
 }

--- a/tests/test-data/files/small-files/replace-data/two_filters_national_after.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/two_filters_national_after.meta.csv
@@ -1,6 +1,6 @@
 col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
 pupil_sen_status,Filter,SEN provision,,,,EHC plan/Statement of SEN or SEN support/School Action/School Action plus,
-primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI…)",
+primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI)",
 number_of_pupils,Indicator,Headcount,Number of pupils,,0,,
 pupil_gender_boys,Indicator,Boys,Gender,,0,,
 pupil_gender_girls,Indicator,Girls,Gender,,0,,

--- a/tests/test-data/files/small-files/replace-data/two_filters_national_before.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/two_filters_national_before.meta.csv
@@ -1,6 +1,6 @@
 col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
 pupil_sen_status,Filter,SEN provision,,,,EHC plan/Statement of SEN or SEN support/School Action/School Action plus,
-primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI…)",
+primary_need,Filter,Primary type of need,,,,"(ASD, HI, VI)",
 number_of_pupils,Indicator,Headcount,Number of pupils,,0,,
 pupil_gender_boys,Indicator,Boys,Gender,,0,,
 pupil_gender_girls,Indicator,Girls,Gender,,0,,

--- a/tests/test-data/files/small-files/replace-data/two_filters_renamed.csv
+++ b/tests/test-data/files/small-files/replace-data/two_filters_renamed.csv
@@ -1,0 +1,17 @@
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,filter_one_updated,filter_two_updated,filter_group_one,filter_three,filter_four,filter_group_four,ind_one
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,Total,One,One group updated,Total,One updated,One group,1
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,Total,One,One group updated,Total,One updated,One group,1
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,Total,One,One group updated,Total,One updated,One group,1
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,Total,One,One group updated,Total,One updated,One group,1
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,Total,Two updated,Two group,Total,One updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,Total,Two updated,Two group,Total,One updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,Total,Two updated,Two group,Total,One updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,Total,Two updated,Two group,Total,One updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,Total,One,One group updated,Total,Two updated,One group,2
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,Total,One,One group updated,Total,Two updated,One group,2
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,Total,One,One group updated,Total,Two updated,One group,2
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,Total,One,One group updated,Total,Two updated,One group,2
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,Total,Two updated,Two group,Total,Two updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,Total,Two updated,Two group,Total,Two updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,Total,Two updated,Two group,Total,Two updated,Two group updated,2
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,Total,Two updated,Two group,Total,Two updated,Two group updated,2

--- a/tests/test-data/files/small-files/replace-data/two_filters_renamed.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/two_filters_renamed.meta.csv
@@ -1,0 +1,6 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+ind_one,Indicator,Indicator one,,,,,
+filter_one_updated,Filter,Filter one updated,,,,,
+filter_two_updated,Filter,Filter two updated,,,,,filter_group_one
+filter_three,Filter,Filter three,,,,,
+filter_four,Filter,Filter four,,,,,filter_group_four


### PR DESCRIPTION
This PR adds backend endpoints to update filter mappings. These will be utilised by the frontend in upcoming work.

:rotating_light: Should only be merged after EES-7279 is merged :rotating_light: 

Updates are only allowed if the parent in the hierarchy is mapped. So a group cannot be mapped if the parent filter isn't mapped. And a item cannot be mapped if the parent group isn't mapped. This was decided previously to avoid additional complication (e.g. code to avoid mapping contradicting each other).

### Other changes
- Created a common `MappingUpdateRequest.cs` that is now used in filter, location, and indicator update requests.
- Used JsonConverter attribute on `Status` for all `*MappingDto` entities so we don't need to manually convert MapStatus -> string.
- Added a test data set `two_filters_renamed.csv`
- Removed a rogue character from two other test data sets that was preventing them from importing.
- Removed a rogue semicolon from `UserResourceRoleNotificationService.cs`