### PR TITLE
EES-7512-afd-cache-existing-downloads

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -29,6 +29,12 @@
     "domain": {
       "value": "dev.explore-education-statistics.service.gov.uk"
     },
+    "contentApiUrl": {
+      "value": "content.dev.explore-education-statistics.service.gov.uk"
+    },
+    "azureFrontDoorCachePurgeEnabled": {
+      "value": true
+    },
     "storageAccountPrefix": {
       "value": "sa"
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -23,6 +23,12 @@
     "domain": {
       "value": "pre-production.explore-education-statistics.service.gov.uk"
     },
+    "contentApiUrl": {
+      "value": "cont.pre-production.explore-education-statistics.service.gov.uk"
+    },
+    "azureFrontDoorCachePurgeEnabled": {
+      "value": false
+    },
     "skuContentDb": {
       "value": "Standard"
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -23,6 +23,12 @@
     "domain": {
       "value": "explore-education-statistics.service.gov.uk"
     },
+    "contentApiUrl": {
+      "value": "content.explore-education-statistics.service.gov.uk"
+    },
+    "azureFrontDoorCachePurgeEnabled": {
+      "value": false
+    },
     "storageAccountPrefix": {
       "value": "sa"
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -23,6 +23,12 @@
     "domain": {
       "value": "test.explore-education-statistics.service.gov.uk"
     },
+    "contentApiUrl": {
+      "value": "content.test.explore-education-statistics.service.gov.uk"
+    },
+    "azureFrontDoorCachePurgeEnabled": {
+      "value": false
+    },
     "skuContentDb": {
       "value": "Standard"
     },

--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -19,7 +19,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
 }
 
 module keyVaultRoleAssignmentModule '../../../common/components/key-vault/keyVaultRoleAssignment.bicep' = {
-  name: '${frontDoorName}KeyVaultRoleAssignmentModuleDeploy'
+  name: '${replace(certificateName, '-', '')}KeyVaultRoleAssignmentModuleDeploy'
   params: {
     principalIds: [frontDoor.identity.principalId]
     keyVaultName: keyVaultName

--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -19,7 +19,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
 }
 
 module keyVaultRoleAssignmentModule '../../../common/components/key-vault/keyVaultRoleAssignment.bicep' = {
-  name: '${replace(certificateName, '-', '')}KeyVaultRoleAssignmentModuleDeploy'
+  name: '${replace(certificateName, '-', '')}KvRoleAssignmentDeploy'
   params: {
     principalIds: [frontDoor.identity.principalId]
     keyVaultName: keyVaultName

--- a/infrastructure/templates/common/components/front-door/frontDoor.bicep
+++ b/infrastructure/templates/common/components/front-door/frontDoor.bicep
@@ -42,6 +42,9 @@ param logAnalyticsWorkspaceId string
 @description('Whether to deploy a Web Application Firewall with this Front Door instance.')
 param deployWaf bool
 
+@description('Whether to associate this Front Door custom domain with the Web Application Firewall security policy.')
+param deployWafSecurityPolicy bool = true
+
 @description('Whether to create or update Azure Monitor alerts during this deploy.')
 param alerts {
   latency: bool
@@ -166,12 +169,12 @@ module wafPolicyModule 'wafPolicy.bicep' = if (deployWaf) {
   }
 }
 
-module wafSecurityPolicyModule 'wafSecurityPolicy.bicep' = if (deployWaf) {
+module wafSecurityPolicyModule 'wafSecurityPolicy.bicep' = if (deployWaf && deployWafSecurityPolicy) {
   name: '${frontDoorProfileName}WafSecurityPolicyModule'
   params: {
     securityPolicyName: '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
     wafPolicyName: wafPolicyName
-    customDomainName: customDomainName
+    customDomainNames: [customDomainName]
     frontDoorProfileName: frontDoorProfileName
   }
   dependsOn: [

--- a/infrastructure/templates/common/components/front-door/wafSecurityPolicy.bicep
+++ b/infrastructure/templates/common/components/front-door/wafSecurityPolicy.bicep
@@ -7,8 +7,8 @@ param wafPolicyName string
 @description('Name of the Azure Front Door profile.')
 param frontDoorProfileName string
 
-@description('Name of the custom domain to associate this policy with.')
-param customDomainName string
+@description('Names of the custom domains to associate this policy with.')
+param customDomainNames string[]
 
 resource wafPolicy 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies@2025-10-01' existing = {
   name: wafPolicyName
@@ -16,11 +16,6 @@ resource wafPolicy 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies@20
 
 resource frontDoorProfile 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorProfileName
-}
-
-resource customDomain 'Microsoft.Cdn/profiles/customdomains@2025-04-15' existing = {
-  parent: frontDoorProfile
-  name: customDomainName
 }
 
 resource securityPolicy 'Microsoft.Cdn/profiles/securitypolicies@2025-09-01-preview' = {
@@ -35,8 +30,8 @@ resource securityPolicy 'Microsoft.Cdn/profiles/securitypolicies@2025-09-01-prev
       associations: [
         {
           domains: [
-            {
-              id: customDomain.id
+            for customDomainName in customDomainNames: {
+              id: resourceId('Microsoft.Cdn/profiles/customdomains', frontDoorProfileName, customDomainName)
             }
           ]
           patternsToMatch: [

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -21,6 +21,11 @@ param contentApiOriginHostName string
 var contentApiResourcePrefix = '${subscription}-ees-content'
 var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
 var certificateName = '${subscription}-as-ees-content-afd-certificate'
+var publisherFunctionName = '${subscription}-fa-ees-publisher'
+var cdnEndpointContributorRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '426e0c7f-0c7e-4658-b36f-ff54d6c29b45'
+)
 
 resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorProfileName
@@ -29,6 +34,20 @@ resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
 resource endpoint 'Microsoft.Cdn/profiles/afdendpoints@2025-04-15' existing = {
   parent: frontDoor
   name: frontDoorEndpointName
+}
+
+resource publisherFunction 'Microsoft.Web/sites@2024-04-01' existing = {
+  name: publisherFunctionName
+}
+
+resource publisherFrontDoorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(endpoint.id, publisherFunction.id, cdnEndpointContributorRoleDefinitionId)
+  scope: endpoint
+  properties: {
+    roleDefinitionId: cdnEndpointContributorRoleDefinitionId
+    principalId: publisherFunction.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
 }
 
 resource originGroup 'Microsoft.Cdn/profiles/origingroups@2025-04-15' = {

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -1,5 +1,4 @@
 import { abbreviations } from '../../../common/abbreviations.bicep'
-import { FrontDoorCertificateType } from '../../../common/components/front-door/types.bicep'
 
 @description('Environment subscription prefix.')
 param subscription string
@@ -18,12 +17,6 @@ param contentApiHostName string
 
 @description('App Service hostname used as the Content API origin.')
 param contentApiOriginHostName string
-
-@description('Certificate type used by Azure Front Door.')
-param certificateType FrontDoorCertificateType
-
-@description('Whether to associate the validated custom domain with the Content API routes and WAF policy.')
-param associateCustomDomain bool = false
 
 var contentApiResourcePrefix = '${subscription}-ees-content'
 var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
@@ -67,7 +60,7 @@ resource origin 'Microsoft.Cdn/profiles/origingroups/origins@2025-04-15' = {
   }
 }
 
-module certificateModule '../../../common/components/front-door/byoCertificate.bicep' = if (certificateType == 'BringYourOwn') {
+module certificateModule '../../../common/components/front-door/byoCertificate.bicep' = {
   name: '${contentApiResourcePrefix}CertificateModuleDeploy'
   params: {
     keyVaultName: keyVaultName
@@ -77,7 +70,7 @@ module certificateModule '../../../common/components/front-door/byoCertificate.b
   }
 }
 
-resource customDomainWithCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'BringYourOwn') {
+resource customDomainWithCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = {
   parent: frontDoor
   name: customDomainName
   properties: {
@@ -93,26 +86,13 @@ resource customDomainWithCertificate 'Microsoft.Cdn/profiles/customdomains@2025-
   }
 }
 
-resource customDomainWithManagedCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'Provisioned') {
-  parent: frontDoor
-  name: customDomainName
-  properties: {
-    hostName: contentApiHostName
-    tlsSettings: {
-      certificateType: 'ManagedCertificate'
-      minimumTlsVersion: 'TLS12'
-      cipherSuiteSetType: 'TLS12_2023'
-    }
-  }
-}
-
-resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = if (associateCustomDomain) {
+resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
   parent: endpoint
   name: '${contentApiResourcePrefix}-${abbreviations.frontDoorRoutes}'
   properties: {
     customDomains: [
       {
-        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+        id: customDomainWithCertificate.id
       }
     ]
     originGroup: {
@@ -136,13 +116,13 @@ resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = if (ass
   ]
 }
 
-resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = if (associateCustomDomain) {
+resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
   parent: endpoint
   name: '${contentApiResourcePrefix}-all-files-cache-${abbreviations.frontDoorRoutes}'
   properties: {
     customDomains: [
       {
-        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+        id: customDomainWithCertificate.id
       }
     ]
     originGroup: {
@@ -173,7 +153,7 @@ resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-
   ]
 }
 
-module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = if (associateCustomDomain) {
+module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
   name: '${contentApiResourcePrefix}WafSecurityPolicyModuleDeploy'
   params: {
     securityPolicyName: '${replace(contentApiResourcePrefix, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
@@ -183,6 +163,5 @@ module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurit
   }
   dependsOn: [
     customDomainWithCertificate
-    customDomainWithManagedCertificate
   ]
 }

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -20,7 +20,7 @@ param contentApiOriginHostName string
 
 var contentApiResourcePrefix = '${subscription}-ees-content'
 var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
-var certificateName = '${subscription}-as-ees-content-certificate'
+var certificateName = '${subscription}-as-ees-content-afd-certificate'
 var wafPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafPolicies}'
 
 resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -1,0 +1,185 @@
+import { abbreviations } from '../../../common/abbreviations.bicep'
+import { FrontDoorCertificateType } from '../../../common/components/front-door/types.bicep'
+
+@description('Environment subscription prefix.')
+param subscription string
+
+@description('Name of the existing Azure Front Door profile.')
+param frontDoorProfileName string
+
+@description('Name of the existing Azure Front Door endpoint.')
+param frontDoorEndpointName string
+
+@description('Name of the Key Vault containing the Content API certificate.')
+param keyVaultName string
+
+@description('Public hostname of the Content API.')
+param contentApiHostName string
+
+@description('App Service hostname used as the Content API origin.')
+param contentApiOriginHostName string
+
+@description('Certificate type used by Azure Front Door.')
+param certificateType FrontDoorCertificateType
+
+var contentApiResourcePrefix = '${subscription}-ees-content'
+var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
+var certificateName = '${subscription}-as-ees-content-certificate'
+var wafPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafPolicies}'
+
+resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
+  name: frontDoorProfileName
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdendpoints@2025-04-15' existing = {
+  parent: frontDoor
+  name: frontDoorEndpointName
+}
+
+resource originGroup 'Microsoft.Cdn/profiles/origingroups@2025-04-15' = {
+  parent: frontDoor
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorOriginGroups}'
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+resource origin 'Microsoft.Cdn/profiles/origingroups/origins@2025-04-15' = {
+  parent: originGroup
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorOrigins}'
+  properties: {
+    hostName: contentApiOriginHostName
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: contentApiOriginHostName
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    enforceCertificateNameCheck: true
+  }
+}
+
+module certificateModule '../../../common/components/front-door/byoCertificate.bicep' = if (certificateType == 'BringYourOwn') {
+  name: '${contentApiResourcePrefix}CertificateModuleDeploy'
+  params: {
+    keyVaultName: keyVaultName
+    frontDoorName: frontDoorProfileName
+    siteHostName: contentApiHostName
+    certificateName: certificateName
+  }
+}
+
+resource customDomainWithCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'BringYourOwn') {
+  parent: frontDoor
+  name: customDomainName
+  properties: {
+    hostName: contentApiHostName
+    tlsSettings: {
+      certificateType: 'CustomerCertificate'
+      minimumTlsVersion: 'TLS12'
+      cipherSuiteSetType: 'TLS12_2023'
+      secret: {
+        id: certificateModule!.outputs.certificateSecretId
+      }
+    }
+  }
+}
+
+resource customDomainWithManagedCertificate 'Microsoft.Cdn/profiles/customdomains@2025-04-15' = if (certificateType == 'Provisioned') {
+  parent: frontDoor
+  name: customDomainName
+  properties: {
+    hostName: contentApiHostName
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+      cipherSuiteSetType: 'TLS12_2023'
+    }
+  }
+}
+
+resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
+  parent: endpoint
+  name: '${contentApiResourcePrefix}-${abbreviations.frontDoorRoutes}'
+  properties: {
+    customDomains: [
+      {
+        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+      }
+    ]
+    originGroup: {
+      id: originGroup.id
+    }
+    ruleSets: []
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+  }
+  dependsOn: [
+    origin
+  ]
+}
+
+resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
+  parent: endpoint
+  name: '${contentApiResourcePrefix}-all-files-cache-${abbreviations.frontDoorRoutes}'
+  properties: {
+    customDomains: [
+      {
+        id: certificateType == 'BringYourOwn' ? customDomainWithCertificate.id : customDomainWithManagedCertificate.id
+      }
+    ]
+    originGroup: {
+      id: originGroup.id
+    }
+    ruleSets: []
+    supportedProtocols: [
+      'Http'
+      'Https'
+    ]
+    patternsToMatch: [
+      '/api/all-files/*'
+    ]
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+    cacheConfiguration: {
+      queryStringCachingBehavior: 'IgnoreQueryString'
+      compressionSettings: {
+        isCompressionEnabled: false
+        contentTypesToCompress: []
+      }
+    }
+  }
+  dependsOn: [
+    origin
+  ]
+}
+
+module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
+  name: '${contentApiResourcePrefix}WafSecurityPolicyModuleDeploy'
+  params: {
+    securityPolicyName: '${replace(contentApiResourcePrefix, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
+    wafPolicyName: wafPolicyName
+    customDomainName: customDomainName
+    frontDoorProfileName: frontDoorProfileName
+  }
+  dependsOn: [
+    customDomainWithCertificate
+    customDomainWithManagedCertificate
+  ]
+}

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -22,6 +22,9 @@ param contentApiOriginHostName string
 @description('Certificate type used by Azure Front Door.')
 param certificateType FrontDoorCertificateType
 
+@description('Whether to associate the validated custom domain with the Content API routes and WAF policy.')
+param associateCustomDomain bool = false
+
 var contentApiResourcePrefix = '${subscription}-ees-content'
 var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
 var certificateName = '${subscription}-as-ees-content-certificate'
@@ -103,7 +106,7 @@ resource customDomainWithManagedCertificate 'Microsoft.Cdn/profiles/customdomain
   }
 }
 
-resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
+resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = if (associateCustomDomain) {
   parent: endpoint
   name: '${contentApiResourcePrefix}-${abbreviations.frontDoorRoutes}'
   properties: {
@@ -133,7 +136,7 @@ resource route 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
   ]
 }
 
-resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = {
+resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-04-15' = if (associateCustomDomain) {
   parent: endpoint
   name: '${contentApiResourcePrefix}-all-files-cache-${abbreviations.frontDoorRoutes}'
   properties: {
@@ -170,7 +173,7 @@ resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-
   ]
 }
 
-module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
+module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = if (associateCustomDomain) {
   name: '${contentApiResourcePrefix}WafSecurityPolicyModuleDeploy'
   params: {
     securityPolicyName: '${replace(contentApiResourcePrefix, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'

--- a/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/contentApiFrontDoor.bicep
@@ -21,7 +21,6 @@ param contentApiOriginHostName string
 var contentApiResourcePrefix = '${subscription}-ees-content'
 var customDomainName = '${contentApiResourcePrefix}-${abbreviations.frontDoorDomains}'
 var certificateName = '${subscription}-as-ees-content-afd-certificate'
-var wafPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafPolicies}'
 
 resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorProfileName
@@ -150,18 +149,5 @@ resource allFilesZipCacheRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2025-
   }
   dependsOn: [
     origin
-  ]
-}
-
-module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
-  name: '${contentApiResourcePrefix}WafSecurityPolicyModuleDeploy'
-  params: {
-    securityPolicyName: '${replace(contentApiResourcePrefix, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
-    wafPolicyName: wafPolicyName
-    customDomainName: customDomainName
-    frontDoorProfileName: frontDoorProfileName
-  }
-  dependsOn: [
-    customDomainWithCertificate
   ]
 }

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -25,12 +25,6 @@ param contentApiUrl string
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
 param certificateType FrontDoorCertificateType = 'BringYourOwn'
 
-@description('Choose whether the Content API uses a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
-param contentApiCertificateType FrontDoorCertificateType = 'BringYourOwn'
-
-@description('Whether to associate the validated Content API custom domain with its Azure Front Door routes and WAF policy.')
-param associateContentApiDomain bool = false
-
 @description('Name of the Key Vault instance in which to store certificates.')
 param keyVaultName string
 
@@ -93,8 +87,6 @@ module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
     keyVaultName: keyVaultName
     contentApiHostName: contentApiHostName
     contentApiOriginHostName: '${subscription}-as-ees-content.azurewebsites.net'
-    certificateType: contentApiCertificateType
-    associateCustomDomain: associateContentApiDomain
   }
   dependsOn: [
     frontDoorModule

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -46,6 +46,10 @@ var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
 var contentApiHostName = replace(contentApiUrl, 'https://', '')
 
 var certificateName = '${subscription}-as-ees-public-site-certificate'
+var publicSiteCustomDomainName = '${resourcePrefix}-public-site-${abbreviations.frontDoorDomains}'
+var contentApiCustomDomainName = '${subscription}-ees-content-${abbreviations.frontDoorDomains}'
+var wafPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafPolicies}'
+var wafSecurityPolicyName = '${replace(frontDoorProfileName, '-', '')}${abbreviations.frontDoorWafSecurityPolicies}'
 
 var nextJsRuleSetName = 'nextjsruleset'
 
@@ -57,12 +61,13 @@ module frontDoorModule '../../../common/components/front-door/frontDoor.bicep' =
     keyVaultName: keyVaultName
     siteHostName: publicSiteHostName
     originHostName: '${subscription}-as-ees-public-site.azurewebsites.net'
-    customDomainName: '${resourcePrefix}-public-site-${abbreviations.frontDoorDomains}'
+    customDomainName: publicSiteCustomDomainName
     certificateType: certificateType
     certificateName: certificateType == 'BringYourOwn' ? certificateName : null
     ruleSetNames: [nextJsRuleSetName]
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     deployWaf: true
+    deployWafSecurityPolicy: false
     alerts: deployAlerts ? {
       latency: true
       originHealth: true
@@ -90,6 +95,23 @@ module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
   }
   dependsOn: [
     frontDoorModule
+  ]
+}
+
+module wafSecurityPolicyModule '../../../common/components/front-door/wafSecurityPolicy.bicep' = {
+  name: '${frontDoorProfileName}WafSecurityPolicyModule'
+  params: {
+    securityPolicyName: wafSecurityPolicyName
+    wafPolicyName: wafPolicyName
+    customDomainNames: [
+      publicSiteCustomDomainName
+      contentApiCustomDomainName
+    ]
+    frontDoorProfileName: frontDoorProfileName
+  }
+  dependsOn: [
+    frontDoorModule
+    contentApiFrontDoorModule
   ]
 }
 

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -18,6 +18,9 @@ param resourcePrefix string
 @description('URL of the public site.')
 param publicSiteUrl string
 
+@description('URL of the Content API.')
+param contentApiUrl string
+
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
 param certificateType 'Provisioned' | 'BringYourOwn' = 'BringYourOwn'
 
@@ -39,6 +42,7 @@ param tagValues object
 var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}'
 
 var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
+var contentApiHostName = replace(contentApiUrl, 'https://', '')
 
 var certificateName = '${subscription}-as-ees-public-site-certificate'
 
@@ -71,6 +75,22 @@ module frontDoorModule '../../../common/components/front-door/frontDoor.bicep' =
     } : null
     tagValues: tagValues
   }
+}
+
+module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
+  name: '${frontDoorProfileName}ContentApiModuleDeploy'
+  params: {
+    subscription: subscription
+    frontDoorProfileName: frontDoorProfileName
+    frontDoorEndpointName: '${resourcePrefix}-${abbreviations.frontDoorEndpoints}'
+    keyVaultName: keyVaultName
+    contentApiHostName: contentApiHostName
+    contentApiOriginHostName: '${subscription}-as-ees-content.azurewebsites.net'
+    certificateType: certificateType
+  }
+  dependsOn: [
+    frontDoorModule
+  ]
 }
 
 resource nextJsRuleSet 'Microsoft.Cdn/profiles/rulesets@2025-04-15' existing = {

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -1,4 +1,5 @@
 import { abbreviations } from '../../../common/abbreviations.bicep'
+import { FrontDoorCertificateType } from '../../../common/components/front-door/types.bicep'
 
 @description('Environment: Subscription name. Used as a prefix for created resources.')
 @allowed([
@@ -22,7 +23,13 @@ param publicSiteUrl string
 param contentApiUrl string
 
 @description('Choose whether to use a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
-param certificateType 'Provisioned' | 'BringYourOwn' = 'BringYourOwn'
+param certificateType FrontDoorCertificateType = 'BringYourOwn'
+
+@description('Choose whether the Content API uses a manually-generated Key Vault certificate or a certificate provisioned by Azure Front Door.')
+param contentApiCertificateType FrontDoorCertificateType = 'BringYourOwn'
+
+@description('Whether to associate the validated Content API custom domain with its Azure Front Door routes and WAF policy.')
+param associateContentApiDomain bool = false
 
 @description('Name of the Key Vault instance in which to store certificates.')
 param keyVaultName string
@@ -86,7 +93,8 @@ module contentApiFrontDoorModule 'contentApiFrontDoor.bicep' = {
     keyVaultName: keyVaultName
     contentApiHostName: contentApiHostName
     contentApiOriginHostName: '${subscription}-as-ees-content.azurewebsites.net'
-    certificateType: certificateType
+    certificateType: contentApiCertificateType
+    associateCustomDomain: associateContentApiDomain
   }
   dependsOn: [
     frontDoorModule

--- a/infrastructure/templates/core/ci/azure-pipelines.yml
+++ b/infrastructure/templates/core/ci/azure-pipelines.yml
@@ -33,6 +33,13 @@ parameters:
       - Yes
       - No
     default: No
+  - name: associateContentApiDomain
+    displayName: Has the Content API domain been validated and should it be associated with Azure Front Door routes?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
   - name: deployApplicationGateway
     displayName: Does Application Gateway need creating or updating?
     type: string
@@ -98,6 +105,8 @@ variables:
     value: ${{ iif(eq(parameters.deployPrivateDnsZones, 'Yes'), true, false) }}
   - name: deployAzureFrontDoor
     value: ${{ iif(eq(parameters.deployAzureFrontDoor, 'Yes'), true, false) }}
+  - name: associateContentApiDomain
+    value: ${{ iif(eq(parameters.associateContentApiDomain, 'Yes'), true, false) }}
   - name: deployApplicationGateway
     value: ${{ iif(eq(parameters.deployApplicationGateway, 'Yes'), true, false) }}
   - name: deployDataFactory

--- a/infrastructure/templates/core/ci/azure-pipelines.yml
+++ b/infrastructure/templates/core/ci/azure-pipelines.yml
@@ -33,13 +33,6 @@ parameters:
       - Yes
       - No
     default: No
-  - name: associateContentApiDomain
-    displayName: Has the Content API domain been validated and should it be associated with Azure Front Door routes?
-    type: string
-    values:
-      - Yes
-      - No
-    default: No
   - name: deployApplicationGateway
     displayName: Does Application Gateway need creating or updating?
     type: string
@@ -105,8 +98,6 @@ variables:
     value: ${{ iif(eq(parameters.deployPrivateDnsZones, 'Yes'), true, false) }}
   - name: deployAzureFrontDoor
     value: ${{ iif(eq(parameters.deployAzureFrontDoor, 'Yes'), true, false) }}
-  - name: associateContentApiDomain
-    value: ${{ iif(eq(parameters.associateContentApiDomain, 'Yes'), true, false) }}
   - name: deployApplicationGateway
     value: ${{ iif(eq(parameters.deployApplicationGateway, 'Yes'), true, false) }}
   - name: deployDataFactory

--- a/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
@@ -32,6 +32,7 @@ jobs:
                 deploySubnets: false
                 deployPrivateDnsZones: false
                 deployAzureFrontDoor: false
+                associateContentApiDomain: false
                 deployApplicationGateway: false
                 deployDataFactory: false
                 deployContainerRegistry: false
@@ -47,6 +48,7 @@ jobs:
                 deploySubnets: $(deploySubnets)
                 deployPrivateDnsZones: $(deployPrivateDnsZones)
                 deployAzureFrontDoor: $(deployAzureFrontDoor)
+                associateContentApiDomain: $(associateContentApiDomain)
                 deployApplicationGateway: $(deployApplicationGateway)
                 deployDataFactory: $(deployDataFactory)
                 deployContainerRegistry: $(deployContainerRegistry)

--- a/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/core/ci/jobs/deploy-infrastructure.yml
@@ -32,7 +32,6 @@ jobs:
                 deploySubnets: false
                 deployPrivateDnsZones: false
                 deployAzureFrontDoor: false
-                associateContentApiDomain: false
                 deployApplicationGateway: false
                 deployDataFactory: false
                 deployContainerRegistry: false
@@ -48,7 +47,6 @@ jobs:
                 deploySubnets: $(deploySubnets)
                 deployPrivateDnsZones: $(deployPrivateDnsZones)
                 deployAzureFrontDoor: $(deployAzureFrontDoor)
-                associateContentApiDomain: $(associateContentApiDomain)
                 deployApplicationGateway: $(deployApplicationGateway)
                 deployDataFactory: $(deployDataFactory)
                 deployContainerRegistry: $(deployContainerRegistry)

--- a/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
@@ -17,6 +17,8 @@ parameters:
     type: string
   - name: deployAzureFrontDoor
     type: string
+  - name: associateContentApiDomain
+    type: string
   - name: deployApplicationGateway
     type: string
   - name: deployDataFactory
@@ -50,6 +52,7 @@ steps:
               deploySubnets=${{ parameters.deploySubnets }} \
               deployPrivateDnsZones=${{ parameters.deployPrivateDnsZones }} \
               deployAzureFrontDoor=${{ parameters.deployAzureFrontDoor }} \
+              associateContentApiDomain=${{ parameters.associateContentApiDomain }} \
               deployApplicationGateway=${{ parameters.deployApplicationGateway }} \
               deployDataFactory=${{ parameters.deployDataFactory }} \
               deployContainerRegistry=${{ parameters.deployContainerRegistry }} \

--- a/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/core/ci/tasks/deploy-bicep.yml
@@ -17,8 +17,6 @@ parameters:
     type: string
   - name: deployAzureFrontDoor
     type: string
-  - name: associateContentApiDomain
-    type: string
   - name: deployApplicationGateway
     type: string
   - name: deployDataFactory
@@ -52,7 +50,6 @@ steps:
               deploySubnets=${{ parameters.deploySubnets }} \
               deployPrivateDnsZones=${{ parameters.deployPrivateDnsZones }} \
               deployAzureFrontDoor=${{ parameters.deployAzureFrontDoor }} \
-              associateContentApiDomain=${{ parameters.associateContentApiDomain }} \
               deployApplicationGateway=${{ parameters.deployApplicationGateway }} \
               deployDataFactory=${{ parameters.deployDataFactory }} \
               deployContainerRegistry=${{ parameters.deployContainerRegistry }} \

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -16,6 +16,9 @@ param slackAlertsChannel string = ''
 @description('The public site URL for use with Azure Front Door.')
 param publicSiteUrl string = ''
 
+@description('The public Content API URL for use with Azure Front Door.')
+param contentApiUrl string
+
 @description('FQDN of the service hosting the public site, rather than the public URL as used by custom domains.')
 param publicSiteInternalServiceFqdn string
 
@@ -44,7 +47,7 @@ param deploySubnets bool = false
 param deployPrivateDnsZones bool = false
 
 @description('Whether or not to deploy Azure Front Door.')
-param deployAzureFrontDoor bool = false
+param deployAzureFrontDoor bool = true
 
 @description('Whether or not to deploy Application Gateway and its configuration.')
 param deployApplicationGateway bool = false
@@ -174,6 +177,7 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = if (deployAzure
     keyVaultName: keyVaultModule.outputs.keyVaultName
     resourcePrefix: commonResourcePrefix
     publicSiteUrl: publicSiteUrl
+    contentApiUrl: contentApiUrl
     certificateType: certificateType
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
     averagePublicSiteResponseTimeAlertThresholdMillis: averagePublicSiteResponseTimeAlertThresholdMillis

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -31,12 +31,6 @@ param publicApiApplicationGatewayFqdn string = ''
 @description('Certificate type for Azure Front Door.')
 param certificateType FrontDoorCertificateType = 'BringYourOwn'
 
-@description('Certificate type for the Content API Azure Front Door domain.')
-param contentApiCertificateType FrontDoorCertificateType = 'BringYourOwn'
-
-@description('Whether to associate the validated Content API custom domain with its Azure Front Door routes and WAF policy.')
-param associateContentApiDomain bool = false
-
 @description('The minimum average response time from the public site (via Azure Front Door) before latency alerts fire.')
 param averagePublicSiteResponseTimeAlertThresholdMillis int = 2500
 
@@ -185,8 +179,6 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = if (deployAzure
     publicSiteUrl: publicSiteUrl
     contentApiUrl: contentApiUrl
     certificateType: certificateType
-    contentApiCertificateType: contentApiCertificateType
-    associateContentApiDomain: associateContentApiDomain
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
     averagePublicSiteResponseTimeAlertThresholdMillis: averagePublicSiteResponseTimeAlertThresholdMillis
     deployAlerts: deployAlerts

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -31,6 +31,12 @@ param publicApiApplicationGatewayFqdn string = ''
 @description('Certificate type for Azure Front Door.')
 param certificateType FrontDoorCertificateType = 'BringYourOwn'
 
+@description('Certificate type for the Content API Azure Front Door domain.')
+param contentApiCertificateType FrontDoorCertificateType = 'BringYourOwn'
+
+@description('Whether to associate the validated Content API custom domain with its Azure Front Door routes and WAF policy.')
+param associateContentApiDomain bool = false
+
 @description('The minimum average response time from the public site (via Azure Front Door) before latency alerts fire.')
 param averagePublicSiteResponseTimeAlertThresholdMillis int = 2500
 
@@ -47,7 +53,7 @@ param deploySubnets bool = false
 param deployPrivateDnsZones bool = false
 
 @description('Whether or not to deploy Azure Front Door.')
-param deployAzureFrontDoor bool = true
+param deployAzureFrontDoor bool = false
 
 @description('Whether or not to deploy Application Gateway and its configuration.')
 param deployApplicationGateway bool = false
@@ -179,6 +185,8 @@ module frontDoorModule 'application/frontDoor/frontDoor.bicep' = if (deployAzure
     publicSiteUrl: publicSiteUrl
     contentApiUrl: contentApiUrl
     certificateType: certificateType
+    contentApiCertificateType: contentApiCertificateType
+    associateContentApiDomain: associateContentApiDomain
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
     averagePublicSiteResponseTimeAlertThresholdMillis: averagePublicSiteResponseTimeAlertThresholdMillis
     deployAlerts: deployAlerts

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -5,6 +5,7 @@ param environmentName = 'Development'
 
 param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'
 
+param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
 param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'
 

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -6,7 +6,6 @@ param environmentName = 'Development'
 param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'
 
 param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
-param contentApiCertificateType = 'Provisioned'
 param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'
 

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Development'
 param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azurefd.net'
 
 param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
+param contentApiCertificateType = 'Provisioned'
 param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'
 

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -5,6 +5,7 @@ param environmentName = 'Pre-Production'
 
 param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'
 
+param contentApiUrl = 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
 param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'
 

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Pre-Production'
 param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'
 
 param contentApiUrl = 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
+param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'
 

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -6,7 +6,6 @@ param environmentName = 'Pre-Production'
 param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azurefd.net'
 
 param contentApiUrl = 'https://cont.pre-production.explore-education-statistics.service.gov.uk'
-param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'
 

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -7,6 +7,7 @@ param averagePublicSiteResponseTimeAlertThresholdMillis = 15000
 
 param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
 
+param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
 param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'
 

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -8,7 +8,6 @@ param averagePublicSiteResponseTimeAlertThresholdMillis = 15000
 param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
 
 param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
-param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'
 

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -8,6 +8,7 @@ param averagePublicSiteResponseTimeAlertThresholdMillis = 15000
 param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azurefd.net'
 
 param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
+param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'
 

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -5,6 +5,7 @@ param environmentName = 'Test'
 
 param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'
 
+param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
 param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'
 

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -6,7 +6,6 @@ param environmentName = 'Test'
 param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'
 
 param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
-param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'
 

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Test'
 param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azurefd.net'
 
 param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
+param contentApiCertificateType = 'BringYourOwn'
 param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'
 

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -5,6 +5,16 @@
     "domain": {
       "type": "string"
     },
+    "contentApiUrl": {
+      "type": "string"
+    },
+    "azureFrontDoorCachePurgeEnabled": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Allow the Publisher Function to purge superseded all-files ZIPs from Azure Front Door. Enable per environment after the AFD role assignment has been deployed."
+      }
+    },
     "subscription": {
       "type": "string",
       "defaultValue": "",
@@ -2582,6 +2592,9 @@
         "App__BauEmail": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-bau-email'), '2018-02-14').secretUriWithVersion, ')')]",
         "App__AdminAppUrl": "[variables('adminAppUrl')]",
         "App__PublicAppUrl": "[variables('publicAppUrl')]",
+        "AzureFrontDoor__CachePurgeEnabled": "[parameters('azureFrontDoorCachePurgeEnabled')]",
+        "AzureFrontDoor__EndpointResourceId": "[variables('resourceIds').afdEndpoint]",
+        "AzureFrontDoor__ContentApiHostName": "[parameters('contentApiUrl')]",
         "Notify__ApiKey": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-publisher-govuknotify-api-key'), '2018-02-14').secretUriWithVersion, ')')]",
         "DataFiles__BasePath": "[variables('publicDataFileShareMountPathWindows')]",
         "EventGrid__EventTopics__0__Key": "PublicationChangedEvent",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerStreamTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerStreamTests.cs
@@ -112,6 +112,17 @@ public abstract class ReleaseFileControllerStreamTests(ReleaseFileControllerStre
 
             fixture
                 .ReleaseFileServiceMock.Setup(s =>
+                    s.GetZipDelivery(
+                        It.Is<ReleaseVersion>(rv => rv.Id == releaseVersion.Id),
+                        AnalyticsFromPage.ReleaseUsefulInfo,
+                        It.Is<IEnumerable<Guid>>(ids => ids.SequenceEqual(ListOf(fileId))),
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(new ZipDelivery.Stream(releaseVersion));
+
+            fixture
+                .ReleaseFileServiceMock.Setup(s =>
                     s.ZipFilesToStream(
                         releaseVersion.Id,
                         It.IsAny<Stream>(),
@@ -152,6 +163,17 @@ public abstract class ReleaseFileControllerStreamTests(ReleaseFileControllerStre
 
             fixture
                 .ReleaseFileServiceMock.Setup(s =>
+                    s.GetZipDelivery(
+                        It.Is<ReleaseVersion>(rv => rv.Id == releaseVersion.Id),
+                        AnalyticsFromPage.ReleaseDownloads,
+                        null,
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(new ZipDelivery.Stream(releaseVersion));
+
+            fixture
+                .ReleaseFileServiceMock.Setup(s =>
                     s.ZipFilesToStream(
                         releaseVersion.Id,
                         It.IsAny<Stream>(),
@@ -172,6 +194,91 @@ public abstract class ReleaseFileControllerStreamTests(ReleaseFileControllerStre
             MockUtils.VerifyAllMocks(fixture.ReleaseFileServiceMock);
 
             response.AssertOk("Test zip");
+            Assert.Contains("no-store", response.Headers.CacheControl.ToString());
+        }
+
+        [Fact]
+        public async Task WarmAllFilesZip_RoutesToVersionedPayload()
+        {
+            Publication publication = DataFixture
+                .DefaultPublication()
+                .WithReleases(DataFixture.DefaultRelease(publishedVersions: 1).GenerateList(1));
+
+            var releaseVersion = publication.Releases.Single().Versions.Single();
+
+            await fixture.GetContentDbContext().AddTestData(context => context.Publications.Add(publication));
+
+            var redirectPath = $"/api/all-files/{releaseVersion.Id}/v1";
+            await using var stream = "Test cached zip".ToStream();
+
+            fixture
+                .ReleaseFileServiceMock.Setup(s =>
+                    s.GetZipDelivery(
+                        It.Is<ReleaseVersion>(rv => rv.Id == releaseVersion.Id),
+                        AnalyticsFromPage.ReleaseDownloads,
+                        null,
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(new ZipDelivery.Redirect(redirectPath));
+
+            fixture
+                .ReleaseFileServiceMock.Setup(s =>
+                    s.StreamCachedAllFilesZip(releaseVersion.Id, 1, It.IsAny<CancellationToken>())
+                )
+                .ReturnsAsync(
+                    new FileStreamResult(stream, MediaTypeNames.Application.Zip)
+                    {
+                        FileDownloadName = "release.zip",
+                        EnableRangeProcessing = true,
+                    }
+                );
+
+            var response = await fixture
+                .CreateClient()
+                .GetAsync($"/api/releases/{releaseVersion.Id}/files?fromPage=ReleaseDownloads");
+
+            MockUtils.VerifyAllMocks(fixture.ReleaseFileServiceMock);
+
+            response.AssertOk("Test cached zip");
+            Assert.Contains("s-maxage=3600", response.Headers.CacheControl.ToString());
+            fixture.ReleaseFileServiceMock.Verify(
+                s =>
+                    s.ZipFilesToStream(
+                        It.IsAny<Guid>(),
+                        It.IsAny<Stream>(),
+                        It.IsAny<AnalyticsFromPage>(),
+                        It.IsAny<IEnumerable<Guid>?>(),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Never
+            );
+        }
+
+        [Fact]
+        public async Task VersionedPayload_IsCacheableAndRangeEnabled()
+        {
+            var releaseVersionId = Guid.NewGuid();
+            await using var stream = "Test cached zip".ToStream();
+
+            fixture
+                .ReleaseFileServiceMock.Setup(s =>
+                    s.StreamCachedAllFilesZip(releaseVersionId, 1, It.IsAny<CancellationToken>())
+                )
+                .ReturnsAsync(
+                    new FileStreamResult(stream, MediaTypeNames.Application.Zip)
+                    {
+                        FileDownloadName = "release.zip",
+                        EnableRangeProcessing = true,
+                    }
+                );
+
+            var response = await fixture.CreateClient().GetAsync($"/api/all-files/{releaseVersionId}/v1");
+
+            MockUtils.VerifyAllMocks(fixture.ReleaseFileServiceMock);
+
+            response.AssertOk("Test cached zip");
+            Assert.Contains("s-maxage=3600", response.Headers.CacheControl.ToString());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
@@ -47,7 +47,6 @@ public class ReleaseFileController(
         return NotFound();
     }
 
-    [ResponseCache(Duration = 300)]
     [HttpGet("releases/{releaseVersionId:guid}/files")]
     [Produces(MediaTypeNames.Application.Octet)]
     public async Task<ActionResult> StreamFilesToZip(
@@ -61,6 +60,8 @@ public class ReleaseFileController(
         [FromQuery] IList<Guid>? fileIds = null
     )
     {
+        Response.Headers.CacheControl = "no-store";
+
         if (fileIds is not null && fileIds.Count > 1)
         {
             ModelState.AddModelError("fileIds", "Providing multiple fileIds is deprecated.");
@@ -72,31 +73,65 @@ public class ReleaseFileController(
                 releaseVersionId,
                 q => q.Include(rv => rv.Release).ThenInclude(r => r.Publication)
             )
-            .OnSuccessDo(releaseVersion => this.CacheWithLastModified(releaseVersion.Published))
-            .OnSuccess(async releaseVersion =>
-            {
-                Response.ContentDispositionAttachment(
-                    contentType: MediaTypeNames.Application.Octet,
-                    filename: $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip"
-                );
-
-                // We start the response immediately, before all the files have
-                // even downloaded from blob storage. As we download them, they are
-                // appended in-flight to the user's download.
-                // This is more efficient and means the user doesn't have
-                // to spend time waiting for the download to initiate.
-                return await releaseFileService.ZipFilesToStream(
-                    releaseVersionId: releaseVersionId,
-                    outputStream: Response.BodyWriter.AsStream(),
-                    fromPage: fromPage,
-                    fileIds: fileIds,
-                    cancellationToken: HttpContext.RequestAborted
-                );
-            })
+            .OnSuccess(releaseVersion =>
+                releaseFileService.GetZipDelivery(releaseVersion, fromPage, fileIds, HttpContext.RequestAborted)
+            )
+            .OnSuccess(delivery => DeliverZip(delivery, fromPage, fileIds, HttpContext.RequestAborted))
             .OnFailureDo(result =>
             {
                 Response.StatusCode = result is StatusCodeResult statusCodeResult ? statusCodeResult.StatusCode : 500;
             })
             .HandleFailuresOrNoOp();
+    }
+
+    private async Task<Either<ActionResult, Unit>> DeliverZip(
+        ZipDelivery delivery,
+        AnalyticsFromPage fromPage,
+        IEnumerable<Guid>? fileIds,
+        CancellationToken cancellationToken
+    )
+    {
+        if (delivery is ZipDelivery.Redirect redirect)
+        {
+            Response.Redirect(redirect.Path);
+            return Unit.Instance;
+        }
+
+        var streamDelivery = (ZipDelivery.Stream)delivery;
+
+        Response.ContentDispositionAttachment(
+            contentType: MediaTypeNames.Application.Octet,
+            filename: $"{streamDelivery.ReleaseVersion.Release.Publication.Slug}_{streamDelivery.ReleaseVersion.Release.Slug}.zip"
+        );
+
+        return await releaseFileService.ZipFilesToStream(
+            streamDelivery.ReleaseVersion.Id,
+            Response.BodyWriter.AsStream(),
+            fromPage,
+            fileIds,
+            cancellationToken
+        );
+    }
+
+    [HttpGet("all-files/{releaseVersionId:guid}/v{formatVersion:int}")]
+    [Produces(MediaTypeNames.Application.Zip)]
+    public async Task<ActionResult> StreamCachedAllFilesZip(Guid releaseVersionId, int formatVersion)
+    {
+        var result = await releaseFileService.StreamCachedAllFilesZip(
+            releaseVersionId,
+            formatVersion,
+            HttpContext.RequestAborted
+        );
+
+        if (result.IsLeft)
+        {
+            Response.Headers.CacheControl = "no-store";
+            return result.Left;
+        }
+
+        // This is the only Content API response intended for AFD edge caching.
+        // The versioned, query-free URL gives each ZIP format an unambiguous cache key.
+        Response.Headers.CacheControl = "public, max-age=0, s-maxage=3600";
+        return result.Right;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseVersionExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseVersionExtensionTests.cs
@@ -21,4 +21,27 @@ public class ReleaseVersionExtensionTests
             releaseVersion.AllFilesZipPath()
         );
     }
+
+    [Fact]
+    public void AllFilesZipPath_Version1UsesExistingPath()
+    {
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithRelease(_dataFixture.DefaultRelease().WithPublication(_dataFixture.DefaultPublication()));
+
+        Assert.Equal(releaseVersion.AllFilesZipPath(), releaseVersion.AllFilesZipPath(formatVersion: 1));
+    }
+
+    [Fact]
+    public void AllFilesZipPath_LaterVersionUsesNewPath()
+    {
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithRelease(_dataFixture.DefaultRelease().WithPublication(_dataFixture.DefaultPublication()));
+
+        Assert.Equal(
+            $"{releaseVersion.Id}/zip/v2/{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip",
+            releaseVersion.AllFilesZipPath(formatVersion: 2)
+        );
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/AllFilesZipFormat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/AllFilesZipFormat.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public static class AllFilesZipFormat
+{
+    /// <summary>
+    /// Increment this version whenever the contents or structure of the all-files ZIP changes.
+    /// This creates a new Blob path and AFD cache key, preventing the previous ZIP format from being served.
+    /// </summary>
+    public const int CurrentVersion = 1;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseVersionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseVersionExtensions.cs
@@ -16,6 +16,18 @@ public static class ReleaseVersionExtensions
         return $"{FilesPath(releaseVersion.Id, AllFilesZip)}{releaseVersion.AllFilesZipFileName()}";
     }
 
+    /// <summary>
+    /// The versioned storage path used for newly generated "All files" zip files.
+    /// Changing the format version creates a new blob and a new edge-cache key.
+    /// </summary>
+    public static string AllFilesZipPath(this ReleaseVersion releaseVersion, int formatVersion)
+    {
+        // Version 1 keeps the existing path so rollout does not trigger a mass cold-cache rebuild.
+        return formatVersion == 1
+            ? releaseVersion.AllFilesZipPath()
+            : $"{FilesPath(releaseVersion.Id, AllFilesZip)}v{formatVersion}/{releaseVersion.AllFilesZipFileName()}";
+    }
+
     public static string AllFilesZipFileName(this ReleaseVersion releaseVersion)
     {
         if (releaseVersion.Release?.Publication == null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -90,6 +91,7 @@ public class ReleaseFileServicePermissionTests
             dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(),
             userService ?? Mock.Of<IUserService>(),
             analyticsManager ?? Mock.Of<IAnalyticsManager>(),
+            Mock.Of<IReleaseVersionRepository>(),
             logger ?? Mock.Of<ILogger<ReleaseFileService>>()
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
@@ -1035,6 +1036,91 @@ public class ReleaseFileServiceTests : IDisposable
         );
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetZipDelivery_SupersededPublishedReleaseVersion_ReturnsNotFound(bool selectedFiles)
+    {
+        var releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(DateTimeOffset.UtcNow.AddDays(-1))
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            )
+            .Generate();
+
+        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+        releaseVersionRepository
+            .Setup(repository =>
+                repository.IsLatestPublishedReleaseVersion(releaseVersion.Id, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(false);
+
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        var service = SetupReleaseFileService(
+            contentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object,
+            releaseVersionRepository: releaseVersionRepository.Object
+        );
+
+        var result = await service.GetZipDelivery(
+            releaseVersion,
+            AnalyticsFromPage.ReleaseDownloads,
+            fileIds: selectedFiles ? [Guid.NewGuid()] : null
+        );
+
+        result.AssertNotFound();
+        releaseVersionRepository.VerifyAll();
+        publicBlobStorageService.VerifyNoOtherCalls();
+        analyticsManager.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task GetZipDelivery_UnpublishedReleaseVersion_ReturnsNotFound(
+        bool futurePublication,
+        bool selectedFiles
+    )
+    {
+        var releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(futurePublication ? DateTimeOffset.UtcNow.AddDays(1) : null)
+            .Generate();
+        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        var userService = new Mock<IUserService>(MockBehavior.Strict);
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        var service = SetupReleaseFileService(
+            contentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            userService: userService.Object,
+            analyticsManager: analyticsManager.Object,
+            releaseVersionRepository: releaseVersionRepository.Object
+        );
+
+        var result = await service.GetZipDelivery(
+            releaseVersion,
+            AnalyticsFromPage.ReleaseDownloads,
+            fileIds: selectedFiles ? [Guid.NewGuid()] : null
+        );
+
+        result.AssertNotFound();
+        releaseVersionRepository.VerifyNoOtherCalls();
+        publicBlobStorageService.VerifyNoOtherCalls();
+        userService.VerifyNoOtherCalls();
+        analyticsManager.VerifyNoOtherCalls();
+    }
+
     [Fact]
     public async Task StreamCachedAllFilesZip_CurrentVersion_ReturnsRangeEnabledDownload()
     {
@@ -1082,6 +1168,51 @@ public class ReleaseFileServiceTests : IDisposable
         Assert.Equal(releaseVersion.AllFilesZipFileName(), file.FileDownloadName);
         Assert.Equal(MediaTypeNames.Application.Zip, file.ContentType);
         await file.FileStream.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StreamCachedAllFilesZip_SupersededPublishedReleaseVersion_ReturnsNotFound()
+    {
+        var releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(DateTimeOffset.UtcNow.AddDays(-1))
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            )
+            .Generate();
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+        releaseVersionRepository
+            .Setup(repository =>
+                repository.IsLatestPublishedReleaseVersion(releaseVersion.Id, It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(false);
+
+        await using var testContentDbContext = InMemoryContentDbContext(contentDbContextId);
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        var service = SetupReleaseFileService(
+            testContentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object,
+            releaseVersionRepository: releaseVersionRepository.Object
+        );
+
+        var result = await service.StreamCachedAllFilesZip(releaseVersion.Id, AllFilesZipFormat.CurrentVersion);
+
+        result.AssertNotFound();
+        releaseVersionRepository.VerifyAll();
+        publicBlobStorageService.VerifyNoOtherCalls();
+        analyticsManager.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -1294,6 +1425,7 @@ public class ReleaseFileServiceTests : IDisposable
         IDataGuidanceFileWriter? dataGuidanceFileWriter = null,
         IUserService? userService = null,
         IAnalyticsManager? analyticsManager = null,
+        IReleaseVersionRepository? releaseVersionRepository = null,
         ILogger<ReleaseFileService>? logger = null
     )
     {
@@ -1304,6 +1436,11 @@ public class ReleaseFileServiceTests : IDisposable
             dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(MockBehavior.Strict),
             userService ?? MockUtils.AlwaysTrueUserService().Object,
             analyticsManager ?? Mock.Of<IAnalyticsManager>(),
+            releaseVersionRepository
+                ?? Mock.Of<IReleaseVersionRepository>(repository =>
+                    repository.IsLatestPublishedReleaseVersion(It.IsAny<Guid>(), It.IsAny<CancellationToken>())
+                    == Task.FromResult(true)
+                ),
             logger ?? Mock.Of<ILogger<ReleaseFileService>>(MockBehavior.Strict)
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -980,7 +980,7 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetZipDelivery_PublishedCachedZip_ReturnsRedirectAndRecordsAnalyticsOnce()
+    public async Task GetZipDelivery_AfdPoc_PublishedAllFilesRedirectsWithoutCheckingCombinedZipBlob()
     {
         var now = DateTimeOffset.UtcNow;
         ReleaseVersion releaseVersion = _dataFixture
@@ -992,18 +992,7 @@ public class ReleaseFileServiceTests : IDisposable
                     .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
             );
 
-        var allFilesZipPath = releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion);
         var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
-        publicBlobStorageService.SetupFindBlob(
-            PublicReleaseFiles,
-            allFilesZipPath,
-            new BlobInfo(
-                path: allFilesZipPath,
-                contentType: MediaTypeNames.Application.Zip,
-                contentLength: 1000,
-                updated: now.AddHours(-2)
-            )
-        );
 
         var request = new CaptureZipDownloadRequest
         {
@@ -1032,6 +1021,11 @@ public class ReleaseFileServiceTests : IDisposable
         analyticsManager.Verify(
             manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()),
             Times.Once
+        );
+        publicBlobStorageService.Verify(
+            service =>
+                service.FindBlob(PublicReleaseFiles, releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion)),
+            Times.Never
         );
     }
 
@@ -1085,7 +1079,7 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_PublishedCachedAllFilesZipDoesNotExpire()
+    public async Task ZipFilesToStream_NoFileIds_AfdPoc_DoesNotReadPublishedCachedAllFilesZip()
     {
         var now = DateTimeOffset.UtcNow;
         ReleaseVersion releaseVersion = _dataFixture
@@ -1160,8 +1154,18 @@ public class ReleaseFileServiceTests : IDisposable
             result.AssertRight();
 
             await stream.DisposeAsync();
-            await using var zip = File.OpenRead(path);
-            Assert.Equal("Test cached all files zip", zip.ReadToEnd());
+            using var zip = ZipFile.OpenRead(path);
+            Assert.Empty(zip.Entries);
+
+            publicBlobStorageService.Verify(
+                service => service.FindBlob(PublicReleaseFiles, allFilesZipPath),
+                Times.Never
+            );
+            publicBlobStorageService.Verify(
+                service =>
+                    service.GetDownloadStream(PublicReleaseFiles, allFilesZipPath, true, It.IsAny<CancellationToken>()),
+                Times.Never
+            );
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -980,10 +980,117 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_CachedAllFilesZip()
+    public async Task GetZipDelivery_PublishedCachedZip_ReturnsRedirectAndRecordsAnalyticsOnce()
     {
+        var now = DateTimeOffset.UtcNow;
         ReleaseVersion releaseVersion = _dataFixture
             .DefaultReleaseVersion()
+            .WithPublished(now.AddDays(-1))
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+
+        var allFilesZipPath = releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion);
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: MediaTypeNames.Application.Zip,
+                contentLength: 1000,
+                updated: now.AddHours(-2)
+            )
+        );
+
+        var request = new CaptureZipDownloadRequest
+        {
+            PublicationName = releaseVersion.Release.Publication.Title,
+            ReleaseVersionId = releaseVersion.Id,
+            ReleaseName = releaseVersion.Release.Title,
+            ReleaseLabel = releaseVersion.Release.Label,
+            FromPage = AnalyticsFromPage.ReleaseDownloads,
+        };
+        var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+        analyticsManager
+            .Setup(manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
+        var service = SetupReleaseFileService(
+            contentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object,
+            analyticsManager: analyticsManager.Object
+        );
+
+        var result = await service.GetZipDelivery(releaseVersion, AnalyticsFromPage.ReleaseDownloads, fileIds: null);
+
+        var redirect = Assert.IsType<ZipDelivery.Redirect>(result.AssertRight());
+        Assert.Equal($"/api/all-files/{releaseVersion.Id}/v{AllFilesZipFormat.CurrentVersion}", redirect.Path);
+        analyticsManager.Verify(
+            manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task StreamCachedAllFilesZip_CurrentVersion_ReturnsRangeEnabledDownload()
+    {
+        var now = DateTimeOffset.UtcNow;
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(now.AddDays(-1))
+            .WithRelease(
+                _dataFixture
+                    .DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
+            );
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var allFilesZipPath = releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion);
+        var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: MediaTypeNames.Application.Zip,
+                contentLength: 1000,
+                updated: now
+            )
+        );
+        publicBlobStorageService.SetupGetDownloadStream(PublicReleaseFiles, allFilesZipPath, "Test cached zip");
+
+        await using var testContentDbContext = InMemoryContentDbContext(contentDbContextId);
+        var service = SetupReleaseFileService(
+            testContentDbContext,
+            publicBlobStorageService: publicBlobStorageService.Object
+        );
+
+        var result = await service.StreamCachedAllFilesZip(releaseVersion.Id, AllFilesZipFormat.CurrentVersion);
+
+        var file = result.AssertRight();
+        Assert.True(file.EnableRangeProcessing);
+        Assert.Equal(releaseVersion.AllFilesZipFileName(), file.FileDownloadName);
+        Assert.Equal(MediaTypeNames.Application.Zip, file.ContentType);
+        await file.FileStream.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ZipFilesToStream_NoFileIds_PublishedCachedAllFilesZipDoesNotExpire()
+    {
+        var now = DateTimeOffset.UtcNow;
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPublished(now.AddDays(-1))
             .WithRelease(
                 _dataFixture
                     .DefaultRelease()
@@ -1010,7 +1117,7 @@ public class ReleaseFileServiceTests : IDisposable
                 path: allFilesZipPath,
                 contentType: "application/zip",
                 contentLength: 1000L,
-                updated: DateTimeOffset.UtcNow.AddMinutes(-5)
+                updated: now.AddHours(-2)
             )
         );
 
@@ -1059,10 +1166,12 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_StaleCachedAllFilesZip()
+    public async Task ZipFilesToStream_NoFileIds_ZipCachedBeforePublicationIsRegenerated()
     {
+        var published = DateTimeOffset.UtcNow.AddMinutes(-30);
         ReleaseVersion releaseVersion = _dataFixture
             .DefaultReleaseVersion()
+            .WithPublished(published)
             .WithRelease(
                 _dataFixture
                     .DefaultRelease()
@@ -1095,7 +1204,7 @@ public class ReleaseFileServiceTests : IDisposable
 
         var allFilesZipPath = releaseVersion.AllFilesZipPath();
 
-        // 'All files' zip is in blob storage - cached, but stale
+        // The zip was cached while the release was still a draft.
         publicBlobStorageService.SetupFindBlob(
             PublicReleaseFiles,
             allFilesZipPath,
@@ -1103,7 +1212,7 @@ public class ReleaseFileServiceTests : IDisposable
                 path: allFilesZipPath,
                 contentType: "application/zip",
                 contentLength: 1000L,
-                updated: DateTimeOffset.UtcNow.AddMinutes(-60)
+                updated: published.AddMinutes(-30)
             )
         );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -980,7 +980,7 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetZipDelivery_AfdPoc_PublishedAllFilesRedirectsWithoutCheckingCombinedZipBlob()
+    public async Task GetZipDelivery_PublishedCachedZip_ReturnsRedirectAndRecordsAnalyticsOnce()
     {
         var now = DateTimeOffset.UtcNow;
         ReleaseVersion releaseVersion = _dataFixture
@@ -992,7 +992,18 @@ public class ReleaseFileServiceTests : IDisposable
                     .WithPublication(_dataFixture.DefaultPublication().WithSlug("publication-slug"))
             );
 
+        var allFilesZipPath = releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion);
         var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
+        publicBlobStorageService.SetupFindBlob(
+            PublicReleaseFiles,
+            allFilesZipPath,
+            new BlobInfo(
+                path: allFilesZipPath,
+                contentType: MediaTypeNames.Application.Zip,
+                contentLength: 1000,
+                updated: now.AddHours(-2)
+            )
+        );
 
         var request = new CaptureZipDownloadRequest
         {
@@ -1021,11 +1032,6 @@ public class ReleaseFileServiceTests : IDisposable
         analyticsManager.Verify(
             manager => manager.Add(ItIs.DeepEqualTo(request), It.IsAny<CancellationToken>()),
             Times.Once
-        );
-        publicBlobStorageService.Verify(
-            service =>
-                service.FindBlob(PublicReleaseFiles, releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion)),
-            Times.Never
         );
     }
 
@@ -1079,7 +1085,7 @@ public class ReleaseFileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ZipFilesToStream_NoFileIds_AfdPoc_DoesNotReadPublishedCachedAllFilesZip()
+    public async Task ZipFilesToStream_NoFileIds_PublishedCachedAllFilesZipDoesNotExpire()
     {
         var now = DateTimeOffset.UtcNow;
         ReleaseVersion releaseVersion = _dataFixture
@@ -1154,18 +1160,8 @@ public class ReleaseFileServiceTests : IDisposable
             result.AssertRight();
 
             await stream.DisposeAsync();
-            using var zip = ZipFile.OpenRead(path);
-            Assert.Empty(zip.Entries);
-
-            publicBlobStorageService.Verify(
-                service => service.FindBlob(PublicReleaseFiles, allFilesZipPath),
-                Times.Never
-            );
-            publicBlobStorageService.Verify(
-                service =>
-                    service.GetDownloadStream(PublicReleaseFiles, allFilesZipPath, true, It.IsAny<CancellationToken>()),
-                Times.Never
-            );
+            await using var zip = File.OpenRead(path);
+            Assert.Equal("Test cached all files zip", zip.ReadToEnd());
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,19 @@ public interface IReleaseFileService
     );
 
     Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseVersionId, Guid fileId);
+
+    Task<Either<ActionResult, ZipDelivery>> GetZipDelivery(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        IEnumerable<Guid>? fileIds,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<Either<ActionResult, FileStreamResult>> StreamCachedAllFilesZip(
+        Guid releaseVersionId,
+        int formatVersion,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Pipe a zip file containing some release files to a stream.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/ZipDelivery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/ZipDelivery.cs
@@ -1,0 +1,10 @@
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+public abstract record ZipDelivery
+{
+    public sealed record Redirect(string Path) : ZipDelivery;
+
+    public sealed record Stream(ReleaseVersion ReleaseVersion) : ZipDelivery;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -33,10 +33,6 @@ public class ReleaseFileService(
     ILogger<ReleaseFileService> logger
 ) : IReleaseFileService
 {
-    /// How long the all files zip should be
-    /// cached in blob storage, in seconds.
-    private const int AllFilesZipTtl = 60 * 60;
-
     private static readonly FileType[] AllowedFileTypes = [FileType.Ancillary, FileType.Data];
 
     public async Task<Either<ActionResult, IList<ReleaseFileViewModel>>> ListReleaseFiles(
@@ -113,6 +109,67 @@ public class ReleaseFileService(
             });
     }
 
+    public async Task<Either<ActionResult, ZipDelivery>> GetZipDelivery(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        IEnumerable<Guid>? fileIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (fileIds is not null || releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow)
+        {
+            return new ZipDelivery.Stream(releaseVersion);
+        }
+
+        var permissionResult = await userService.CheckCanViewReleaseVersion(releaseVersion);
+        if (permissionResult.IsLeft)
+        {
+            return permissionResult.Left;
+        }
+
+        if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
+        {
+            return new ZipDelivery.Stream(releaseVersion);
+        }
+
+        await RecordZipDownloadAnalytics(releaseVersion, releaseFiles: null, fromPage, cancellationToken);
+
+        return new ZipDelivery.Redirect($"/api/all-files/{releaseVersion.Id}/v{AllFilesZipFormat.CurrentVersion}");
+    }
+
+    public async Task<Either<ActionResult, FileStreamResult>> StreamCachedAllFilesZip(
+        Guid releaseVersionId,
+        int formatVersion,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (formatVersion != AllFilesZipFormat.CurrentVersion)
+        {
+            return new NotFoundResult();
+        }
+
+        return await contentDbContext
+            .ReleaseVersions.Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
+            .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
+            .OnSuccess(EnsurePublished)
+            .OnSuccess(userService.CheckCanViewReleaseVersion)
+            .OnSuccessCombineWith(releaseVersion => FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion))
+            .OnSuccess(releaseVersionAndZip =>
+                publicBlobStorageService
+                    .GetDownloadStream(
+                        PublicReleaseFiles,
+                        releaseVersionAndZip.Item2.Path,
+                        cancellationToken: cancellationToken
+                    )
+                    .OnSuccess(stream => new FileStreamResult(stream, MediaTypeNames.Application.Zip)
+                    {
+                        FileDownloadName = releaseVersionAndZip.Item1.AllFilesZipFileName(),
+                        EnableRangeProcessing = true,
+                    })
+            );
+    }
+
     public async Task<Either<ActionResult, Unit>> ZipFilesToStream(
         Guid releaseVersionId,
         Stream outputStream,
@@ -166,18 +223,12 @@ public class ReleaseFileService(
         CancellationToken cancellationToken
     )
     {
-        var path = releaseVersion.AllFilesZipPath();
-        var allFilesZip = await publicBlobStorageService.FindBlob(PublicReleaseFiles, path);
-
-        // Ideally, we would have some way to do this caching via annotations,
-        // but this a chunk of work to get working properly as piping
-        // the cached file to target stream isn't super trivial.
-        // For now, we'll just do this manually as it's way easier.
-        if (allFilesZip?.Updated is not null && allFilesZip.Updated.Value.AddSeconds(AllFilesZipTtl) >= DateTime.UtcNow)
+        var allFilesZip = await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion);
+        if (allFilesZip is not null)
         {
             var streamResult = await publicBlobStorageService.GetDownloadStream(
                 containerName: PublicReleaseFiles,
-                path: path,
+                path: allFilesZip.Path,
                 cancellationToken: cancellationToken
             );
 
@@ -192,6 +243,43 @@ public class ReleaseFileService(
         }
 
         return false;
+    }
+
+    private async Task<BlobInfo?> FindValidAllFilesZip(ReleaseVersion releaseVersion, int formatVersion)
+    {
+        if (releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow)
+        {
+            return null;
+        }
+
+        var allFilesZip = await publicBlobStorageService.FindBlob(
+            PublicReleaseFiles,
+            releaseVersion.AllFilesZipPath(formatVersion)
+        );
+
+        if (allFilesZip?.Updated is null)
+        {
+            return null;
+        }
+
+        return allFilesZip.Updated >= releaseVersion.Published ? allFilesZip : null;
+    }
+
+    private static Either<ActionResult, ReleaseVersion> EnsurePublished(ReleaseVersion releaseVersion)
+    {
+        return releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow
+            ? new NotFoundResult()
+            : releaseVersion;
+    }
+
+    private async Task<Either<ActionResult, BlobInfo>> FindValidAllFilesZipOrNotFound(
+        ReleaseVersion releaseVersion,
+        int formatVersion
+    )
+    {
+        return await FindValidAllFilesZip(releaseVersion, formatVersion) is { } allFilesZip
+            ? allFilesZip
+            : new NotFoundResult();
     }
 
     private async Task ZipAllFilesToStream(
@@ -220,7 +308,7 @@ public class ReleaseFileService(
 
         await publicBlobStorageService.UploadStream(
             containerName: PublicReleaseFiles,
-            path: releaseVersion.AllFilesZipPath(),
+            path: releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion),
             sourceStream: fileStream,
             contentType: MediaTypeNames.Application.Zip,
             cancellationToken: cancellationToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -127,10 +127,12 @@ public class ReleaseFileService(
             return permissionResult.Left;
         }
 
-        if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
-        {
-            return new ZipDelivery.Stream(releaseVersion);
-        }
+        // Temporarily disabled for the AFD-generated ZIP POC. Published all-files
+        // requests always redirect to the versioned endpoint so AFD can cache its response.
+        // if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
+        // {
+        //     return new ZipDelivery.Stream(releaseVersion);
+        // }
 
         await RecordZipDownloadAnalytics(releaseVersion, releaseFiles: null, fromPage, cancellationToken);
 
@@ -148,26 +150,69 @@ public class ReleaseFileService(
             return new NotFoundResult();
         }
 
-        return await contentDbContext
+        var releaseVersionResult = await contentDbContext
             .ReleaseVersions.Include(rv => rv.Release)
                 .ThenInclude(r => r.Publication)
             .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
             .OnSuccess(EnsurePublished)
-            .OnSuccess(userService.CheckCanViewReleaseVersion)
-            .OnSuccessCombineWith(releaseVersion => FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion))
-            .OnSuccess(releaseVersionAndZip =>
-                publicBlobStorageService
-                    .GetDownloadStream(
-                        PublicReleaseFiles,
-                        releaseVersionAndZip.Item2.Path,
-                        cancellationToken: cancellationToken
-                    )
-                    .OnSuccess(stream => new FileStreamResult(stream, MediaTypeNames.Application.Zip)
-                    {
-                        FileDownloadName = releaseVersionAndZip.Item1.AllFilesZipFileName(),
-                        EnableRangeProcessing = true,
-                    })
+            .OnSuccess(userService.CheckCanViewReleaseVersion);
+
+        if (releaseVersionResult.IsLeft)
+        {
+            return releaseVersionResult.Left;
+        }
+
+        var releaseVersion = releaseVersionResult.Right;
+
+        // Temporarily disabled for the AFD-generated ZIP POC. The versioned endpoint
+        // generates a fresh ZIP on an AFD cache miss instead of reading the combined ZIP
+        // from Blob Storage.
+        // return await FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion)
+        //     .OnSuccess(allFilesZip =>
+        //         publicBlobStorageService
+        //             .GetDownloadStream(
+        //                 PublicReleaseFiles,
+        //                 allFilesZip.Path,
+        //                 cancellationToken: cancellationToken
+        //             )
+        //             .OnSuccess(stream => new FileStreamResult(stream, MediaTypeNames.Application.Zip)
+        //             {
+        //                 FileDownloadName = releaseVersion.AllFilesZipFileName(),
+        //                 EnableRangeProcessing = true,
+        //             })
+        //     );
+
+        var temporaryZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
+        var temporaryZipStream = new FileStream(
+            temporaryZipPath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.Read,
+            bufferSize: 81920,
+            FileOptions.Asynchronous | FileOptions.DeleteOnClose
+        );
+
+        try
+        {
+            await ZipAllFilesToStream(
+                releaseVersion,
+                temporaryZipStream,
+                cancellationToken,
+                leaveOutputStreamOpen: true
             );
+            temporaryZipStream.Position = 0;
+
+            return new FileStreamResult(temporaryZipStream, MediaTypeNames.Application.Zip)
+            {
+                FileDownloadName = releaseVersion.AllFilesZipFileName(),
+                EnableRangeProcessing = true,
+            };
+        }
+        catch
+        {
+            await temporaryZipStream.DisposeAsync();
+            throw;
+        }
     }
 
     public async Task<Either<ActionResult, Unit>> ZipFilesToStream(
@@ -189,16 +234,20 @@ public class ReleaseFileService(
 
                 if (fileIds is null)
                 {
-                    var successfullyStreamCachedAllFilesZip = await TryStreamCachedAllFilesZip(
-                        releaseVersion,
-                        outputStream,
-                        cancellationToken
-                    );
+                    // Temporarily disabled for the AFD-generated ZIP POC. All-files ZIPs
+                    // are generated rather than read from the combined ZIP Blob.
+                    // var successfullyStreamCachedAllFilesZip = await TryStreamCachedAllFilesZip(
+                    //     releaseVersion,
+                    //     outputStream,
+                    //     cancellationToken
+                    // );
+                    //
+                    // if (!successfullyStreamCachedAllFilesZip)
+                    // {
+                    //     await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
+                    // }
 
-                    if (!successfullyStreamCachedAllFilesZip)
-                    {
-                        await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
-                    }
+                    await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
                 }
                 else
                 {
@@ -285,7 +334,8 @@ public class ReleaseFileService(
     private async Task ZipAllFilesToStream(
         ReleaseVersion releaseVersion,
         Stream outputStream,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool leaveOutputStreamOpen = false
     )
     {
         var releaseFiles = (
@@ -294,38 +344,43 @@ public class ReleaseFileService(
             .OrderBy(rf => rf.File.ZipFileEntryName())
             .ToList();
 
-        var path = Path.GetTempPath() + releaseVersion.AllFilesZipFileName();
-        var fileStream = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+        // var path = Path.GetTempPath() + releaseVersion.AllFilesZipFileName();
+        // var fileStream = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
 
-        await using var multiWriteStream = new MultiWriteStream(outputStream, fileStream);
+        // await using var multiWriteStream = new MultiWriteStream(outputStream, fileStream);
 
-        await DoZipFilesToStream(releaseFiles, releaseVersion, multiWriteStream, cancellationToken);
-        await multiWriteStream.FlushAsync(cancellationToken);
+        await DoZipFilesToStream(releaseFiles, releaseVersion, outputStream, cancellationToken, leaveOutputStreamOpen);
+
+        if (leaveOutputStreamOpen)
+        {
+            await outputStream.FlushAsync(cancellationToken);
+        }
 
         // Now cache the All files zip into blob storage
         // so that we can quickly fetch it again.
-        fileStream.Position = 0;
+        // fileStream.Position = 0;
 
-        await publicBlobStorageService.UploadStream(
-            containerName: PublicReleaseFiles,
-            path: releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion),
-            sourceStream: fileStream,
-            contentType: MediaTypeNames.Application.Zip,
-            cancellationToken: cancellationToken
-        );
-
-        await fileStream.DisposeAsync();
-        File.Delete(path);
+        // await publicBlobStorageService.UploadStream(
+        //     containerName: PublicReleaseFiles,
+        //     path: releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion),
+        //     sourceStream: fileStream,
+        //     contentType: MediaTypeNames.Application.Zip,
+        //     cancellationToken: cancellationToken
+        // );
+        //
+        // await fileStream.DisposeAsync();
+        // File.Delete(path);
     }
 
     private async Task DoZipFilesToStream(
         List<ReleaseFile> releaseFiles,
         ReleaseVersion releaseVersion,
         Stream outputStream,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool leaveOutputStreamOpen = false
     )
     {
-        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create);
+        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: leaveOutputStreamOpen);
 
         var releaseFilesWithZipEntries = new List<ReleaseFile>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -127,12 +127,10 @@ public class ReleaseFileService(
             return permissionResult.Left;
         }
 
-        // Temporarily disabled for the AFD-generated ZIP POC. Published all-files
-        // requests always redirect to the versioned endpoint so AFD can cache its response.
-        // if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
-        // {
-        //     return new ZipDelivery.Stream(releaseVersion);
-        // }
+        if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
+        {
+            return new ZipDelivery.Stream(releaseVersion);
+        }
 
         await RecordZipDownloadAnalytics(releaseVersion, releaseFiles: null, fromPage, cancellationToken);
 
@@ -150,69 +148,26 @@ public class ReleaseFileService(
             return new NotFoundResult();
         }
 
-        var releaseVersionResult = await contentDbContext
+        return await contentDbContext
             .ReleaseVersions.Include(rv => rv.Release)
                 .ThenInclude(r => r.Publication)
             .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
             .OnSuccess(EnsurePublished)
-            .OnSuccess(userService.CheckCanViewReleaseVersion);
-
-        if (releaseVersionResult.IsLeft)
-        {
-            return releaseVersionResult.Left;
-        }
-
-        var releaseVersion = releaseVersionResult.Right;
-
-        // Temporarily disabled for the AFD-generated ZIP POC. The versioned endpoint
-        // generates a fresh ZIP on an AFD cache miss instead of reading the combined ZIP
-        // from Blob Storage.
-        // return await FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion)
-        //     .OnSuccess(allFilesZip =>
-        //         publicBlobStorageService
-        //             .GetDownloadStream(
-        //                 PublicReleaseFiles,
-        //                 allFilesZip.Path,
-        //                 cancellationToken: cancellationToken
-        //             )
-        //             .OnSuccess(stream => new FileStreamResult(stream, MediaTypeNames.Application.Zip)
-        //             {
-        //                 FileDownloadName = releaseVersion.AllFilesZipFileName(),
-        //                 EnableRangeProcessing = true,
-        //             })
-        //     );
-
-        var temporaryZipPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.zip");
-        var temporaryZipStream = new FileStream(
-            temporaryZipPath,
-            FileMode.CreateNew,
-            FileAccess.ReadWrite,
-            FileShare.Read,
-            bufferSize: 81920,
-            FileOptions.Asynchronous | FileOptions.DeleteOnClose
-        );
-
-        try
-        {
-            await ZipAllFilesToStream(
-                releaseVersion,
-                temporaryZipStream,
-                cancellationToken,
-                leaveOutputStreamOpen: true
+            .OnSuccess(userService.CheckCanViewReleaseVersion)
+            .OnSuccessCombineWith(releaseVersion => FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion))
+            .OnSuccess(releaseVersionAndZip =>
+                publicBlobStorageService
+                    .GetDownloadStream(
+                        PublicReleaseFiles,
+                        releaseVersionAndZip.Item2.Path,
+                        cancellationToken: cancellationToken
+                    )
+                    .OnSuccess(stream => new FileStreamResult(stream, MediaTypeNames.Application.Zip)
+                    {
+                        FileDownloadName = releaseVersionAndZip.Item1.AllFilesZipFileName(),
+                        EnableRangeProcessing = true,
+                    })
             );
-            temporaryZipStream.Position = 0;
-
-            return new FileStreamResult(temporaryZipStream, MediaTypeNames.Application.Zip)
-            {
-                FileDownloadName = releaseVersion.AllFilesZipFileName(),
-                EnableRangeProcessing = true,
-            };
-        }
-        catch
-        {
-            await temporaryZipStream.DisposeAsync();
-            throw;
-        }
     }
 
     public async Task<Either<ActionResult, Unit>> ZipFilesToStream(
@@ -234,20 +189,16 @@ public class ReleaseFileService(
 
                 if (fileIds is null)
                 {
-                    // Temporarily disabled for the AFD-generated ZIP POC. All-files ZIPs
-                    // are generated rather than read from the combined ZIP Blob.
-                    // var successfullyStreamCachedAllFilesZip = await TryStreamCachedAllFilesZip(
-                    //     releaseVersion,
-                    //     outputStream,
-                    //     cancellationToken
-                    // );
-                    //
-                    // if (!successfullyStreamCachedAllFilesZip)
-                    // {
-                    //     await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
-                    // }
+                    var successfullyStreamCachedAllFilesZip = await TryStreamCachedAllFilesZip(
+                        releaseVersion,
+                        outputStream,
+                        cancellationToken
+                    );
 
-                    await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
+                    if (!successfullyStreamCachedAllFilesZip)
+                    {
+                        await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
+                    }
                 }
                 else
                 {
@@ -334,8 +285,7 @@ public class ReleaseFileService(
     private async Task ZipAllFilesToStream(
         ReleaseVersion releaseVersion,
         Stream outputStream,
-        CancellationToken cancellationToken,
-        bool leaveOutputStreamOpen = false
+        CancellationToken cancellationToken
     )
     {
         var releaseFiles = (
@@ -344,43 +294,38 @@ public class ReleaseFileService(
             .OrderBy(rf => rf.File.ZipFileEntryName())
             .ToList();
 
-        // var path = Path.GetTempPath() + releaseVersion.AllFilesZipFileName();
-        // var fileStream = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+        var path = Path.GetTempPath() + releaseVersion.AllFilesZipFileName();
+        var fileStream = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
 
-        // await using var multiWriteStream = new MultiWriteStream(outputStream, fileStream);
+        await using var multiWriteStream = new MultiWriteStream(outputStream, fileStream);
 
-        await DoZipFilesToStream(releaseFiles, releaseVersion, outputStream, cancellationToken, leaveOutputStreamOpen);
-
-        if (leaveOutputStreamOpen)
-        {
-            await outputStream.FlushAsync(cancellationToken);
-        }
+        await DoZipFilesToStream(releaseFiles, releaseVersion, multiWriteStream, cancellationToken);
+        await multiWriteStream.FlushAsync(cancellationToken);
 
         // Now cache the All files zip into blob storage
         // so that we can quickly fetch it again.
-        // fileStream.Position = 0;
+        fileStream.Position = 0;
 
-        // await publicBlobStorageService.UploadStream(
-        //     containerName: PublicReleaseFiles,
-        //     path: releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion),
-        //     sourceStream: fileStream,
-        //     contentType: MediaTypeNames.Application.Zip,
-        //     cancellationToken: cancellationToken
-        // );
-        //
-        // await fileStream.DisposeAsync();
-        // File.Delete(path);
+        await publicBlobStorageService.UploadStream(
+            containerName: PublicReleaseFiles,
+            path: releaseVersion.AllFilesZipPath(AllFilesZipFormat.CurrentVersion),
+            sourceStream: fileStream,
+            contentType: MediaTypeNames.Application.Zip,
+            cancellationToken: cancellationToken
+        );
+
+        await fileStream.DisposeAsync();
+        File.Delete(path);
     }
 
     private async Task DoZipFilesToStream(
         List<ReleaseFile> releaseFiles,
         ReleaseVersion releaseVersion,
         Stream outputStream,
-        CancellationToken cancellationToken,
-        bool leaveOutputStreamOpen = false
+        CancellationToken cancellationToken
     )
     {
-        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: leaveOutputStreamOpen);
+        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create);
 
         var releaseFilesWithZipEntries = new List<ReleaseFile>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -30,6 +31,7 @@ public class ReleaseFileService(
     IDataGuidanceFileWriter dataGuidanceFileWriter,
     IUserService userService,
     IAnalyticsManager analyticsManager,
+    IReleaseVersionRepository releaseVersionRepository,
     ILogger<ReleaseFileService> logger
 ) : IReleaseFileService
 {
@@ -116,17 +118,38 @@ public class ReleaseFileService(
         CancellationToken cancellationToken = default
     )
     {
-        if (fileIds is not null || releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow)
+        return await EnsurePublished(releaseVersion)
+            .OnSuccess(publishedReleaseVersion =>
+                EnsureLatestPublishedReleaseVersion(publishedReleaseVersion, cancellationToken)
+            )
+            .OnSuccess(latestPublishedReleaseVersion =>
+                ResolveZipDelivery(latestPublishedReleaseVersion, fromPage, fileIds, cancellationToken)
+            );
+    }
+
+    private async Task<Either<ActionResult, ZipDelivery>> ResolveZipDelivery(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        IEnumerable<Guid>? fileIds,
+        CancellationToken cancellationToken
+    )
+    {
+        if (fileIds is not null)
         {
             return new ZipDelivery.Stream(releaseVersion);
         }
 
-        var permissionResult = await userService.CheckCanViewReleaseVersion(releaseVersion);
-        if (permissionResult.IsLeft)
-        {
-            return permissionResult.Left;
-        }
+        return await userService
+            .CheckCanViewReleaseVersion(releaseVersion)
+            .OnSuccess(() => GetAllFilesZipDelivery(releaseVersion, fromPage, cancellationToken));
+    }
 
+    private async Task<Either<ActionResult, ZipDelivery>> GetAllFilesZipDelivery(
+        ReleaseVersion releaseVersion,
+        AnalyticsFromPage fromPage,
+        CancellationToken cancellationToken
+    )
+    {
         if (await FindValidAllFilesZip(releaseVersion, AllFilesZipFormat.CurrentVersion) is null)
         {
             return new ZipDelivery.Stream(releaseVersion);
@@ -153,6 +176,7 @@ public class ReleaseFileService(
                 .ThenInclude(r => r.Publication)
             .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
             .OnSuccess(EnsurePublished)
+            .OnSuccess(releaseVersion => EnsureLatestPublishedReleaseVersion(releaseVersion, cancellationToken))
             .OnSuccess(userService.CheckCanViewReleaseVersion)
             .OnSuccessCombineWith(releaseVersion => FindValidAllFilesZipOrNotFound(releaseVersion, formatVersion))
             .OnSuccess(releaseVersionAndZip =>
@@ -270,6 +294,16 @@ public class ReleaseFileService(
         return releaseVersion.Published is null || releaseVersion.Published > DateTimeOffset.UtcNow
             ? new NotFoundResult()
             : releaseVersion;
+    }
+
+    private async Task<Either<ActionResult, ReleaseVersion>> EnsureLatestPublishedReleaseVersion(
+        ReleaseVersion releaseVersion,
+        CancellationToken cancellationToken
+    )
+    {
+        return await releaseVersionRepository.IsLatestPublishedReleaseVersion(releaseVersion.Id, cancellationToken)
+            ? releaseVersion
+            : new NotFoundResult();
     }
 
     private async Task<Either<ActionResult, BlobInfo>> FindValidAllFilesZipOrNotFound(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentServiceMockBuilder.cs
@@ -13,7 +13,7 @@ public class ContentServiceMockBuilder
     public ContentServiceMockBuilder()
     {
         _mock
-            .Setup(m => m.DeletePreviousVersionsDownloadFiles(It.IsAny<IReadOnlyList<Guid>>()))
+            .Setup(m => m.InvalidatePreviousVersionsDownloadFiles(It.IsAny<IReadOnlyList<Guid>>()))
             .Returns(Task.CompletedTask);
 
         _mock.Setup(m => m.DeletePreviousVersionsContent(It.IsAny<IReadOnlyList<Guid>>())).Returns(Task.CompletedTask);
@@ -23,11 +23,11 @@ public class ContentServiceMockBuilder
 
     public class Asserter(Mock<IContentService> mock)
     {
-        public void DeletePreviousVersionsDownloadFilesCalled(params Guid[] expectedReleaseVersionIds)
+        public void InvalidatePreviousVersionsDownloadFilesCalled(params Guid[] expectedReleaseVersionIds)
         {
             mock.Verify(
                 m =>
-                    m.DeletePreviousVersionsDownloadFiles(
+                    m.InvalidatePreviousVersionsDownloadFiles(
                         It.Is<IReadOnlyList<Guid>>(actual =>
                             expectedReleaseVersionIds.OrderBy(g => g).SequenceEqual(actual.OrderBy(g => g))
                         )

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ContentServiceTests.cs
@@ -1,0 +1,108 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Publications;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
+
+public class ContentServiceTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public async Task InvalidatePreviousVersionsDownloadFiles_InitialPublication_DoesNothing()
+    {
+        var releaseVersion = _dataFixture.DefaultReleaseVersion().Generate();
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+        var frontDoorCacheService = new Mock<IFrontDoorCacheService>(MockBehavior.Strict);
+
+        await using var testContentDbContext = InMemoryContentDbContext(contentDbContextId);
+        var service = BuildService(testContentDbContext, blobStorageService.Object, frontDoorCacheService.Object);
+
+        await service.InvalidatePreviousVersionsDownloadFiles([releaseVersion.Id]);
+
+        blobStorageService.VerifyNoOtherCalls();
+        frontDoorCacheService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task InvalidatePreviousVersionsDownloadFiles_Amendments_DeletesAndPurgesPreviousVersions()
+    {
+        var previousReleaseVersion1 = _dataFixture.DefaultReleaseVersion().Generate();
+        var previousReleaseVersion2 = _dataFixture.DefaultReleaseVersion().Generate();
+        var amendedReleaseVersion1 = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPreviousVersion(previousReleaseVersion1)
+            .Generate();
+        var amendedReleaseVersion2 = _dataFixture
+            .DefaultReleaseVersion()
+            .WithPreviousVersion(previousReleaseVersion2)
+            .Generate();
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.AddRange(amendedReleaseVersion1, amendedReleaseVersion2);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+        blobStorageService
+            .Setup(service => service.DeleteBlobs(PublicReleaseFiles, $"{previousReleaseVersion1.Id}/", null))
+            .Returns(Task.CompletedTask);
+        blobStorageService
+            .Setup(service => service.DeleteBlobs(PublicReleaseFiles, $"{previousReleaseVersion2.Id}/", null))
+            .Returns(Task.CompletedTask);
+
+        var expectedPreviousVersionIds = new HashSet<Guid> { previousReleaseVersion1.Id, previousReleaseVersion2.Id };
+        var frontDoorCacheService = new Mock<IFrontDoorCacheService>(MockBehavior.Strict);
+        frontDoorCacheService
+            .Setup(service =>
+                service.PurgeAllFilesZipCache(
+                    It.Is<IReadOnlySet<Guid>>(ids => ids.SetEquals(expectedPreviousVersionIds)),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+
+        await using var testContentDbContext = InMemoryContentDbContext(contentDbContextId);
+        var service = BuildService(testContentDbContext, blobStorageService.Object, frontDoorCacheService.Object);
+
+        await service.InvalidatePreviousVersionsDownloadFiles([amendedReleaseVersion1.Id, amendedReleaseVersion2.Id]);
+
+        blobStorageService.VerifyAll();
+        frontDoorCacheService.VerifyAll();
+    }
+
+    private static ContentService BuildService(
+        ContentDbContext contentDbContext,
+        IBlobStorageService blobStorageService,
+        IFrontDoorCacheService frontDoorCacheService
+    ) =>
+        new(
+            contentDbContext,
+            Mock.Of<IBlobCacheService>(),
+            Mock.Of<IBlobCacheService>(),
+            blobStorageService,
+            Mock.Of<IReleaseService>(),
+            Mock.Of<IMethodologyCacheService>(),
+            Mock.Of<IPublicationsTreeService>(),
+            frontDoorCacheService
+        );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/FrontDoorCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/FrontDoorCacheServiceTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Text.Json;
+using Azure.Core;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Options;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
+
+public class FrontDoorCacheServiceTests
+{
+    private static readonly AzureFrontDoorOptions EnabledOptions = new()
+    {
+        CachePurgeEnabled = true,
+        EndpointResourceId =
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Cdn/profiles/profile/afdEndpoints/endpoint",
+        ContentApiHostName = "content.dev.explore-education-statistics.service.gov.uk",
+    };
+
+    [Fact]
+    public async Task PurgeAllFilesZipCache_Disabled_DoesNotSendRequest()
+    {
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.OK);
+        var service = BuildService(
+            handler,
+            new AzureFrontDoorOptions
+            {
+                CachePurgeEnabled = false,
+                EndpointResourceId = EnabledOptions.EndpointResourceId,
+                ContentApiHostName = EnabledOptions.ContentApiHostName,
+            }
+        );
+
+        await service.PurgeAllFilesZipCache(new HashSet<Guid> { Guid.NewGuid() });
+
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task PurgeAllFilesZipCache_Success_SendsSingleBatchedRequest()
+    {
+        var releaseVersionId1 = Guid.NewGuid();
+        var releaseVersionId2 = Guid.NewGuid();
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.Accepted);
+        var service = BuildService(handler);
+
+        await service.PurgeAllFilesZipCache(new HashSet<Guid> { releaseVersionId2, releaseVersionId1 });
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(
+            $"https://management.azure.com{EnabledOptions.EndpointResourceId}/purge?api-version=2025-04-15",
+            request.RequestUri?.ToString()
+        );
+        Assert.Equal("Bearer", request.AuthorizationScheme);
+        Assert.Equal("test-token", request.AuthorizationToken);
+
+        using var body = JsonDocument.Parse(request.Body);
+        Assert.Equal(
+            new[] { $"/api/all-files/{releaseVersionId1}/*", $"/api/all-files/{releaseVersionId2}/*" }.Order(),
+            body.RootElement.GetProperty("contentPaths").EnumerateArray().Select(value => value.GetString()).Order()
+        );
+        Assert.Equal(EnabledOptions.ContentApiHostName, body.RootElement.GetProperty("domains")[0].GetString());
+    }
+
+    [Fact]
+    public async Task PurgeAllFilesZipCache_TransientFailures_RetriesAndDoesNotThrow()
+    {
+        var handler = new RecordingHttpMessageHandler(
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.TooManyRequests,
+            HttpStatusCode.ServiceUnavailable
+        );
+        var service = BuildService(handler);
+
+        await service.PurgeAllFilesZipCache(new HashSet<Guid> { Guid.NewGuid() });
+
+        Assert.Equal(3, handler.Requests.Count);
+    }
+
+    private static FrontDoorCacheService BuildService(
+        RecordingHttpMessageHandler handler,
+        AzureFrontDoorOptions? options = null
+    ) =>
+        new(
+            new HttpClient(handler),
+            new TestTokenCredential(),
+            Microsoft.Extensions.Options.Options.Create(options ?? EnabledOptions),
+            TimeProvider.System,
+            Mock.Of<ILogger<FrontDoorCacheService>>()
+        );
+
+    private sealed class TestTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            new("test-token", DateTimeOffset.MaxValue);
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken
+        ) => ValueTask.FromResult(new AccessToken("test-token", DateTimeOffset.MaxValue));
+    }
+
+    private sealed class RecordingHttpMessageHandler(params HttpStatusCode[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpStatusCode> _responses = new(responses);
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Requests.Add(
+                new RecordedRequest(
+                    request.Method,
+                    request.RequestUri,
+                    request.Headers.Authorization?.Scheme,
+                    request.Headers.Authorization?.Parameter,
+                    await request.Content!.ReadAsStringAsync(cancellationToken)
+                )
+            );
+
+            return new HttpResponseMessage(_responses.Dequeue());
+        }
+    }
+
+    private record RecordedRequest(
+        HttpMethod Method,
+        Uri? RequestUri,
+        string? AuthorizationScheme,
+        string? AuthorizationToken,
+        string Body
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -378,7 +378,7 @@ public class PublishingCompletionServiceTests
                 await sut.CompletePublishing(keys);
 
                 // ASSERT
-                _contentService.Assert.DeletePreviousVersionsDownloadFilesCalled(
+                _contentService.Assert.InvalidatePreviousVersionsDownloadFilesCalled(
                     _releaseVersion1.Id,
                     _releaseVersion2.Id
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Options/AzureFrontDoorOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Options/AzureFrontDoorOptions.cs
@@ -1,0 +1,12 @@
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Options;
+
+public class AzureFrontDoorOptions
+{
+    public const string Section = "AzureFrontDoor";
+
+    public bool CachePurgeEnabled { get; init; }
+
+    public string EndpointResourceId { get; init; } = string.Empty;
+
+    public string ContentApiHostName { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using Azure.Core;
+using Azure.Identity;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
@@ -83,6 +85,8 @@ public static class PublisherHostBuilderExtensions
                 // TODO EES-5073 Remove this when the Public Data db exists in ALL Azure environments.
                 var publicDataDbExists = configuration.GetValue<bool>("PublicDataDbExists");
 
+                services.AddHttpClient<IFrontDoorCacheService, FrontDoorCacheService>();
+
                 services
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
@@ -95,6 +99,7 @@ public static class PublisherHostBuilderExtensions
                         )
                     )
                     .AddSingleton(TimeProvider.System)
+                    .AddSingleton<TokenCredential, DefaultAzureCredential>()
                     .AddSingleton<IFileStorageService, FileStorageService>(provider => new FileStorageService(
                         provider.GetRequiredService<IOptions<AppOptions>>().Value.PublisherStorageConnectionString
                     ))
@@ -132,7 +137,8 @@ public static class PublisherHostBuilderExtensions
                         ),
                         releaseService: provider.GetRequiredService<IReleaseService>(),
                         methodologyCacheService: provider.GetRequiredService<IMethodologyCacheService>(),
-                        publicationsTreeService: provider.GetRequiredService<IPublicationsTreeService>()
+                        publicationsTreeService: provider.GetRequiredService<IPublicationsTreeService>(),
+                        frontDoorCacheService: provider.GetRequiredService<IFrontDoorCacheService>()
                     ))
                     .AddScoped<IReleaseService, ReleaseService>()
                     .AddTransient<IPublisherTableStorageService, PublisherTableStorageService>(
@@ -182,6 +188,7 @@ public static class PublisherHostBuilderExtensions
                     .AddSingleton<DateTimeProvider>()
                     .AddSingleton(TimeProvider.System)
                     .Configure<AppOptions>(configuration.GetSection(AppOptions.Section))
+                    .Configure<AzureFrontDoorOptions>(configuration.GetSection(AzureFrontDoorOptions.Section))
                     .Configure<NotifyOptions>(configuration.GetSection(NotifyOptions.Section));
 
                 // TODO EES-5073 Remove this check when the Public Data db is available in all Azure environments.

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -21,6 +21,7 @@ public class ContentService : IContentService
     private readonly IReleaseService _releaseService;
     private readonly IMethodologyCacheService _methodologyCacheService;
     private readonly IPublicationsTreeService _publicationsTreeService;
+    private readonly IFrontDoorCacheService _frontDoorCacheService;
 
     public ContentService(
         ContentDbContext contentDbContext,
@@ -29,7 +30,8 @@ public class ContentService : IContentService
         IBlobStorageService publicBlobStorageService,
         IReleaseService releaseService,
         IMethodologyCacheService methodologyCacheService,
-        IPublicationsTreeService publicationsTreeService
+        IPublicationsTreeService publicationsTreeService,
+        IFrontDoorCacheService frontDoorCacheService
     )
     {
         _contentDbContext = contentDbContext;
@@ -39,6 +41,7 @@ public class ContentService : IContentService
         _releaseService = releaseService;
         _methodologyCacheService = methodologyCacheService;
         _publicationsTreeService = publicationsTreeService;
+        _frontDoorCacheService = frontDoorCacheService;
     }
 
     public async Task DeletePreviousVersionsContent(IReadOnlyList<Guid> releaseVersionIds)
@@ -82,22 +85,29 @@ public class ContentService : IContentService
         );
     }
 
-    public async Task DeletePreviousVersionsDownloadFiles(IReadOnlyList<Guid> releaseVersionIds)
+    public async Task InvalidatePreviousVersionsDownloadFiles(IReadOnlyList<Guid> releaseVersionIds)
     {
         var releaseVersions = await _contentDbContext
             .ReleaseVersions.Where(rv => releaseVersionIds.Contains(rv.Id))
             .Include(rv => rv.PreviousVersion)
             .ToListAsync();
 
-        foreach (var releaseVersion in releaseVersions)
+        var previousReleaseVersionIds = releaseVersions
+            .Where(releaseVersion => releaseVersion.PreviousVersion != null)
+            .Select(releaseVersion => releaseVersion.PreviousVersion!.Id)
+            .ToHashSet();
+
+        foreach (var previousReleaseVersionId in previousReleaseVersionIds)
         {
-            if (releaseVersion.PreviousVersion != null)
-            {
-                await _publicBlobStorageService.DeleteBlobs(
-                    containerName: PublicReleaseFiles,
-                    directoryPath: $"{releaseVersion.PreviousVersion.Id}/"
-                );
-            }
+            await _publicBlobStorageService.DeleteBlobs(
+                containerName: PublicReleaseFiles,
+                directoryPath: $"{previousReleaseVersionId}/"
+            );
+        }
+
+        if (previousReleaseVersionIds.Count > 0)
+        {
+            await _frontDoorCacheService.PurgeAllFilesZipCache(previousReleaseVersionIds);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FrontDoorCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FrontDoorCacheService.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Azure.Core;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Options;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+
+public class FrontDoorCacheService(
+    HttpClient httpClient,
+    TokenCredential tokenCredential,
+    IOptions<AzureFrontDoorOptions> options,
+    TimeProvider timeProvider,
+    ILogger<FrontDoorCacheService> logger
+) : IFrontDoorCacheService
+{
+    private const string AzureManagementScope = "https://management.azure.com/.default";
+    private const string ApiVersion = "2025-04-15";
+    private static readonly TimeSpan[] RetryDelays = [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)];
+
+    public async Task PurgeAllFilesZipCache(
+        IReadOnlySet<Guid> releaseVersionIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var frontDoorOptions = options.Value;
+        if (!frontDoorOptions.CachePurgeEnabled || releaseVersionIds.Count == 0)
+        {
+            return;
+        }
+
+        var contentPaths = releaseVersionIds.Select(id => $"/api/all-files/{id}/*").Order().ToArray();
+
+        try
+        {
+            var accessToken = await tokenCredential.GetTokenAsync(
+                new TokenRequestContext([AzureManagementScope]),
+                cancellationToken
+            );
+
+            for (var attempt = 0; attempt <= RetryDelays.Length; attempt++)
+            {
+                try
+                {
+                    using var request = CreateRequest(frontDoorOptions, contentPaths, accessToken.Token);
+                    using var response = await httpClient.SendAsync(request, cancellationToken);
+
+                    if (response.StatusCode is HttpStatusCode.OK or HttpStatusCode.Accepted)
+                    {
+                        logger.LogInformation(
+                            "Accepted Azure Front Door cache purge for paths {ContentPaths}",
+                            contentPaths
+                        );
+                        return;
+                    }
+
+                    var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                    if (!IsTransient(response.StatusCode) || attempt == RetryDelays.Length)
+                    {
+                        logger.LogError(
+                            "Azure Front Door cache purge failed with status {StatusCode} for paths {ContentPaths}. Response: {ResponseBody}",
+                            (int)response.StatusCode,
+                            contentPaths,
+                            responseBody
+                        );
+                        return;
+                    }
+                }
+                catch (HttpRequestException exception) when (attempt < RetryDelays.Length)
+                {
+                    logger.LogWarning(
+                        exception,
+                        "Azure Front Door cache purge attempt {Attempt} failed for paths {ContentPaths}",
+                        attempt + 1,
+                        contentPaths
+                    );
+                }
+                catch (OperationCanceledException exception)
+                    when (!cancellationToken.IsCancellationRequested && attempt < RetryDelays.Length)
+                {
+                    logger.LogWarning(
+                        exception,
+                        "Azure Front Door cache purge attempt {Attempt} timed out for paths {ContentPaths}",
+                        attempt + 1,
+                        contentPaths
+                    );
+                }
+
+                await Task.Delay(RetryDelays[attempt], timeProvider, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Azure Front Door cache purge failed for paths {ContentPaths}", contentPaths);
+        }
+    }
+
+    private static HttpRequestMessage CreateRequest(
+        AzureFrontDoorOptions options,
+        string[] contentPaths,
+        string accessToken
+    )
+    {
+        var endpointResourceId = options.EndpointResourceId.TrimEnd('/');
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"https://management.azure.com{endpointResourceId}/purge?api-version={ApiVersion}"
+        )
+        {
+            Content = JsonContent.Create(new { contentPaths, domains = new[] { options.ContentApiHostName } }),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return request;
+    }
+
+    private static bool IsTransient(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests || (int)statusCode >= 500;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
 public interface IContentService
 {
-    Task DeletePreviousVersionsDownloadFiles(IReadOnlyList<Guid> releaseVersionIds);
+    Task InvalidatePreviousVersionsDownloadFiles(IReadOnlyList<Guid> releaseVersionIds);
 
     Task DeletePreviousVersionsContent(IReadOnlyList<Guid> releaseVersionIds);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFrontDoorCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFrontDoorCacheService.cs
@@ -1,0 +1,6 @@
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+
+public interface IFrontDoorCacheService
+{
+    Task PurgeAllFilesZipCache(IReadOnlySet<Guid> releaseVersionIds, CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -76,7 +76,7 @@ public class PublishingCompletionService(
 
         await HandleArchivedPublications(publishedPublicationInfos, cancellationToken);
 
-        await contentService.DeletePreviousVersionsDownloadFiles(releaseVersionIdsToUpdate);
+        await contentService.InvalidatePreviousVersionsDownloadFiles(releaseVersionIdsToUpdate);
         await contentService.DeletePreviousVersionsContent(releaseVersionIdsToUpdate);
 
         await notificationsService.NotifySubscribersIfApplicable(releaseVersionIdsToUpdate);


### PR DESCRIPTION
This PR adds AFD to the content API and adds caching to the `/api/all-files/` endpoint.
It also enables purging of cached old release zip files for releases that have been amended, so the user isn't served an old file belonging to a release which has been amended.
## Summary

Addresses EES-7512 by placing the Content API behind Azure Front Door and caching published all-files ZIP downloads at the AFD edge.

Cold requests continue to generate and stream the ZIP through the Content API while storing it in Blob Storage. Warm requests redirect to a versioned, cacheable Content API URL that AFD can serve without repeatedly proxying the payload from the origin.

## Changes

### Azure Front Door

- Adds the Content API as a separate origin group on the existing AFD profile.
- Adds an uncached general Content API route.
- Adds a cache-enabled `/api/all-files/*` route with compression disabled.
- Associates the Content API domain with the existing WAF policy.
- Uses a dedicated BYO Key Vault certificate named `${subscription}-as-ees-content-afd-certificate`.
- Supports optionally restricting direct Content API App Service access to the environment’s AFD profile.
- Grants the Publisher managed identity endpoint-scoped `CDN Endpoint Contributor` access.

### All-files ZIP delivery

- Introduces a versioned canonical URL:

  `/api/all-files/{releaseVersionId}/v{formatVersion}`

- Cold-cache requests generate, stream and store the all-files ZIP as before.
- Warm requests record analytics and redirect to the canonical URL.
- The canonical response uses `s-maxage=3600` for AFD caching and supports byte ranges.
- Selected-file ZIP requests continue using the existing generated streaming path and are not cached by AFD.
- ZIP format versioning provides a new cache key when the generated ZIP structure changes.

### Amendment invalidation and validation

- When an amendment is published, the Publisher:
  - Deletes the previous release version’s download directory from Blob Storage.
  - Purges `/api/all-files/{previousReleaseVersionId}/*` from AFD.
- AFD purges are batched and retried for transient failures.
- Purge failures are logged but do not fail publication.
- Superseded published release versions return `404` from both ZIP endpoints.
- Draft and future-scheduled releases return `404` from the public Content API ZIP endpoint.
- Draft ZIP downloads remain available through the separate Admin API.
- The purge feature is enabled in development and disabled by default elsewhere.

### Analytics

Analytics continue to be recorded once per download request:

- Cold cache: recorded by the generated streaming path.
- Warm cache: recorded before redirecting to the AFD-cacheable URL.

## Testing

- Added coverage for:
  - Cold and warm all-files ZIP delivery.
  - Versioned canonical downloads and byte-range support.
  - Selected-file ZIP cache bypass.
  - Draft and future-scheduled release rejection.
  - Superseded release-version rejection.
  - Amendment Blob deletion and batched AFD purging.
  - Disabled purging, successful purging and transient retries.
- `ReleaseFileServiceTests` pass.
- Content API controller streaming tests pass.
- Publisher invalidation and publishing-completion tests pass.
- Core Bicep and all environment parameter files compile successfully.
- ARM template and parameter JSON validation pass.

## Deployment notes

- The appropriate Content API BYO certificate must exist in each environment’s Key Vault.
- Deploy the Core infrastructure with Azure Front Door deployment enabled.
- Complete and verify the Content API DNS cutover before enabling the optional App Service origin restriction.
- AFD cache purging is initially enabled only in development.