### PR TITLE
EES-7523 Fix failing UI test

### DIFF
--- a/tests/robot-tests/README.md
+++ b/tests/robot-tests/README.md
@@ -209,8 +209,7 @@ If searching for an IDE to add/edit these tests, consider using IntelliJ, Pychar
 
 IntelliJ / Pycharm:
 
-- [IntelliBot](https://plugins.jetbrains.com/plugin/7386-intellibot)
-- [Robot Plugin](https://plugins.jetbrains.com/plugin/7430-robot-plugin)
+- [Hyper RobotFramework Support](https://plugins.jetbrains.com/plugin/16382-hyper-robotframework-support)
 
 VScode:
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/edit_data_block_from_replacement.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/edit_data_block_from_replacement.robot
@@ -109,12 +109,11 @@ Upload a replacement data set and verify replacement details and data block erro
     user checks table column heading contains    1    1    Original file
     user checks table column heading contains    1    2    Replacement file
     user checks headed table body row cell contains    Data file import status    2    Complete
-    user waits until h3 is visible    Data blocks: ERROR
 
-Edit data block from the pending data replacement page
-    user opens details dropdown    edit data block from replacement data block name
+    user waits until h3 is visible    Data blocks: OK
+    user waits until h3 is visible    Footnotes: OK
 
-    user clicks link containing text    Edit data block
-    user waits until h2 is visible    Edit data block
-    user clicks link    Back to data replacement page
-    user waits until h2 is visible    Pending data replacement
+    # No confirm button because the replacement data set contains an additional filter and there is a data block
+    # so `hasDataBlockAndReplacementHasAdditionalFilter` is true, and hence the replacement-plan is `valid: false`.
+    # The UI doesn't make this clear, which will be fixed in EES-7524
+    user checks page does not contain button    Confirm data replacement


### PR DESCRIPTION
This PR fixes a failing UI test in `edit_data_block_from_replacement.robot`. 

This UI test failure was introduced by EES-7279. Previously, if replacement data set had additional filters, this would result in the replacement plan's data blocks becoming invalid. After EES-7279, the data blocks aren't now automatically invalid, and instead the plan has a new boolean, `hasDataBlockAndReplacementHasAdditionalFilter`, that signals whether the plan is invalid in this circumstance.

This is just a quick fix to address the failing UI test. The confusing data replacement page UI will be fixed in EES-7524.

### Other changes

- Update the Robot test README.md to refer to a RF plugin that works with newer versions of Pycharm.