### PR TITLE
EES-7521 Allow access to the Natural language search prototype on Prod

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolSearchPage.tsx
@@ -312,7 +312,7 @@ const TableToolSearchPage: NextPage<TableToolSearchPageProps> = ({
 export const getServerSideProps: GetServerSideProps<
   TableToolSearchPageProps
 > = async ({ query }) => {
-  if (process.env.APP_ENV === 'Production') {
+  if (process.env.APP_ENV === 'Production' && query.prototype !== 'true') {
     return {
       notFound: true,
     };


### PR DESCRIPTION
This PR allows access to the Natural language search prototype pages for each publication on Prod.

It makes a similar change to the one made by @Guy-HiveIT in #7211 to allow access to the Combined Search prototype page.

I found that we don’t need to make any changes to the sitemap for this because we aren’t adding the `/data-tables/<publication-slug>` routes to the sitemap anyway. See the TODO that's already in `sitemapService.ts` that mentions this.

So I didn’t make any changes to `excludes` in `next-sitemap.config.js` like we did in #7211.

We shouldn’t need to add an exclude to the `robots.txt` either, because the pages are not accessible without the query param, so they should not be indexed or followed.