### PR TITLE
EES-7512 Serve published downloads through Azure Front Door

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "directBlobDownloadsEnabled": {
+      "value": false
+    },
     "skuPublic": {
       "value": "B1 Basic"
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "directBlobDownloadsEnabled": {
+      "value": false
+    },
     "skuPublic": {
       "value": "P1V2 PremiumV2"
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "directBlobDownloadsEnabled": {
+      "value": false
+    },
     "skuPublic": {
       "value": "P2V2 PremiumV2"
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "directBlobDownloadsEnabled": {
+      "value": false
+    },
     "skuPublic": {
       "value": "B1 Basic"
     },

--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -19,7 +19,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
 }
 
 module keyVaultRoleAssignmentModule '../../../common/components/key-vault/keyVaultRoleAssignment.bicep' = {
-  name: '${frontDoorName}KeyVaultRoleAssignmentModuleDeploy'
+  name: '${replace(certificateName, '-', '')}KeyVaultRoleAssignmentModuleDeploy'
   params: {
     principalIds: [frontDoor.identity.principalId]
     keyVaultName: keyVaultName

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -19,6 +19,9 @@ param contentApiHostName string
 @description('App Service hostname used as the Content API origin.')
 param contentApiOriginHostName string
 
+@description('Name of the storage account containing published downloads.')
+param publicStorageAccountName string
+
 @description('Certificate type used by Azure Front Door.')
 param certificateType FrontDoorCertificateType
 
@@ -130,6 +133,103 @@ resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
   }
   dependsOn: [
     origin
+  ]
+}
+
+resource publicStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: publicStorageAccountName
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
+  parent: publicStorageAccount
+  name: 'default'
+}
+
+resource downloadsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' existing = {
+  parent: blobService
+  name: 'downloads'
+}
+
+var storageBlobDataReaderRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+)
+
+resource blobDataReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(downloadsContainer.id, frontDoor.id, storageBlobDataReaderRoleId)
+  scope: downloadsContainer
+  properties: {
+    roleDefinitionId: storageBlobDataReaderRoleId
+    principalId: frontDoor.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource blobOriginGroup 'Microsoft.Cdn/profiles/origingroups@2026-04-01-preview' = {
+  parent: frontDoor
+  name: '${contentApiResourcePrefix}-downloads-${abbreviations.frontDoorOriginGroups}'
+  properties: {
+    authentication: {
+      scope: 'https://storage.azure.com/.default'
+      tokenDestinationHeader: 'Authorization'
+      type: 'SystemAssignedIdentity'
+    }
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    sessionAffinityState: 'Disabled'
+  }
+  dependsOn: [
+    blobDataReaderRoleAssignment
+  ]
+}
+
+var blobOriginHostName = '${publicStorageAccountName}.blob.${environment().suffixes.storage}'
+
+resource blobOrigin 'Microsoft.Cdn/profiles/origingroups/origins@2026-04-01-preview' = {
+  parent: blobOriginGroup
+  name: '${contentApiResourcePrefix}-downloads-${abbreviations.frontDoorOrigins}'
+  properties: {
+    hostName: blobOriginHostName
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: blobOriginHostName
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    enforceCertificateNameCheck: true
+  }
+}
+
+resource downloadsRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2026-04-01-preview' = {
+  parent: endpoint
+  name: '${contentApiResourcePrefix}-downloads-${abbreviations.frontDoorRoutes}'
+  properties: {
+    customDomains: [
+      {
+        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+      }
+    ]
+    originGroup: {
+      id: blobOriginGroup.id
+    }
+    ruleSets: []
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/downloads/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+  }
+  dependsOn: [
+    blobOrigin
   ]
 }
 

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -1,0 +1,148 @@
+import { abbreviations } from '../../../common/abbreviations.bicep'
+import { FrontDoorCertificateType } from '../../../common/components/front-door/types.bicep'
+
+@description('Environment subscription prefix.')
+param subscription string
+
+@description('Name of the existing Azure Front Door profile.')
+param frontDoorProfileName string
+
+@description('Name of the existing Azure Front Door endpoint.')
+param frontDoorEndpointName string
+
+@description('Name of the Key Vault containing the Content API certificate.')
+param keyVaultName string
+
+@description('Public hostname of the Content API.')
+param contentApiHostName string
+
+@description('App Service hostname used as the Content API origin.')
+param contentApiOriginHostName string
+
+@description('Certificate type used by Azure Front Door.')
+param certificateType FrontDoorCertificateType
+
+var contentApiResourcePrefix = '${subscription}-ees-content'
+var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
+var certificateName = '${subscription}-as-ees-content-certificate'
+var wafPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafPolicies}'
+
+resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
+  name: frontDoorProfileName
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdendpoints@2025-04-15' existing = {
+  parent: frontDoor
+  name: frontDoorEndpointName
+}
+
+resource originGroup 'Microsoft.Cdn/profiles/origingroups@2025-04-15' = {
+  parent: frontDoor
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorOriginGroups}'
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+resource origin 'Microsoft.Cdn/profiles/origingroups/origins@2025-04-15' = {
+  parent: originGroup
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorOrigins}'
+  properties: {
+    hostName: contentApiOriginHostName
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: contentApiOriginHostName
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    enforceCertificateNameCheck: true
+  }
+}
+
+module certificateModule '../../../common/components/front-door/byoCertificate.bicep' = if (certificateType == 'BringYourOwn') {
+  name: '${contentApiResourcePrefix}CertificateModuleDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    frontDoorName: frontDoorProfileName
+    siteHostName: contentApiHostName
+    certificateName: certificateName
+  }
+}
+
+resource customDomainWithCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'BringYourOwn') {
+  parent: frontDoor
+  name: customDomainName
+  properties: {
+    hostName: contentApiHostName
+    tlsSettings: {
+      certificateType: 'CustomerCertificate'
+      minimumTlsVersion: 'TLS12'
+      cipherSuiteSetType: 'TLS12_2023'
+      secret: {
+        id: certificateModule!.outputs.certificateSecretId
+      }
+    }
+  }
+}
+
+resource customDomainWithManagedCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'Provisioned') {
+  parent: frontDoor
+  name: customDomainName
+  properties: {
+    hostName: contentApiHostName
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+      cipherSuiteSetType: 'TLS12_2023'
+    }
+  }
+}
+
+resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
+  parent: endpoint
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorRoutes}'
+  properties: {
+    customDomains: [
+      {
+        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+      }
+    ]
+    originGroup: {
+      id: originGroup.id
+    }
+    ruleSets: []
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+  }
+  dependsOn: [
+    origin
+  ]
+}
+
+module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
+  name: '${contentApiResourcePrefix}WafSecurityPolicyModuleDeploy'
+  params: {
+    securityPolicyName: '${replace(contentApiResourcePrefix, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
+    wafPolicyName: wafPolicyName
+    customDomainName: customDomainName
+    frontDoorProfileName: frontDoorProfileName
+  }
+  dependsOn: [
+    customDomainWithCertificate
+    customDomainWithManagedCertificate
+  ]
+}

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -86,6 +86,7 @@ module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
     keyVaultName: keyVaultName
     contentApiHostName: contentApiHostName
     contentApiOriginHostName: '${subscription}-as-ees-content.azurewebsites.net'
+    publicStorageAccountName: '${subscription}saeespublic'
     certificateType: certificateType
   }
   dependsOn: [

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -18,6 +18,9 @@ param resourcePrefix string
 @description('URL of the public site.')
 param publicSiteUrl string
 
+@description('URL of the Content API.')
+param contentApiUrl string
+
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
 param certificateType 'Provisioned' | 'BringYourOwn' = 'BringYourOwn'
 
@@ -39,6 +42,7 @@ param tagValues object
 var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}'
 
 var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
+var contentApiHostName = replace(contentApiUrl, 'https://', '')
 
 var certificateName = '${subscription}-as-ees-public-site-certificate'
 
@@ -71,6 +75,22 @@ module frontDoorModule '../../../common/components/front-door/frontDoor.bicep' =
     } : null
     tagValues: tagValues
   }
+}
+
+module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
+  name: '${frontDoorProfileName}ContentApiModuleDeploy'
+  params: {
+    subscription: subscription
+    frontDoorProfileName: frontDoorProfileName
+    frontDoorEndpointName: '${resourcePrefix}-${abbreviations.frontDoorEndpoints}'
+    keyVaultName: keyVaultName
+    contentApiHostName: contentApiHostName
+    contentApiOriginHostName: '${subscription}-as-ees-content.azurewebsites.net'
+    certificateType: certificateType
+  }
+  dependsOn: [
+    frontDoorModule
+  ]
 }
 
 resource nextJsRuleSet 'Microsoft.Cdn/profiles/rulesets@2025-04-15' existing = {

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -13,6 +13,9 @@ param environmentName string
 @description('The public site URL for use with Azure Front Door.')
 param publicSiteUrl string = ''
 
+@description('The public Content API URL for use with Azure Front Door.')
+param contentApiUrl string
+
 @description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
 param publicSiteInternalServiceFqdn string
 
@@ -137,6 +140,7 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = if (deployAzure
     keyVaultName: keyVaultModule.outputs.keyVaultName
     resourcePrefix: resourcePrefix
     publicSiteUrl: publicSiteUrl
+    contentApiUrl: contentApiUrl
     certificateType: certificateType
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
     averagePublicSiteResponseTimeAlertThresholdMillis: averagePublicSiteResponseTimeAlertThresholdMillis

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -4,6 +4,7 @@ using '../main.bicep'
 param environmentName = 'Development'
 
 param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'
+param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
 
 param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -4,6 +4,7 @@ using '../main.bicep'
 param environmentName = 'Pre-Production'
 
 param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'
+param contentApiUrl = 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
 
 param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Production'
 param averagePublicSiteResponseTimeAlertThresholdMillis = 15000
 
 param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
+param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
 
 param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -4,6 +4,7 @@ using '../main.bicep'
 param environmentName = 'Test'
 
 param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'
+param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
 
 param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -8,6 +8,13 @@
     "contentApiUrl": {
       "type": "string"
     },
+    "restrictContentApiOriginToFrontDoor": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Restrict the Content API App Service origin to requests from this environment's Azure Front Door profile. Enable only after the Content API custom domain has been cut over to Front Door."
+      }
+    },
     "dataApiUrl": {
       "type": "string"
     },
@@ -1669,6 +1676,8 @@
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
           "use32BitWorkerProcess": false,
+          "ipSecurityRestrictions": "[if(parameters('restrictContentApiOriginToFrontDoor'), array(createObject('ipAddress', 'AzureFrontDoor.Backend', 'action', 'Allow', 'priority', 100, 'name', 'Allow Azure Front Door', 'description', 'Only allow requests routed through this environment Azure Front Door profile.', 'tag', 'ServiceTag', 'headers', createObject('x-azure-fdid', array(reference(resourceId('Microsoft.Cdn/profiles', variables('frontDoorName')), '2025-04-15').frontDoorId)))), createArray())]",
+          "ipSecurityRestrictionsDefaultAction": "[if(parameters('restrictContentApiOriginToFrontDoor'), 'Deny', 'Allow')]",
           "cors": {
             "allowedOrigins": "[union(variables('publicAllowedOrigins'), array(format('https://{0}', reference(variables('resourceIds').afdEndpoint, variables('apiVersions').afdEndpoint).hostName)))]"
           },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -15,6 +15,13 @@
         "description": "Restrict the Content API App Service origin to requests from this environment's Azure Front Door profile. Enable only after the Content API custom domain has been cut over to Front Door."
       }
     },
+    "directBlobDownloadsEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Redirect published file downloads from the Content API to the Azure Front Door downloads route."
+      }
+    },
     "dataApiUrl": {
       "type": "string"
     },
@@ -1717,7 +1724,8 @@
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
         "enableSwagger": "[parameters('enableSwagger')]",
         "Analytics__Enabled": "[parameters('analyticsEnabled')]",
-        "Analytics__BasePath": "[parameters('analyticsFileShareMountPath')]"
+        "Analytics__BasePath": "[parameters('analyticsFileShareMountPath')]",
+        "DirectBlobDownloads__Enabled": "[parameters('directBlobDownloadsEnabled')]"
       }
     },
     {
@@ -3487,6 +3495,12 @@
           "bypass": "AzureServices",
           "virtualNetworkRules": "[if(parameters('useSubnets'), variables('publicStorageVnetRules'), createArray())]",
           "ipRules": "[parameters('storageFirewallRules')]",
+          "resourceAccessRules": [
+            {
+              "tenantId": "[subscription().tenantId]",
+              "resourceId": "[resourceId('Microsoft.Cdn/profiles', variables('frontDoorName'))]"
+            }
+          ],
           "defaultAction": "Deny"
         }
       },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -654,6 +654,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddTransient<IDataSetValidator, DataSetValidator>();
         services.AddTransient<IFileValidatorService, FileValidatorService>();
         services.AddTransient<IReleaseFileBlobService, PrivateReleaseFileBlobService>();
+        services.AddTransient<IPublicReleaseFileBlobService, PublicReleaseFileBlobService>();
         services.AddSingleton<IBlobSasService, BlobSasService>();
         services.AddTransient<IPrivateBlobStorageService, PrivateBlobStorageService>(
             provider => new PrivateBlobStorageService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobServiceTestUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobServiceTestUtils.cs
@@ -13,6 +13,7 @@ public static class BlobServiceTestUtils
         DateTimeOffset createdOn = default,
         int contentLength = 0,
         string? contentType = null,
+        string? contentEncoding = null,
         IDictionary<string, string>? metadata = null,
         bool exists = true
     )
@@ -27,6 +28,7 @@ public static class BlobServiceTestUtils
             createdOn: createdOn,
             contentLength: contentLength,
             contentType: contentType,
+            contentEncoding: contentEncoding,
             metadata: metadata
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/BlobStorageServiceTests.cs
@@ -31,6 +31,36 @@ public class BlobStorageServiceTests
     private record TestClass(string Value);
 
     [Fact]
+    public async Task UpdateBlobProperties_PreservesExistingHttpHeaders()
+    {
+        const string path = "path/to/test.csv";
+        var blobClient = MockBlobClient(name: path, contentType: "text/csv", contentEncoding: "gzip");
+        BlobHttpHeaders? updatedHeaders = null;
+        blobClient
+            .Setup(client =>
+                client.SetHttpHeadersAsync(It.IsAny<BlobHttpHeaders>(), default, It.IsAny<CancellationToken>())
+            )
+            .Callback<BlobHttpHeaders, BlobRequestConditions?, CancellationToken>(
+                (headers, _, _) => updatedHeaders = headers
+            )
+            .ReturnsAsync((Response<Azure.Storage.Blobs.Models.BlobInfo>)null!);
+        var blobContainerClient = MockBlobContainerClient(PublicReleaseFiles.Name, blobClient);
+        var blobServiceClient = MockBlobServiceClient(blobContainerClient);
+        var service = SetupTestBlobStorageService(blobServiceClient.Object);
+
+        await service.UpdateBlobProperties(
+            PublicReleaseFiles,
+            path,
+            contentDisposition: "attachment; filename=\"test.csv\""
+        );
+
+        Assert.NotNull(updatedHeaders);
+        Assert.Equal("text/csv", updatedHeaders.ContentType);
+        Assert.Equal("gzip", updatedHeaders.ContentEncoding);
+        Assert.Equal("attachment; filename=\"test.csv\"", updatedHeaders.ContentDisposition);
+    }
+
+    [Fact]
     public async Task CheckBlobExists_BlobExists()
     {
         const string path = "path/to/test.pdf";

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpResponseExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/HttpResponseExtensions.cs
@@ -29,9 +29,14 @@ public static class HttpResponseExtensions
     {
         response.ContentType = contentType;
         response.Headers[HeaderNames.ContentDisposition] = filename is not null
-            ? @$"attachment; filename=""{filename}"""
+            ? ContentDispositionAttachmentHeader(filename)
             : "attachment";
 
         return response;
+    }
+
+    public static string ContentDispositionAttachmentHeader(string filename)
+    {
+        return @$"attachment; filename=""{filename}""";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
@@ -8,6 +8,8 @@ public class BlobInfo
 
     public readonly long ContentLength;
 
+    public readonly string? ContentDisposition;
+
     public readonly IDictionary<string, string> Meta;
 
     public readonly DateTimeOffset? Created;
@@ -20,12 +22,14 @@ public class BlobInfo
         long contentLength,
         IDictionary<string, string>? meta = null,
         DateTimeOffset? created = null,
-        DateTimeOffset? updated = null
+        DateTimeOffset? updated = null,
+        string? contentDisposition = null
     )
     {
         Path = path;
         ContentType = contentType;
         ContentLength = contentLength;
+        ContentDisposition = contentDisposition;
         Meta = meta ?? new Dictionary<string, string>();
         Created = created;
         Updated = updated;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -176,6 +176,46 @@ public abstract partial class BlobStorageService(
         await blob.UploadAsync(path: tempFilePath, httpHeaders: new BlobHttpHeaders { ContentType = file.ContentType });
     }
 
+    public async Task UpdateBlobProperties(
+        IBlobContainer containerName,
+        string path,
+        string? contentType = null,
+        string? contentDisposition = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var blob = await GetBlobClient(containerName, path);
+        var properties = await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
+
+        if (contentType is not null || contentDisposition is not null)
+        {
+            await blob.SetHttpHeadersAsync(
+                new BlobHttpHeaders
+                {
+                    CacheControl = properties.Value.CacheControl,
+                    ContentDisposition = contentDisposition ?? properties.Value.ContentDisposition,
+                    ContentEncoding = properties.Value.ContentEncoding,
+                    ContentHash = properties.Value.ContentHash,
+                    ContentLanguage = properties.Value.ContentLanguage,
+                    ContentType = contentType ?? properties.Value.ContentType,
+                },
+                cancellationToken: cancellationToken
+            );
+        }
+
+        if (metadata is not null)
+        {
+            var updatedMetadata = new Dictionary<string, string>(properties.Value.Metadata);
+            foreach (var (key, value) in metadata)
+            {
+                updatedMetadata[key] = value;
+            }
+
+            await blob.SetMetadataAsync(updatedMetadata, cancellationToken: cancellationToken);
+        }
+    }
+
     public async Task<bool> MoveBlob(
         IBlobContainer sourceContainer,
         string sourcePath,
@@ -611,6 +651,7 @@ public abstract partial class BlobStorageService(
                 path: destination.Name,
                 contentType: source.Properties.ContentType,
                 contentLength: source.Properties.Length,
+                contentDisposition: source.Properties.ContentDisposition,
                 meta: source.Metadata,
                 created: source.Properties.Created,
                 updated: source.Properties.LastModified
@@ -739,6 +780,7 @@ public abstract partial class BlobStorageService(
             path: blob.Name,
             contentType: properties.ContentType,
             contentLength: properties.ContentLength,
+            contentDisposition: properties.ContentDisposition,
             meta: properties.Metadata,
             created: properties.CreatedOn,
             updated: properties.LastModified

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -47,6 +47,18 @@ public interface IBlobStorageService
 
     Task UploadFile(IBlobContainer containerName, string path, IFormFile file);
 
+    /// <summary>
+    /// Update selected HTTP headers and metadata on a blob while preserving all values that are not supplied.
+    /// </summary>
+    Task UpdateBlobProperties(
+        IBlobContainer containerName,
+        string path,
+        string? contentType = null,
+        string? contentDisposition = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default
+    );
+
     Task UploadStream(
         IBlobContainer containerName,
         string path,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerDirectBlobDownloadTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerDirectBlobDownloadTests.cs
@@ -1,0 +1,190 @@
+using System.Net.Mime;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
+
+public class ReleaseFileControllerDirectBlobDownloadTests
+{
+    private static readonly DataFixture DataFixture = new();
+
+    [Fact]
+    public async Task Stream_Enabled_RedirectsIndividualPublishedFile()
+    {
+        var releaseVersionId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+        releaseFileService
+            .Setup(service => service.GetFileDownloadRedirectPath(releaseVersionId, fileId, CancellationToken.None))
+            .ReturnsAsync("/downloads/release/data/file.csv");
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        var controller = CreateController(contentDbContext, releaseFileService.Object);
+
+        var result = await controller.Stream(releaseVersionId.ToString(), fileId.ToString());
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/downloads/release/data/file.csv", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Stream_Enabled_UnpublishedFileFallsBackToExistingStreamingPath()
+    {
+        ReleaseVersion releaseVersion = DataFixture.DefaultReleaseVersion().WithPublished(null);
+        var fileId = Guid.NewGuid();
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+        var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+        releaseFileService
+            .Setup(service => service.GetFileDownloadRedirectPath(releaseVersion.Id, fileId, CancellationToken.None))
+            .ReturnsAsync((string?)null);
+        releaseFileService
+            .Setup(service => service.StreamFile(releaseVersion.Id, fileId))
+            .ReturnsAsync(
+                new FileStreamResult(new MemoryStream("draft"u8.ToArray()), MediaTypeNames.Text.Plain)
+                {
+                    FileDownloadName = "draft.txt",
+                }
+            );
+        var controller = CreateController(contentDbContext, releaseFileService.Object);
+
+        var result = await controller.Stream(releaseVersion.Id.ToString(), fileId.ToString());
+
+        Assert.IsType<FileStreamResult>(result);
+        releaseFileService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task StreamFilesToZip_Enabled_RedirectsCachedAllFilesZip()
+    {
+        var releaseVersion = CreatePublishedReleaseVersion();
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+        var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+        releaseFileService
+            .Setup(service =>
+                service.GetAllFilesZipDownloadRedirectPath(
+                    It.Is<ReleaseVersion>(version => version.Id == releaseVersion.Id),
+                    AnalyticsFromPage.ReleaseDownloads,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync("/downloads/release/zip/all-files.zip");
+        var controller = CreateController(contentDbContext, releaseFileService.Object);
+
+        var result = await controller.StreamFilesToZip(releaseVersion.Id, AnalyticsFromPage.ReleaseDownloads);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/downloads/release/zip/all-files.zip", redirect.Url);
+    }
+
+    [Fact]
+    public async Task StreamFilesToZip_Enabled_ColdCacheStreamsAndGeneratesNormally()
+    {
+        var releaseVersion = CreatePublishedReleaseVersion();
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+        var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+        releaseFileService
+            .Setup(service =>
+                service.GetAllFilesZipDownloadRedirectPath(
+                    It.Is<ReleaseVersion>(version => version.Id == releaseVersion.Id),
+                    AnalyticsFromPage.ReleaseDownloads,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync((string?)null);
+        releaseFileService
+            .Setup(service =>
+                service.ZipFilesToStream(
+                    releaseVersion.Id,
+                    It.IsAny<Stream>(),
+                    AnalyticsFromPage.ReleaseDownloads,
+                    null,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(Unit.Instance);
+        var controller = CreateController(contentDbContext, releaseFileService.Object);
+
+        var result = await controller.StreamFilesToZip(releaseVersion.Id, AnalyticsFromPage.ReleaseDownloads);
+
+        Assert.IsType<EmptyResult>(result);
+        releaseFileService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task StreamFilesToZip_Enabled_SelectedFileNeverRedirects()
+    {
+        var releaseVersion = CreatePublishedReleaseVersion();
+        var fileId = Guid.NewGuid();
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+        var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+        releaseFileService
+            .Setup(service =>
+                service.ZipFilesToStream(
+                    releaseVersion.Id,
+                    It.IsAny<Stream>(),
+                    AnalyticsFromPage.ReleaseUsefulInfo,
+                    It.Is<IEnumerable<Guid>>(ids => ids.SequenceEqual(new[] { fileId })),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(Unit.Instance);
+        var controller = CreateController(contentDbContext, releaseFileService.Object);
+
+        var result = await controller.StreamFilesToZip(
+            releaseVersion.Id,
+            AnalyticsFromPage.ReleaseUsefulInfo,
+            new[] { fileId }
+        );
+
+        Assert.IsType<EmptyResult>(result);
+        releaseFileService.VerifyAll();
+    }
+
+    private static ReleaseFileController CreateController(
+        ContentDbContext contentDbContext,
+        IReleaseFileService releaseFileService
+    )
+    {
+        return new ReleaseFileController(
+            new PersistenceHelper<ContentDbContext>(contentDbContext),
+            releaseFileService,
+            Options.Create(new DirectBlobDownloadsOptions { Enabled = true })
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+    }
+
+    private static ReleaseVersion CreatePublishedReleaseVersion()
+    {
+        return DataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(DateTimeOffset.UtcNow.AddHours(-1))
+            .WithRelease(
+                DataFixture
+                    .DefaultRelease()
+                    .WithPublication(DataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
@@ -7,10 +7,12 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 
@@ -18,7 +20,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 [ApiController]
 public class ReleaseFileController(
     IPersistenceHelper<ContentDbContext> persistenceHelper,
-    IReleaseFileService releaseFileService
+    IReleaseFileService releaseFileService,
+    IOptions<DirectBlobDownloadsOptions> directBlobDownloadsOptions
 ) : ControllerBase
 {
     [HttpPost("release-files")]
@@ -36,6 +39,25 @@ public class ReleaseFileController(
     {
         if (Guid.TryParse(releaseVersionId, out var releaseVersionIdGuid) && Guid.TryParse(fileId, out var fileIdGuid))
         {
+            if (directBlobDownloadsOptions.Value.Enabled)
+            {
+                var redirectResult = await releaseFileService.GetFileDownloadRedirectPath(
+                    releaseVersionIdGuid,
+                    fileIdGuid,
+                    HttpContext.RequestAborted
+                );
+
+                if (redirectResult.IsLeft)
+                {
+                    return redirectResult.Left;
+                }
+
+                if (redirectResult.Right is { } redirectPath)
+                {
+                    return Redirect(redirectPath);
+                }
+            }
+
             return await persistenceHelper
                 .CheckEntityExists<ReleaseVersion>(releaseVersionIdGuid)
                 .OnSuccessDo(rv => this.CacheWithLastModified(rv.Published))
@@ -67,36 +89,64 @@ public class ReleaseFileController(
             return BadRequest(ModelState);
         }
 
-        return await persistenceHelper
-            .CheckEntityExists<ReleaseVersion>(
-                releaseVersionId,
-                q => q.Include(rv => rv.Release).ThenInclude(r => r.Publication)
-            )
-            .OnSuccessDo(releaseVersion => this.CacheWithLastModified(releaseVersion.Published))
-            .OnSuccess(async releaseVersion =>
-            {
-                Response.ContentDispositionAttachment(
-                    contentType: MediaTypeNames.Application.Octet,
-                    filename: $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip"
-                );
+        var releaseVersionResult = await persistenceHelper.CheckEntityExists<ReleaseVersion>(
+            releaseVersionId,
+            q => q.Include(rv => rv.Release).ThenInclude(r => r.Publication)
+        );
 
-                // We start the response immediately, before all the files have
-                // even downloaded from blob storage. As we download them, they are
-                // appended in-flight to the user's download.
-                // This is more efficient and means the user doesn't have
-                // to spend time waiting for the download to initiate.
-                return await releaseFileService.ZipFilesToStream(
-                    releaseVersionId: releaseVersionId,
-                    outputStream: Response.BodyWriter.AsStream(),
-                    fromPage: fromPage,
-                    fileIds: fileIds,
-                    cancellationToken: HttpContext.RequestAborted
-                );
-            })
-            .OnFailureDo(result =>
+        if (releaseVersionResult.IsLeft)
+        {
+            return releaseVersionResult.Left;
+        }
+
+        var releaseVersion = releaseVersionResult.Right;
+        var cacheResult = await this.CacheWithLastModified(releaseVersion.Published);
+        if (cacheResult.IsLeft)
+        {
+            return cacheResult.Left;
+        }
+
+        if (directBlobDownloadsOptions.Value.Enabled && fileIds is null)
+        {
+            var redirectResult = await releaseFileService.GetAllFilesZipDownloadRedirectPath(
+                releaseVersion,
+                fromPage,
+                HttpContext.RequestAborted
+            );
+
+            if (redirectResult.IsLeft)
             {
-                Response.StatusCode = result is StatusCodeResult statusCodeResult ? statusCodeResult.StatusCode : 500;
-            })
-            .HandleFailuresOrNoOp();
+                return redirectResult.Left;
+            }
+
+            if (redirectResult.Right is { } redirectPath)
+            {
+                return Redirect(redirectPath);
+            }
+        }
+
+        Response.ContentDispositionAttachment(
+            contentType: MediaTypeNames.Application.Octet,
+            filename: $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip"
+        );
+
+        // Start the response before all files have downloaded and append them in-flight.
+        var streamResult = await releaseFileService.ZipFilesToStream(
+            releaseVersionId: releaseVersionId,
+            outputStream: Response.BodyWriter.AsStream(),
+            fromPage: fromPage,
+            fileIds: fileIds,
+            cancellationToken: HttpContext.RequestAborted
+        );
+
+        if (streamResult.IsLeft)
+        {
+            Response.StatusCode = streamResult.Left is StatusCodeResult statusCodeResult
+                ? statusCodeResult.StatusCode
+                : 500;
+            return streamResult.Left;
+        }
+
+        return new EmptyResult();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -121,6 +121,9 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         // Options - to allow them to be injected into services
         services.AddOptions<AnalyticsOptions>().Bind(configuration.GetSection(AnalyticsOptions.Section));
+        services
+            .AddOptions<DirectBlobDownloadsOptions>()
+            .Bind(configuration.GetSection(DirectBlobDownloadsOptions.Section));
 
         // Services
         services.AddSingleton<IBlobSasService, BlobSasService>();
@@ -171,7 +174,10 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddTransient<IReleaseVersionRepository, ReleaseVersionRepository>();
         services.AddTransient<IReleaseService, ReleaseService>();
         services.AddTransient<IReleaseFileService, ReleaseFileService>();
-        services.AddTransient<IReleaseFileBlobService, PublicReleaseFileBlobService>();
+        services.AddTransient<IPublicReleaseFileBlobService, PublicReleaseFileBlobService>();
+        services.AddTransient<IReleaseFileBlobService>(provider =>
+            provider.GetRequiredService<IPublicReleaseFileBlobService>()
+        );
         services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
         services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
         services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Services/PublicReleaseFileBlobServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Services/PublicReleaseFileBlobServiceTests.cs
@@ -1,0 +1,101 @@
+using System.Net.Mime;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Services;
+
+public class PublicReleaseFileBlobServiceTests
+{
+    [Fact]
+    public async Task GetDownloadRedirectPath_ReturnsNotFound_WhenPublishedBlobDoesNotExist()
+    {
+        var releaseFile = CreateReleaseFile();
+        var blobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        blobStorageService
+            .Setup(service => service.FindBlob(PublicReleaseFiles, releaseFile.PublicPath()))
+            .ReturnsAsync((BlobInfo?)null);
+
+        var result = await new PublicReleaseFileBlobService(blobStorageService.Object).GetDownloadRedirectPath(
+            releaseFile
+        );
+
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task GetDownloadRedirectPath_ReturnsRelativePath_WithoutUpdatingCorrectHeaders()
+    {
+        var releaseFile = CreateReleaseFile();
+        var path = releaseFile.PublicPath();
+        var blobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        blobStorageService
+            .Setup(service => service.FindBlob(PublicReleaseFiles, path))
+            .ReturnsAsync(
+                new BlobInfo(
+                    path: path,
+                    contentType: MediaTypeNames.Application.Pdf,
+                    contentLength: 100,
+                    contentDisposition: "attachment; filename=\"supporting-file.pdf\""
+                )
+            );
+
+        var result = await new PublicReleaseFileBlobService(blobStorageService.Object).GetDownloadRedirectPath(
+            releaseFile
+        );
+
+        Assert.Equal($"/downloads/{path}", result.AssertRight());
+    }
+
+    [Fact]
+    public async Task GetDownloadRedirectPath_RepairsMissingDownloadHeaders()
+    {
+        var releaseFile = CreateReleaseFile();
+        var path = releaseFile.PublicPath();
+        var blobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        blobStorageService
+            .Setup(service => service.FindBlob(PublicReleaseFiles, path))
+            .ReturnsAsync(new BlobInfo(path: path, contentType: string.Empty, contentLength: 100));
+        blobStorageService
+            .Setup(service =>
+                service.UpdateBlobProperties(
+                    PublicReleaseFiles,
+                    path,
+                    MediaTypeNames.Application.Pdf,
+                    "attachment; filename=\"supporting-file.pdf\"",
+                    null,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+
+        var result = await new PublicReleaseFileBlobService(blobStorageService.Object).GetDownloadRedirectPath(
+            releaseFile
+        );
+
+        Assert.Equal($"/downloads/{path}", result.AssertRight());
+        blobStorageService.VerifyAll();
+    }
+
+    private static ReleaseFile CreateReleaseFile()
+    {
+        return new ReleaseFile
+        {
+            ReleaseVersionId = Guid.NewGuid(),
+            File = new File
+            {
+                Id = Guid.NewGuid(),
+                RootPath = Guid.NewGuid(),
+                Filename = "supporting-file.pdf",
+                ContentType = MediaTypeNames.Application.Pdf,
+                Type = FileType.Ancillary,
+            },
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IPublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IPublicReleaseFileBlobService.cs
@@ -1,0 +1,12 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+
+public interface IPublicReleaseFileBlobService : IReleaseFileBlobService
+{
+    Task<Either<ActionResult, string>> GetDownloadRedirectPath(
+        ReleaseFile releaseFile,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -8,8 +9,37 @@ using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
 
-public class PublicReleaseFileBlobService(IPublicBlobStorageService publicBlobStorageService) : IReleaseFileBlobService
+public class PublicReleaseFileBlobService(IPublicBlobStorageService publicBlobStorageService)
+    : IPublicReleaseFileBlobService
 {
+    public async Task<Either<ActionResult, string>> GetDownloadRedirectPath(
+        ReleaseFile releaseFile,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var path = releaseFile.PublicPath();
+        var blob = await publicBlobStorageService.FindBlob(PublicReleaseFiles, path);
+        if (blob is null)
+        {
+            return new NotFoundResult();
+        }
+
+        var contentDisposition = HttpResponseExtensions.ContentDispositionAttachmentHeader(releaseFile.File.Filename);
+
+        if (blob.ContentDisposition != contentDisposition || blob.ContentType != releaseFile.File.ContentType)
+        {
+            await publicBlobStorageService.UpdateBlobProperties(
+                containerName: PublicReleaseFiles,
+                path: path,
+                contentType: releaseFile.File.ContentType,
+                contentDisposition: contentDisposition,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        return $"/downloads/{path}";
+    }
+
     public Task<Either<ActionResult, Stream>> GetDownloadStream(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
@@ -1,0 +1,63 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests;
+
+public class DataSetFileServiceTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public async Task DownloadDataSetFile_DirectDownloadsEnabled_RedirectsLatestPublishedCsv()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+        ReleaseFile releaseFile = _dataFixture
+            .DefaultReleaseFile()
+            .WithReleaseVersion(publication.Releases[0].Versions[0])
+            .WithFile(_dataFixture.DefaultFile(FileType.Data));
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        contentDbContext.ReleaseFiles.Add(releaseFile);
+        await contentDbContext.SaveChangesAsync();
+
+        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+        releaseVersionRepository
+            .Setup(repository =>
+                repository.IsLatestPublishedReleaseVersion(releaseFile.ReleaseVersionId, CancellationToken.None)
+            )
+            .ReturnsAsync(true);
+        var releaseFileBlobService = new Mock<IPublicReleaseFileBlobService>(MockBehavior.Strict);
+        releaseFileBlobService
+            .Setup(service => service.GetDownloadRedirectPath(releaseFile, CancellationToken.None))
+            .ReturnsAsync("/downloads/release/data/file.csv");
+
+        var service = new DataSetFileService(
+            contentDbContext,
+            releaseVersionRepository.Object,
+            releaseFileBlobService.Object,
+            Mock.Of<IFootnoteRepository>(),
+            Mock.Of<IAnalyticsManager>(),
+            Options.Create(new DirectBlobDownloadsOptions { Enabled = true }),
+            Mock.Of<ILogger<DataSetFileService>>()
+        );
+
+        var result = await service.DownloadDataSetFile(releaseFile.File.DataSetFileId!.Value, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/downloads/release/data/file.csv", redirect.Url);
+        releaseFileBlobService.VerifyAll();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -45,6 +46,39 @@ public class ReleaseFileServicePermissionTests
     }
 
     [Fact]
+    public async Task GetFileDownloadRedirectPath()
+    {
+        await PolicyCheckBuilder<ContentSecurityPolicies>()
+            .SetupResourceCheckToFail(ReleaseFile.ReleaseVersion, ContentSecurityPolicies.CanViewSpecificReleaseVersion)
+            .AssertForbidden(userService =>
+            {
+                var persistenceHelper = MockPersistenceHelper<ContentDbContext, ReleaseFile>(ReleaseFile);
+                var service = BuildService(
+                    userService: userService.Object,
+                    persistenceHelper: persistenceHelper.Object
+                );
+
+                return service.GetFileDownloadRedirectPath(ReleaseFile.ReleaseVersionId, ReleaseFile.FileId);
+            });
+    }
+
+    [Fact]
+    public async Task GetAllFilesZipDownloadRedirectPath()
+    {
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(DateTimeOffset.UtcNow.AddHours(-1));
+
+        await PolicyCheckBuilder<ContentSecurityPolicies>()
+            .SetupResourceCheckToFail(releaseVersion, ContentSecurityPolicies.CanViewSpecificReleaseVersion)
+            .AssertForbidden(userService =>
+            {
+                var service = BuildService(userService: userService.Object);
+                return service.GetAllFilesZipDownloadRedirectPath(releaseVersion, AnalyticsFromPage.ReleaseDownloads);
+            });
+    }
+
+    [Fact]
     public async Task ZipFilesToStream()
     {
         ReleaseVersion releaseVersion = _dataFixture
@@ -77,6 +111,7 @@ public class ReleaseFileServicePermissionTests
         ContentDbContext? contentDbContext = null,
         IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
         IPublicBlobStorageService? publicBlobStorageService = null,
+        IPublicReleaseFileBlobService? releaseFileBlobService = null,
         IDataGuidanceFileWriter? dataGuidanceFileWriter = null,
         IUserService? userService = null,
         IAnalyticsManager? analyticsManager = null,
@@ -87,6 +122,7 @@ public class ReleaseFileServicePermissionTests
             contentDbContext ?? Mock.Of<ContentDbContext>(),
             persistenceHelper ?? DefaultPersistenceHelperMock().Object,
             publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(),
+            releaseFileBlobService ?? Mock.Of<IPublicReleaseFileBlobService>(),
             dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(),
             userService ?? Mock.Of<IUserService>(),
             analyticsManager ?? Mock.Of<IAnalyticsManager>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
@@ -84,6 +85,71 @@ public class ReleaseFileServiceTests : IDisposable
             Assert.Equal("ancillary.pdf", result.Right.FileDownloadName);
             Assert.Equal("Test blob", result.Right.FileStream.ReadToEnd());
         }
+    }
+
+    [Fact]
+    public async Task GetFileDownloadRedirectPath_PublishedSupportingFile()
+    {
+        var releaseFile = new ReleaseFile
+        {
+            ReleaseVersion = new ReleaseVersion { Published = DateTimeOffset.UtcNow.AddHours(-1) },
+            File = new Model.File
+            {
+                RootPath = Guid.NewGuid(),
+                Filename = "ancillary.pdf",
+                ContentType = MediaTypeNames.Application.Pdf,
+                Type = Ancillary,
+            },
+        };
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseFiles.Add(releaseFile);
+            await contentDbContext.SaveChangesAsync();
+        }
+        var releaseFileBlobService = new Mock<IPublicReleaseFileBlobService>(MockBehavior.Strict);
+        releaseFileBlobService
+            .Setup(service =>
+                service.GetDownloadRedirectPath(
+                    It.Is<ReleaseFile>(file => file.FileId == releaseFile.FileId),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync("/downloads/release/supporting/ancillary.pdf");
+        await using var serviceDbContext = InMemoryContentDbContext(contentDbContextId);
+        var service = SetupReleaseFileService(serviceDbContext, releaseFileBlobService: releaseFileBlobService.Object);
+
+        var result = await service.GetFileDownloadRedirectPath(releaseFile.ReleaseVersionId, releaseFile.FileId);
+
+        Assert.Equal("/downloads/release/supporting/ancillary.pdf", result.AssertRight());
+        releaseFileBlobService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetFileDownloadRedirectPath_PublishedImage_FallsBackToStreaming()
+    {
+        var releaseFile = new ReleaseFile
+        {
+            ReleaseVersion = new ReleaseVersion { Published = DateTimeOffset.UtcNow.AddHours(-1) },
+            File = new Model.File
+            {
+                RootPath = Guid.NewGuid(),
+                Filename = "image.png",
+                Type = Image,
+            },
+        };
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseFiles.Add(releaseFile);
+            await contentDbContext.SaveChangesAsync();
+        }
+        await using var serviceDbContext = InMemoryContentDbContext(contentDbContextId);
+        var service = SetupReleaseFileService(serviceDbContext);
+
+        var result = await service.GetFileDownloadRedirectPath(releaseFile.ReleaseVersionId, releaseFile.FileId);
+
+        Assert.Null(result.AssertRight());
     }
 
     [Fact]
@@ -909,6 +975,7 @@ public class ReleaseFileServiceTests : IDisposable
                 )
             )
             .Returns(Task.CompletedTask);
+        SetupAllFilesZipProperties(publicBlobStorageService, releaseVersion, allFilesZipPath);
 
         var dataGuidanceFileWriter = new Mock<IDataGuidanceFileWriter>(MockBehavior.Strict);
 
@@ -1059,7 +1126,167 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_StaleCachedAllFilesZip()
+    public async Task GetAllFilesZipDownloadRedirectPath_CachedZip_RecordsAnalyticsOnce()
+    {
+        var now = DateTimeOffset.UtcNow;
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(now.AddDays(-1))
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+        var allFilesZipPath = releaseVersion.AllFilesZipPath();
+        var contentDisposition = HttpResponseExtensions.ContentDispositionAttachmentHeader(
+            releaseVersion.AllFilesZipFileName()
+        );
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: MediaTypeNames.Application.Zip,
+                contentLength: 1000,
+                contentDisposition: contentDisposition,
+                updated: now.AddHours(-2)
+            )
+        );
+
+        var request = new CaptureZipDownloadRequest
+        {
+            PublicationName = releaseVersion.Release.Publication.Title,
+            ReleaseVersionId = releaseVersion.Id,
+            ReleaseName = releaseVersion.Release.Title,
+            ReleaseLabel = releaseVersion.Release.Label,
+            FromPage = AnalyticsFromPage.ReleaseDownloads,
+        };
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        analyticsManager
+            .Setup(manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        var service = SetupReleaseFileService(
+            contentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object
+        );
+
+        var result = await service.GetAllFilesZipDownloadRedirectPath(
+            releaseVersion,
+            AnalyticsFromPage.ReleaseDownloads
+        );
+
+        Assert.Equal($"/downloads/{allFilesZipPath}", result.AssertRight());
+        analyticsManager.Verify(
+            manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task ZipFilesToStream_NoFileIds_AmendmentZipCachedBeforePublicationIsRegenerated()
+    {
+        var published = DateTimeOffset.UtcNow.AddHours(-1);
+
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithVersion(1)
+            .WithPreviousVersionId(Guid.NewGuid())
+            .WithPublished(published)
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+
+        var allFilesZipPath = releaseVersion.AllFilesZipPath();
+
+        // The amendment zip was cached while it was still a draft.
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: "application/zip",
+                contentLength: 1000L,
+                updated: published.AddMinutes(-1)
+            )
+        );
+
+        publicBlobStorageService
+            .Setup(s =>
+                s.UploadStream(
+                    PublicReleaseFiles,
+                    allFilesZipPath,
+                    It.IsAny<Stream>(),
+                    MediaTypeNames.Application.Zip,
+                    null,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+        SetupAllFilesZipProperties(publicBlobStorageService, releaseVersion, allFilesZipPath);
+
+        var request = new CaptureZipDownloadRequest
+        {
+            PublicationName = releaseVersion.Release.Publication.Title,
+            ReleaseVersionId = releaseVersion.Id,
+            ReleaseName = releaseVersion.Release.Title,
+            ReleaseLabel = releaseVersion.Release.Label,
+            FromPage = AnalyticsFromPage.DataCatalogue,
+        };
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        analyticsManager
+            .Setup(m => m.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var serviceDbContext = InMemoryContentDbContext(contentDbContextId);
+        var path = GenerateZipFilePath();
+        await using var stream = File.OpenWrite(path);
+
+        var service = SetupReleaseFileService(
+            contentDbContext: serviceDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object
+        );
+
+        var result = await service.ZipFilesToStream(
+            releaseVersionId: releaseVersion.Id,
+            fromPage: AnalyticsFromPage.DataCatalogue,
+            outputStream: stream
+        );
+
+        result.AssertRight();
+
+        publicBlobStorageService.Verify(
+            s =>
+                s.UploadStream(
+                    PublicReleaseFiles,
+                    allFilesZipPath,
+                    It.IsAny<Stream>(),
+                    MediaTypeNames.Application.Zip,
+                    null,
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task ZipFilesToStream_NoFileIds_CachedAllFilesZipWithMismatchedFormatVersion()
     {
         ReleaseVersion releaseVersion = _dataFixture
             .DefaultReleaseVersion()
@@ -1095,7 +1322,7 @@ public class ReleaseFileServiceTests : IDisposable
 
         var allFilesZipPath = releaseVersion.AllFilesZipPath();
 
-        // 'All files' zip is in blob storage - cached, but stale
+        // 'All files' zip is cached, but was generated using an incompatible structure.
         publicBlobStorageService.SetupFindBlob(
             PublicReleaseFiles,
             allFilesZipPath,
@@ -1103,7 +1330,8 @@ public class ReleaseFileServiceTests : IDisposable
                 path: allFilesZipPath,
                 contentType: "application/zip",
                 contentLength: 1000L,
-                updated: DateTimeOffset.UtcNow.AddMinutes(-60)
+                updated: DateTimeOffset.UtcNow,
+                meta: new Dictionary<string, string> { ["ees-zip-format-version"] = "2" }
             )
         );
 
@@ -1127,6 +1355,7 @@ public class ReleaseFileServiceTests : IDisposable
                 )
             )
             .Returns(Task.CompletedTask);
+        SetupAllFilesZipProperties(publicBlobStorageService, releaseVersion, allFilesZipPath);
 
         var request = new CaptureZipDownloadRequest
         {
@@ -1178,10 +1407,31 @@ public class ReleaseFileServiceTests : IDisposable
         return path;
     }
 
+    private static void SetupAllFilesZipProperties(
+        Mock<IPublicBlobStorageService> publicBlobStorageService,
+        ReleaseVersion releaseVersion,
+        string allFilesZipPath
+    )
+    {
+        publicBlobStorageService
+            .Setup(s =>
+                s.UpdateBlobProperties(
+                    PublicReleaseFiles,
+                    allFilesZipPath,
+                    MediaTypeNames.Application.Zip,
+                    It.Is<string>(value => value.Contains(releaseVersion.AllFilesZipFileName())),
+                    It.Is<IReadOnlyDictionary<string, string>>(metadata => metadata["ees-zip-format-version"] == "1"),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+    }
+
     private static ReleaseFileService SetupReleaseFileService(
         ContentDbContext contentDbContext,
         IPersistenceHelper<ContentDbContext>? contentPersistenceHelper = null,
         IPublicBlobStorageService? publicBlobStorageService = null,
+        IPublicReleaseFileBlobService? releaseFileBlobService = null,
         IDataGuidanceFileWriter? dataGuidanceFileWriter = null,
         IUserService? userService = null,
         IAnalyticsManager? analyticsManager = null,
@@ -1192,6 +1442,7 @@ public class ReleaseFileServiceTests : IDisposable
             contentDbContext,
             contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
             publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(MockBehavior.Strict),
+            releaseFileBlobService ?? Mock.Of<IPublicReleaseFileBlobService>(MockBehavior.Strict),
             dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(MockBehavior.Strict),
             userService ?? MockUtils.AlwaysTrueUserService().Object,
             analyticsManager ?? Mock.Of<IAnalyticsManager>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -22,6 +22,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.DataSetsListRequestSortBy;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
@@ -31,9 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 public class DataSetFileService(
     ContentDbContext contentDbContext,
     IReleaseVersionRepository releaseVersionRepository,
-    IReleaseFileBlobService releaseFileBlobStorageService,
+    IPublicReleaseFileBlobService releaseFileBlobStorageService,
     IFootnoteRepository footnoteRepository,
     IAnalyticsManager analyticsManager,
+    IOptions<DirectBlobDownloadsOptions> directBlobDownloadsOptions,
     ILogger<DataSetFileService> logger
 ) : IDataSetFileService
 {
@@ -308,6 +310,16 @@ public class DataSetFileService(
         }
 
         await RecordCsvDownloadAnalytics(releaseFile, cancellationToken);
+
+        if (directBlobDownloadsOptions.Value.Enabled)
+        {
+            var redirectResult = await releaseFileBlobStorageService.GetDownloadRedirectPath(
+                releaseFile,
+                cancellationToken
+            );
+
+            return redirectResult.IsLeft ? redirectResult.Left : new RedirectResult(redirectResult.Right);
+        }
 
         var streamResult = await releaseFileBlobStorageService.GetDownloadStream(
             releaseFile: releaseFile,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DirectBlobDownloadsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DirectBlobDownloadsOptions.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class DirectBlobDownloadsOptions
+{
+    public const string Section = "DirectBlobDownloads";
+
+    public bool Enabled { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,18 @@ public interface IReleaseFileService
     );
 
     Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseVersionId, Guid fileId);
+
+    Task<Either<ActionResult, string?>> GetFileDownloadRedirectPath(
+        Guid releaseVersionId,
+        Guid fileId,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<Either<ActionResult, string?>> GetAllFilesZipDownloadRedirectPath(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Pipe a zip file containing some release files to a stream.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -27,6 +28,7 @@ public class ReleaseFileService(
     ContentDbContext contentDbContext,
     IPersistenceHelper<ContentDbContext> persistenceHelper,
     IPublicBlobStorageService publicBlobStorageService,
+    IPublicReleaseFileBlobService releaseFileBlobService,
     IDataGuidanceFileWriter dataGuidanceFileWriter,
     IUserService userService,
     IAnalyticsManager analyticsManager,
@@ -36,6 +38,8 @@ public class ReleaseFileService(
     /// How long the all files zip should be
     /// cached in blob storage, in seconds.
     private const int AllFilesZipTtl = 60 * 60;
+    private const string AllFilesZipFormatVersion = "1";
+    private const string AllFilesZipFormatVersionMetadataKey = "ees-zip-format-version";
 
     private static readonly FileType[] AllowedFileTypes = [FileType.Ancillary, FileType.Data];
 
@@ -113,6 +117,87 @@ public class ReleaseFileService(
             });
     }
 
+    public async Task<Either<ActionResult, string?>> GetFileDownloadRedirectPath(
+        Guid releaseVersionId,
+        Guid fileId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var releaseFileResult = await persistenceHelper.CheckEntityExists<ReleaseFile>(q =>
+            q.Include(rf => rf.File)
+                .Include(rf => rf.ReleaseVersion)
+                .Where(rf => rf.ReleaseVersionId == releaseVersionId && rf.FileId == fileId)
+        );
+
+        if (releaseFileResult.IsLeft)
+        {
+            return releaseFileResult.Left;
+        }
+
+        var releaseFile = releaseFileResult.Right;
+        var permissionResult = await userService.CheckCanViewReleaseVersion(releaseFile.ReleaseVersion);
+        if (permissionResult.IsLeft)
+        {
+            return permissionResult.Left;
+        }
+
+        if (
+            releaseFile.ReleaseVersion.Published is null
+            || releaseFile.ReleaseVersion.Published > DateTimeOffset.UtcNow
+            || !AllowedFileTypes.Contains(releaseFile.File.Type)
+        )
+        {
+            return (string?)null;
+        }
+
+        return await releaseFileBlobService.GetDownloadRedirectPath(releaseFile, cancellationToken);
+    }
+
+    public async Task<Either<ActionResult, string?>> GetAllFilesZipDownloadRedirectPath(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow)
+        {
+            return (string?)null;
+        }
+
+        var permissionResult = await userService.CheckCanViewReleaseVersion(releaseVersion);
+        if (permissionResult.IsLeft)
+        {
+            return permissionResult.Left;
+        }
+
+        var allFilesZip = await FindValidAllFilesZip(releaseVersion);
+        if (allFilesZip is null)
+        {
+            return (string?)null;
+        }
+
+        var contentDisposition = HttpResponseExtensions.ContentDispositionAttachmentHeader(
+            releaseVersion.AllFilesZipFileName()
+        );
+
+        if (
+            allFilesZip.ContentDisposition != contentDisposition
+            || allFilesZip.ContentType != MediaTypeNames.Application.Zip
+        )
+        {
+            await publicBlobStorageService.UpdateBlobProperties(
+                containerName: PublicReleaseFiles,
+                path: allFilesZip.Path,
+                contentType: MediaTypeNames.Application.Zip,
+                contentDisposition: contentDisposition,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        await RecordZipDownloadAnalytics(releaseVersion, releaseFiles: null, fromPage, cancellationToken);
+        return $"/downloads/{allFilesZip.Path}";
+    }
+
     public async Task<Either<ActionResult, Unit>> ZipFilesToStream(
         Guid releaseVersionId,
         Stream outputStream,
@@ -166,32 +251,60 @@ public class ReleaseFileService(
         CancellationToken cancellationToken
     )
     {
-        var path = releaseVersion.AllFilesZipPath();
-        var allFilesZip = await publicBlobStorageService.FindBlob(PublicReleaseFiles, path);
-
-        // Ideally, we would have some way to do this caching via annotations,
-        // but this a chunk of work to get working properly as piping
-        // the cached file to target stream isn't super trivial.
-        // For now, we'll just do this manually as it's way easier.
-        if (allFilesZip?.Updated is not null && allFilesZip.Updated.Value.AddSeconds(AllFilesZipTtl) >= DateTime.UtcNow)
+        var allFilesZip = await FindValidAllFilesZip(releaseVersion);
+        if (allFilesZip is null)
         {
-            var streamResult = await publicBlobStorageService.GetDownloadStream(
-                containerName: PublicReleaseFiles,
-                path: path,
-                cancellationToken: cancellationToken
-            );
-
-            if (streamResult.IsLeft)
-            {
-                return false;
-            }
-
-            await using var blobStream = streamResult.Right;
-            await blobStream.CopyToAsync(outputStream, cancellationToken);
-            return true;
+            return false;
         }
 
-        return false;
+        var streamResult = await publicBlobStorageService.GetDownloadStream(
+            containerName: PublicReleaseFiles,
+            path: allFilesZip.Path,
+            cancellationToken: cancellationToken
+        );
+
+        if (streamResult.IsLeft)
+        {
+            return false;
+        }
+
+        await using var blobStream = streamResult.Right;
+        await blobStream.CopyToAsync(outputStream, cancellationToken);
+        return true;
+    }
+
+    private async Task<BlobInfo?> FindValidAllFilesZip(ReleaseVersion releaseVersion)
+    {
+        var allFilesZip = await publicBlobStorageService.FindBlob(PublicReleaseFiles, releaseVersion.AllFilesZipPath());
+
+        // Existing unversioned ZIPs contain the version 1 format and remain valid during rollout.
+        if (
+            allFilesZip?.Meta.TryGetValue(AllFilesZipFormatVersionMetadataKey, out var formatVersion) == true
+            && formatVersion != AllFilesZipFormatVersion
+        )
+        {
+            return null;
+        }
+
+        if (allFilesZip?.Updated is null)
+        {
+            return null;
+        }
+
+        if (releaseVersion.Published is not null && allFilesZip.Updated < releaseVersion.Published)
+        {
+            return null;
+        }
+
+        if (
+            releaseVersion.Published is null
+            && allFilesZip.Updated.Value.AddSeconds(AllFilesZipTtl) < DateTimeOffset.UtcNow
+        )
+        {
+            return null;
+        }
+
+        return allFilesZip;
     }
 
     private async Task ZipAllFilesToStream(
@@ -223,6 +336,20 @@ public class ReleaseFileService(
             path: releaseVersion.AllFilesZipPath(),
             sourceStream: fileStream,
             contentType: MediaTypeNames.Application.Zip,
+            cancellationToken: cancellationToken
+        );
+
+        await publicBlobStorageService.UpdateBlobProperties(
+            containerName: PublicReleaseFiles,
+            path: releaseVersion.AllFilesZipPath(),
+            contentType: MediaTypeNames.Application.Zip,
+            contentDisposition: HttpResponseExtensions.ContentDispositionAttachmentHeader(
+                releaseVersion.AllFilesZipFileName()
+            ),
+            metadata: new Dictionary<string, string>
+            {
+                [AllFilesZipFormatVersionMetadataKey] = AllFilesZipFormatVersion,
+            },
             cancellationToken: cancellationToken
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -1,6 +1,8 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Options;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -85,6 +87,16 @@ public class PublishingService(
                             logger: logger
                         ),
                 }
+            );
+        }
+
+        foreach (var file in files.Where(file => file.Type is Ancillary or FileType.Data))
+        {
+            await publicBlobStorageService.UpdateBlobProperties(
+                containerName: PublicReleaseFiles,
+                path: file.PublicPath(releaseVersion.Id),
+                contentType: file.ContentType,
+                contentDisposition: HttpResponseExtensions.ContentDispositionAttachmentHeader(file.Filename)
             );
         }
     }


### PR DESCRIPTION
## Summary

Implements the EES-7512 direct-download design in two ordered commits:

1. Route the Content API through the existing Azure Front Door Standard profile.
2. Serve immutable published downloads from the private Blob Storage `downloads` container through Azure Front Door.

Existing Content API download URLs remain unchanged. The API performs publication and permission checks, records analytics, and returns a relative `302` redirect; Azure Front Door then transfers the Blob payload without proxying it through the Content API.

## Infrastructure changes

- Adds a dedicated uncached Content API origin group, route and custom-domain association to the existing AFD profile.
- Applies the existing WAF policy to the Content API domain.
- Supports both Key Vault and AFD-managed certificate configurations.
- Adds staged App Service origin restrictions requiring `AzureFrontDoor.Backend` and the profile-specific `X-Azure-FDID`.
- Adds a Blob Storage origin group and `/downloads/*` route for the Content API domain.
- Uses the AFD system-assigned managed identity for Blob origin authentication.
- Grants `Storage Blob Data Reader` only at the `downloads` container scope.
- Retains the storage firewall default action of `Deny` and permits the AFD profile through a resource-instance rule.
- Leaves edge caching and compression disabled initially.

## Application changes

- Adds `DirectBlobDownloads:Enabled`, disabled by default in every environment for controlled rollout and immediate rollback.
- Redirects published data/supporting files and latest data-catalogue CSV downloads to relative `/downloads/...` paths.
- Redirects cached all-files ZIP downloads after recording analytics.
- Retains the existing generation/streaming path for cold all-files ZIP requests.
- Keeps selected-dataset ZIPs, draft files, images, chart files, methodology assets and dynamic exports on their existing paths.
- Preserves authorization, publication-state, missing-file and `X-Robots-Tag: noindex` behaviour.
- Sets download content headers during publication and lazily repairs existing Blob headers without losing content type or encoding.
- Adds all-files ZIP format metadata. Existing unversioned ZIPs are treated as version 1; future version mismatches regenerate through the normal cold-cache path.

## Rollout

1. Deploy the Content API AFD route while direct App Service access remains enabled.
2. Validate the custom domain and streaming endpoints through AFD, then enable the App Service restriction.
3. Deploy Blob-origin infrastructure with direct downloads disabled.
4. Validate managed-identity origin access, range requests and download headers.
5. Enable `DirectBlobDownloads:Enabled` progressively in development, test, pre-production and production.

Disabling the feature flag restores the existing Content API streaming behaviour.

## Validation

- Core Bicep compilation passed.
- Content Services tests: 234 passed.
- Content API tests: 162 passed.
- Content Model tests: 218 passed.
- Blob Storage service tests: 22 passed.
- Publisher tests: 14 passed.
- Content API and Admin builds passed during implementation.

An Azure deployment `what-if` was not run locally because the Azure CLI session does not have deployment credentials; this remains a development-environment validation step.
