### PR TITLE
EES-XXXX - swap startup script to use the recommended "dotnet run" rather than "func start" after the .NET 10 upgrade

### DIFF
--- a/useful-scripts/start.ts
+++ b/useful-scripts/start.ts
@@ -400,7 +400,7 @@ async function startService(service: ServiceName): Promise<void> {
       break;
     }
     case 'func': {
-      command = 'func host start';
+      command = 'dotnet run';
       args = ['--port', `${schema.port}`, '--pause-on-error'];
 
       env.ASPNETCORE_ENVIRONMENT ??= 'Development';


### PR DESCRIPTION
This PR:
- addresses a warning in Function App project startups, indicating that "dotnet run" is preferable as a starting command now.