### PR TITLE
EES-7515 - Fixing robot tests due to EES-7335

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -13,11 +13,13 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Identity;
 using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Services.UserPreReleaseRoleRepository;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Services.UserPublicationRoleRepository;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -259,7 +261,10 @@ public abstract class UserManagementServiceTests
                 var expectedUserPreReleaseRoles1 = CreateUserPreReleaseRoleViewModels([userPreReleaseRoles[0]]);
 
                 Assert.Equal(expectedUserInvite1.Email, pendingInvite1.Email);
-                Assert.Equal(expectedUserInvite1.Role!.Name, pendingInvite1.GlobalRole);
+                Assert.Equal(
+                    EnumUtil.GetFromEnumLabel<Role>(expectedUserInvite1.Role!.Name!),
+                    pendingInvite1.GlobalRole
+                );
                 Assert.Equal(expectedUserPublicationRoles1, pendingInvite1.UserPublicationRoles);
                 Assert.Equal(expectedUserPreReleaseRoles1, pendingInvite1.UserPreReleaseRoles);
 
@@ -270,7 +275,10 @@ public abstract class UserManagementServiceTests
                 var expectedUserPreReleaseRoles2 = CreateUserPreReleaseRoleViewModels([userPreReleaseRoles[1]]);
 
                 Assert.Equal(expectedUserInvite2.Email, pendingInvite2.Email);
-                Assert.Equal(expectedUserInvite2.Role!.Name, pendingInvite2.GlobalRole);
+                Assert.Equal(
+                    EnumUtil.GetFromEnumLabel<Role>(expectedUserInvite2.Role!.Name!),
+                    pendingInvite2.GlobalRole
+                );
                 Assert.Equal(expectedUserPublicationRoles2, pendingInvite2.UserPublicationRoles);
                 Assert.Equal(expectedUserPreReleaseRoles2, pendingInvite2.UserPreReleaseRoles);
 
@@ -281,7 +289,10 @@ public abstract class UserManagementServiceTests
                 var expectedUserPreReleaseRoles3 = CreateUserPreReleaseRoleViewModels([userPreReleaseRoles[2]]);
 
                 Assert.Equal(expectedUserInvite3.Email, pendingInvite3.Email);
-                Assert.Equal(expectedUserInvite3.Role!.Name, pendingInvite3.GlobalRole);
+                Assert.Equal(
+                    EnumUtil.GetFromEnumLabel<Role>(expectedUserInvite3.Role!.Name!),
+                    pendingInvite3.GlobalRole
+                );
                 Assert.Equal(expectedUserPublicationRoles3, pendingInvite3.UserPublicationRoles);
                 Assert.Equal(expectedUserPreReleaseRoles3, pendingInvite3.UserPreReleaseRoles);
 
@@ -290,7 +301,10 @@ public abstract class UserManagementServiceTests
                 var pendingInvite4 = pendingInvites.Single(pi => pi.Email == expectedUserInvite4.Email);
 
                 Assert.Equal(expectedUserInvite4.Email, pendingInvite4.Email);
-                Assert.Equal(expectedUserInvite4.Role!.Name, pendingInvite4.GlobalRole);
+                Assert.Equal(
+                    EnumUtil.GetFromEnumLabel<Role>(expectedUserInvite4.Role!.Name!),
+                    pendingInvite4.GlobalRole
+                );
                 Assert.Empty(pendingInvite4.UserPublicationRoles);
                 Assert.Empty(pendingInvite4.UserPreReleaseRoles);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -137,7 +138,7 @@ public class UserManagementService(
                             return new PendingInviteViewModel
                             {
                                 Email = pendingUserInvite.Email,
-                                GlobalRole = pendingUserInvite.Role!.Name!,
+                                GlobalRole = EnumUtil.GetFromEnumLabel<Role>(pendingUserInvite.Role!.Name!),
                                 UserPublicationRoles = userPublicationRoles,
                                 UserPreReleaseRoles = userPreReleaseRoles,
                             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PendingInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PendingInviteViewModel.cs
@@ -1,11 +1,16 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 public record PendingInviteViewModel
 {
     public required string Email { get; init; }
 
-    public required string GlobalRole { get; init; }
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required GlobalRoles.Role GlobalRole { get; init; }
 
     public List<UserPublicationRoleViewModel> UserPublicationRoles { get; init; } = [];
 

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -1,5 +1,6 @@
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
+import { globalRoleLabels } from '@admin/services/types/GlobalRole';
 import userInvitesService, {
   PendingInvite,
 } from '@admin/services/user-management/userInvitesService';
@@ -75,7 +76,7 @@ const InvitedUsersPage = () => {
                   {model.pendingInvites.map(pendingInvite => (
                     <tr key={pendingInvite.email}>
                       <td>{pendingInvite.email}</td>
-                      <td>{pendingInvite.globalRole}</td>
+                      <td>{globalRoleLabels[pendingInvite.globalRole]}</td>
                       <td>
                         {pendingInvite.userPreReleaseRoles.length === 0 ? (
                           'No user pre-release roles'

--- a/src/explore-education-statistics-admin/src/services/user-management/userInvitesService.ts
+++ b/src/explore-education-statistics-admin/src/services/user-management/userInvitesService.ts
@@ -4,10 +4,11 @@ import {
   UserPublicationRole,
 } from '../types/userWithRoles';
 import { PublicationRole } from '../types/PublicationRole';
+import { GlobalRole } from '../types/GlobalRole';
 
 export interface PendingInvite {
   email: string;
-  globalRole: string;
+  globalRole: GlobalRole;
   userPublicationRoles: UserPublicationRole[];
   userPreReleaseRoles: UserPreReleaseRole[];
 }

--- a/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_drafter.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_drafter.robot
@@ -70,15 +70,15 @@ Update publication details
 
     user clicks button    Edit publication details
 
-    # Only BAU should see title
+    # Only Super Users should see title
     user checks page does not contain element    id:publicationDetailsForm-title
 
     user waits until page contains element    id:publicationDetailsForm-summary
 
-    # Only BAU should see theme
+    # Only Super Users should see theme
     user checks page does not contain element    name:themeId
 
-    # Only BAU users should see supersededById
+    # Only Super Users should see supersededById
     user checks page does not contain element    id:publicationDetailsForm-supersededById
 
     user enters text into element    id:publicationDetailsForm-summary    UI test publication summary

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_approver_ui_permissions.robot
@@ -53,9 +53,9 @@ Check Edit publication details page inputs are correct
     user clicks button    Edit publication details
 
     user waits until page contains element    label:Publication summary
-    user checks page does not contain element    label:Publication title    # Only BAU users should see this
-    user checks page does not contain element    label:Select theme    # Only BAU users should see this
-    user checks page does not contain element    label:Superseding publication    # Only BAU users should see this
+    user checks page does not contain element    label:Publication title    # Only Super Users should see this
+    user checks page does not contain element    label:Select theme    # Only Super Users should see this
+    user checks page does not contain element    label:Superseding publication    # Only Super Users should see this
 
     user clicks button    Cancel
     user waits until page does not contain button    Cancel

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_drafter_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_drafter_ui_permissions.robot
@@ -53,9 +53,9 @@ Check Edit publication details page inputs are correct
     user clicks button    Edit publication details
 
     user waits until page contains element    label:Publication summary
-    user checks page does not contain element    label:Publication title    # Only BAU users should see this
-    user checks page does not contain element    label:Select theme    # Only BAU users should see this
-    user checks page does not contain element    label:Superseding publication    # Only BAU users should see this
+    user checks page does not contain element    label:Publication title    # Only Super Users should see this
+    user checks page does not contain element    label:Select theme    # Only Super Users should see this
+    user checks page does not contain element    label:Superseding publication    # Only Super Users should see this
 
     user clicks button    Cancel
     user waits until page does not contain button    Cancel

--- a/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
+++ b/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
@@ -10,7 +10,7 @@ Force Tags          Admin    Local    Dev
 
 
 *** Test Cases ***
-Log in as BAU and check the dashboard is looking OK and the sign out buttons are available
+Log in as Super User and check the dashboard is looking OK and the sign out buttons are available
     user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button

--- a/tests/robot-tests/tests/admin/authentication/register.robot
+++ b/tests/robot-tests/tests/admin/authentication/register.robot
@@ -62,7 +62,7 @@ Log out and log back in again to make sure that the user still has the correct a
 Clear down the invited user so that we can invite them again
     delete test user    %{PENDING_INVITE_USER_EMAIL}
 
-Invite the user as a BAU user
+Invite the user as a Super User
     user signs in as bau1
     user clicks link    Platform administration
     user waits until h1 is visible    Platform administration
@@ -71,22 +71,22 @@ Invite the user as a BAU user
     user clicks link    Invite a new user
     user waits until h1 is visible    Invite user
     user enters text into element    name:userEmail    %{PENDING_INVITE_USER_EMAIL}
-    user clicks checkbox    BAU User
-    user checks checkbox is checked    BAU User
+    user clicks checkbox    Super User
+    user checks checkbox is checked    Super User
     user clicks button    Send invite
     user waits until h1 is visible    Pending invites
     user closes the browser
 
-Sign in as the invitee to register as a BAU user
+Sign in as the invitee to register as a Super User
     user opens browser and logs in via Identity Provider
 
-Check that the user is on the dashboard and has the correct access for a BAU user
-    user checks for BAU access on the Dashboard
+Check that the user is on the dashboard and has the correct access for a Super User
+    user checks for Super User access on the Dashboard
 
-Log out and log back in again to make sure that the user still has the correct access for a BAU user
+Log out and log back in again to make sure that the user still has the correct access for a Super User
     user closes the browser
     user opens browser and logs in via Identity Provider
-    user checks for BAU access on the Dashboard
+    user checks for Super User access on the Dashboard
 
 
 *** Keywords ***
@@ -110,7 +110,7 @@ user checks for Standard User access on the Dashboard
     user checks page contains    Logged in as Pending
     user checks page does not contain link    Platform administration
 
-user checks for BAU access on the Dashboard
+user checks for Super User access on the Dashboard
     user waits until page contains title    Dashboard
     user checks page contains    Logged in as Pending
     user checks page contains link    Platform administration

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -39,12 +39,12 @@ Check correct test users are present in table
 
     ${row}=    user gets table row with heading    Bau1 User1
     user checks row cell contains text    ${row}    1    ees-test.bau1@education.gov.uk
-    user checks row cell contains text    ${row}    2    BAU User
+    user checks row cell contains text    ${row}    2    Super User
     user checks row cell contains text    ${row}    3    Manage
 
     ${row}=    user gets table row with heading    Bau2 User2
     user checks row cell contains text    ${row}    1    ees-test.bau2@education.gov.uk
-    user checks row cell contains text    ${row}    2    BAU User
+    user checks row cell contains text    ${row}    2    Super User
     user checks row cell contains text    ${row}    3    Manage
 
 Assert prerelease users are present in table
@@ -76,7 +76,7 @@ Select a user to manage
     user waits until h1 is visible    Prerelease2 User2    10
 
 Check the initial manage user page
-    user checks checkbox is not checked    BAU User
+    user checks checkbox is not checked    Super User
 
     user checks select contains option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user checks select contains option    name:releaseId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
@@ -124,25 +124,25 @@ Give the user drafter access to some publications
     user checks table cell contains    2    2    Drafter    testid:publicationAccessTable
     user checks table cell contains    2    3    Remove    testid:publicationAccessTable
 
-Give the user the BAU User role
-    user clicks checkbox    BAU User
-    user checks checkbox is checked    BAU User
+Give the user the Super User role
+    user clicks checkbox    Super User
+    user checks checkbox is checked    Super User
     user clicks button    Update access
     user waits until page finishes loading
-    user checks checkbox is checked    BAU User
+    user checks checkbox is checked    Super User
 
-Remove publication drafter access for one of the publications from user while they are BAU
+Remove publication drafter access for one of the publications from user while they are Super User
     user clicks button in table cell    1    3    Remove    testid:publicationAccessTable
     user checks table body has x rows    1    testid:publicationAccessTable
     user checks table cell contains    1    1    ${PUBLICATION_2_NAME}    testid:publicationAccessTable
     user checks table cell contains    1    2    Drafter    testid:publicationAccessTable
     user checks table cell contains    1    3    Remove    testid:publicationAccessTable
 
-Remove publication drafter access for the final publication from user while they are BAU
+Remove publication drafter access for the final publication from user while they are Super User
     user clicks button in table cell    1    3    Remove    testid:publicationAccessTable
     user checks table body has x rows    0    testid:publicationAccessTable
 
-Give the user approver access to a publication while they are BAU and manually set their global role to Standard User
+Give the user approver access to a publication while they are Super User and manually set their global role to Standard User
     user chooses select option    name:publicationId    ${PUBLICATION_NAME}
     user chooses select option    name:publicationRole    Approver
     user clicks button    Add publication access
@@ -151,11 +151,11 @@ Give the user approver access to a publication while they are BAU and manually s
     user checks table cell contains    1    2    Approver    testid:publicationAccessTable
     user checks table cell contains    1    3    Remove    testid:publicationAccessTable
 
-    user clicks checkbox    BAU User
-    user checks checkbox is not checked    BAU User
+    user clicks checkbox    Super User
+    user checks checkbox is not checked    Super User
     user clicks button    Update access
     user waits until page finishes loading
-    user checks checkbox is not checked    BAU User
+    user checks checkbox is not checked    Super User
 
 Remove publication approver access from user after they have manually been set to Standard User
     user clicks button in table cell    1    3    Remove    testid:publicationAccessTable


### PR DESCRIPTION
In the pull-request for EES-7335 we changed all areas in the UI where 'BAU' was being displayed, to refer to 'Super Users' instead.

During this, we forgot to change any corresponding robot tests - so those were failing. This PR fixes those tests.

In addition to this, I noticed that the **Pending Invites** page in **Platform Administration** wasn't displaying the **Role** column properly. I've changed the BE to return the `GlobalRoles.Role` enum in the view-model, rather than it's label, and the FE now uses the `globalRoleLabels` that we created in EES-7335 to display them in a consistent way with other places. This is also less prone to bugs because we're not trying to return to the FE **how** the role should be displayed - we're letting the FE handle it. Doing it the same way as elsewhere (using the `globalRoleLabels`) means that if we ever want to change how they're displayed then we only have to make the change in 1 place.