### PR TITLE
EES-7407 combined search prototype superseded filter

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/__tests__/createDataSetListRequest.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/__tests__/createDataSetListRequest.test.ts
@@ -30,7 +30,7 @@ describe('createDataSetListRequest', () => {
         page: 1,
         search: '',
         orderBy: 'published desc',
-        filter: 'latestData eq true',
+        filter: 'isSuperseded eq false and latestData eq true',
       });
     });
   });
@@ -100,7 +100,7 @@ describe('createDataSetListRequest', () => {
       const result = createDataSetListRequest(testQuery);
 
       expect(result.filter).toBe(
-        "search.in(releaseType, 'AccreditedOfficialStatistics|OfficialStatistics', '|') and latestData eq true",
+        "isSuperseded eq false and search.in(releaseType, 'AccreditedOfficialStatistics|OfficialStatistics', '|') and latestData eq true",
       );
     });
 
@@ -112,7 +112,9 @@ describe('createDataSetListRequest', () => {
 
       const result = createDataSetListRequest(testInvalidQuery);
 
-      expect(result.filter).toBe('latestData eq true');
+      expect(result.filter).toBe(
+        'isSuperseded eq false and latestData eq true',
+      );
     });
 
     test('when latestDataOnly is undefined', () => {
@@ -122,7 +124,9 @@ describe('createDataSetListRequest', () => {
 
       const result = createDataSetListRequest(testQuery);
 
-      expect(result.filter).toBe('latestData eq true');
+      expect(result.filter).toBe(
+        'isSuperseded eq false and latestData eq true',
+      );
     });
 
     test('excludes latestdata filter when latestDataOnly is false', () => {
@@ -132,7 +136,7 @@ describe('createDataSetListRequest', () => {
 
       const result = createDataSetListRequest(testQuery);
 
-      expect(result.filter).toBeUndefined();
+      expect(result.filter).toBe('isSuperseded eq false');
     });
 
     test('includes api filter when dataSetType is api', () => {
@@ -143,7 +147,7 @@ describe('createDataSetListRequest', () => {
       const result = createDataSetListRequest(testQuery);
 
       expect(result.filter).toBe(
-        "latestData eq true and api/id ne null and api/id ne ''",
+        "isSuperseded eq false and latestData eq true and api/id ne null and api/id ne ''",
       );
     });
 
@@ -154,7 +158,9 @@ describe('createDataSetListRequest', () => {
 
       const result = createDataSetListRequest(testQuery);
 
-      expect(result.filter).toBe('latestData eq true');
+      expect(result.filter).toBe(
+        'isSuperseded eq false and latestData eq true',
+      );
     });
 
     test('excludes api filter when dataSetType is undefined', () => {
@@ -164,7 +170,9 @@ describe('createDataSetListRequest', () => {
 
       const result = createDataSetListRequest(testQuery);
 
-      expect(result.filter).toBe('latestData eq true');
+      expect(result.filter).toBe(
+        'isSuperseded eq false and latestData eq true',
+      );
     });
 
     test('combines themeId, publicationId, releaseType and geographicLevel filters', () => {
@@ -221,7 +229,7 @@ describe('createDataSetSuggestRequest', () => {
       page: 1,
       search: 'test search',
       orderBy: 'published desc',
-      filter: 'latestData eq true',
+      filter: 'isSuperseded eq false and latestData eq true',
     });
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -128,6 +128,9 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
         : themeAndPubConditions[0];
 
     conditions.push(combinedGroup);
+  } else {
+    // If no publication or theme ids are provided, only include non-superseded data sets.
+    conditions.push(odata`isSuperseded eq false`);
   }
 
   if (filters.releaseTypes?.length) {


### PR DESCRIPTION
To match behaviour of the data catalogue, for the combined search prototype we only want to show superseded data sets if a publication or theme filter option is selected.
On the data catalogue, this is handled in the backend, but for the combined search we have to provide this filtering in the request.

n.b unlike the data catalogue, we are able to filter by entire theme here, so I've included superseded data sets if a theme is selected.
It also affects the suggestions/autocomplete results, as this shares the same filtering mechanism.