### PR TITLE
EES-7299 - Reintroducing a security policy that is needed in Admin

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSubjectDataAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSubjectDataAuthorizationHandler.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+
+public class ViewSubjectDataAuthorizationHandler(
+    ContentDbContext contentDbContext,
+    IAuthorizationHandlerService authorizationHandlerService
+) : AuthorizationHandler<ViewSubjectDataRequirement, ReleaseSubject>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        ViewSubjectDataRequirement requirement,
+        ReleaseSubject releaseSubject
+    )
+    {
+        // If this data has been published, it is visible to anyone.
+        var releaseVersion = await contentDbContext
+            .ReleaseVersions.Include(rv => rv.Release)
+            .SingleAsync(rv => rv.Id == releaseSubject.ReleaseVersionId);
+
+        if (await authorizationHandlerService.IsReleaseVersionViewableByUser(releaseVersion, context.User))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Security;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
 
@@ -159,6 +160,11 @@ public static class StartupSecurityConfiguration
             );
 
             options.AddPolicy(
+                nameof(DataSecurityPolicies.CanViewSubjectData),
+                policy => policy.Requirements.Add(new ViewSubjectDataRequirement())
+            );
+
+            options.AddPolicy(
                 nameof(SecurityPolicies.CanViewSpecificPreReleaseSummary),
                 policy => policy.Requirements.Add(new ViewSpecificPreReleaseSummaryRequirement())
             );
@@ -305,6 +311,7 @@ public static class StartupSecurityConfiguration
         services.AddTransient<IAuthorizationHandler, MarkReleaseAsHigherLevelReviewAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, MarkReleaseAsApprovedAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, MakeAmendmentOfSpecificReleaseAuthorizationHandler>();
+        services.AddTransient<IAuthorizationHandler, ViewSubjectDataAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, ViewSpecificPreReleaseSummaryAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, ResolveSpecificCommentAuthorizationHandler>();
         services.AddTransient<IAuthorizationHandler, UpdateSpecificCommentAuthorizationHandler>();


### PR DESCRIPTION
During the changes made [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/7199), I accidentally removed a security policy from Admin that looked unused, but in fact **was** used indirectly via Admin's `TableBuilderController` which triggers `GovUk.Education.ExploreEducationStatistics.Data.Services.TableBuilderService.Query` which in turn triggers `GovUk.Education.ExploreEducationStatistics.Data.Services.SubjectResultMetaService.GetSubjectMeta` which **does** use the policy