### PR TITLE
🐛 EES-6901 Fix Public API database conversions in collections requiring `EnumToEnumValueConverter`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -1,7 +1,9 @@
 using System.Numerics;
+using GovUk.Education.ExploreEducationStatistics.Common.Comparers;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Semver;
@@ -133,7 +135,13 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
                         }
                     );
 
-                    ms.Property(msb => msb.GeographicLevels).HasColumnType("text[]");
+                    ms.PrimitiveCollection(msb => msb.GeographicLevels)
+                        .ElementType(b =>
+                            b.HasConversion<
+                                EnumToEnumValueConverter<GeographicLevel>,
+                                EnumValueComparer<GeographicLevel>
+                            >()
+                        );
                 }
             );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GeographicLevelMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GeographicLevelMeta.cs
@@ -1,3 +1,5 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Comparers;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Microsoft.EntityFrameworkCore;
@@ -23,7 +25,11 @@ public class GeographicLevelMeta : ICreatedUpdatedTimestamps<DateTimeOffset, Dat
     {
         public void Configure(EntityTypeBuilder<GeographicLevelMeta> builder)
         {
-            builder.Property(msb => msb.Levels).HasColumnType("text[]");
+            builder
+                .PrimitiveCollection(msb => msb.Levels)
+                .ElementType(b =>
+                    b.HasConversion<EnumToEnumValueConverter<GeographicLevel>, EnumValueComparer<GeographicLevel>>()
+                );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.9")
+                .HasAnnotation("ProductVersion", "10.0.10")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -836,8 +836,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                                 .IsRequired();
 
                             b1.PrimitiveCollection<string>("GeographicLevels")
-                                .IsRequired()
-                                .HasColumnType("text[]");
+                                .IsRequired();
 
                             b1.PrimitiveCollection<string>("Indicators")
                                 .IsRequired();


### PR DESCRIPTION
This PR fixes a bug with the Public API where querying or listing DataSetVersions would throw an error like

> System.InvalidOperationException: Cannot convert string value 'LA' from the database to any value in the mapped 'GeographicLevel' enum.


since #7212 was merged.

**BEFORE** the changes in #7212, data serialized to the Public API's meta database looked as follows:

GeographicLevelMetas.Levels: `{LA,NAT,REG}`
DataSetVersions.MetaSummary.GeographicLevels: `"GeographicLevels": ["LA", "NAT", "REG"]`

**AFTER** the changes in #7212, data serialized to the database looked as follows:

GeographicLevelMetas.Levels: `{LocalAuthority,Country,Region}`
DataSetVersions.MetaSummary.GeographicLevels: `"GeographicLevels": ["LocalAuthority", "Country", "Region"]`

Now with the changes in **this PR**, we see the values revert to being serialized as they were before:

GeographicLevelMetas.Levels: `{LA,NAT,REG}`
DataSetVersions.MetaSummary.GeographicLevels: `"GeographicLevels": ["LA", "NAT", "REG"]`

In #7212 I incorrectly assumed that the conversions configured in `ConfigureConventions` would apply to collections, which is not the case.

### UI Test report

* Running with UI test fixes in #7240

<img width="840" height="99" alt="image" src="https://github.com/user-attachments/assets/05def034-4ae4-4862-b154-a7e49722542a" />
