### PR TITLE
EES-7374 data uploads section refactor

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -38,8 +38,6 @@ const ReleaseDataPage = () => {
     [releaseVersionId],
   );
 
-  // Shares its query key with the data uploads section below, so this is served
-  // from the cache rather than making a request of its own.
   const { data: dataFiles = [] } = useQuery(
     releaseDataFileQueries.list(releaseVersionId),
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -7,12 +7,13 @@ import ReleaseDataReorderSection from '@admin/pages/release/data/components/Rele
 import ReleaseDataUploadsSection from '@admin/pages/release/data/components/ReleaseDataUploadsSection';
 import ReleaseFileUploadsSection from '@admin/pages/release/data/components/ReleaseFileUploadsSection';
 import releaseDataPageTabs from '@admin/pages/release/data/utils/releaseDataPageTabs';
+import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import permissionService from '@admin/services/permissionService';
-import { DataFile } from '@admin/services/releaseDataFileService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import { useQuery } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useLocation } from 'react-router';
 
@@ -28,7 +29,6 @@ const ReleaseDataPage = () => {
     : undefined;
   const defaultTabTitle = releaseDataPageTabs.dataUploads.title;
 
-  const [dataFiles, setDataFiles] = useState<DataFile[]>([]);
   const [tabTitle, setTabTitle] = useState<string>(
     tabTitleFromHash ?? defaultTabTitle,
   );
@@ -37,6 +37,16 @@ const ReleaseDataPage = () => {
     () => permissionService.canUpdateRelease(releaseVersionId),
     [releaseVersionId],
   );
+
+  // Shares its query key with the data uploads section below, so this is served
+  // from the cache rather than making a request of its own.
+  const { data: dataFiles = [] } = useQuery(
+    releaseDataFileQueries.list(releaseVersionId),
+  );
+
+  const completeDataFilesCount = dataFiles.filter(
+    file => file.status === 'COMPLETE',
+  ).length;
 
   return (
     <>
@@ -58,7 +68,6 @@ const ReleaseDataPage = () => {
               publicationId={releaseVersion.publicationId}
               releaseVersionId={releaseVersionId}
               canUpdateRelease={canUpdateRelease}
-              onDataFilesChange={setDataFiles}
             />
           </TabsSection>
           <TabsSection
@@ -79,7 +88,7 @@ const ReleaseDataPage = () => {
             <ReleaseDataGuidanceSection
               // Track data files so that we can re-render this
               // section automatically whenever there is a change
-              key={dataFiles.filter(file => file.status === 'COMPLETE').length}
+              key={completeDataFilesCount}
               releaseVersionId={releaseVersionId}
               canUpdateRelease={canUpdateRelease}
             />
@@ -90,7 +99,7 @@ const ReleaseDataPage = () => {
             lazy
           >
             <ReleaseDataReorderSection
-              key={dataFiles.filter(file => file.status === 'COMPLETE').length}
+              key={completeDataFilesCount}
               releaseVersionId={releaseVersionId}
               canUpdateRelease={canUpdateRelease}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReorderableList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReorderableList.tsx
@@ -14,9 +14,6 @@ export default function DataFilesReorderableList({
   onCancelReordering,
   onConfirmReordering,
 }: Props) {
-  // Deliberately not re-seeded from the prop: this list is unmounted whenever
-  // reordering stops, and a background refetch mid-drag would otherwise discard
-  // the ordering the user is part-way through.
   const [dataFiles, setDataFiles] = useState<DataFile[]>(initialDataFiles);
 
   const list = useMemo(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReorderableList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReorderableList.tsx
@@ -1,7 +1,7 @@
 import { DataFile } from '@admin/services/releaseDataFileService';
 import ReorderableList from '@common/components/ReorderableList';
 import reorder from '@common/utils/reorder';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 interface Props {
   dataFiles: DataFile[];
@@ -14,11 +14,10 @@ export default function DataFilesReorderableList({
   onCancelReordering,
   onConfirmReordering,
 }: Props) {
+  // Deliberately not re-seeded from the prop: this list is unmounted whenever
+  // reordering stops, and a background refetch mid-drag would otherwise discard
+  // the ordering the user is part-way through.
   const [dataFiles, setDataFiles] = useState<DataFile[]>(initialDataFiles);
-
-  useEffect(() => {
-    setDataFiles(initialDataFiles);
-  }, [initialDataFiles]);
 
   const list = useMemo(
     () =>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
@@ -19,7 +19,6 @@ interface Props {
   onDeleteUpload: (deletedUploadId: string) => void;
   onDataSetImport: (dataSetImportIds: string[]) => void;
   onRefreshUploads: () => void;
-  onReplacementStatusChange: (updatedDataFile: DataFile) => void;
 }
 
 export default function DataFilesReplacementTable({
@@ -34,7 +33,6 @@ export default function DataFilesReplacementTable({
   onRefreshUploads,
   onDeleteUpload,
   onDataSetImport,
-  onReplacementStatusChange,
 }: Props) {
   return (
     <div className="table-container">
@@ -60,7 +58,6 @@ export default function DataFilesReplacementTable({
               publicationId={publicationId}
               releaseVersionId={releaseVersionId}
               onConfirmAction={onConfirmReplacement}
-              onReplacementStatusChange={onReplacementStatusChange}
             />
           ))}
           {dataSetUploads.map((upload, index) => (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -11,16 +11,15 @@ import releaseDataFileService, {
   DataFileImportStatus,
 } from '@admin/services/releaseDataFileService';
 import dataReplacementService from '@admin/services/dataReplacementService';
-import useToggle from '@common/hooks/useToggle';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import Tag from '@common/components/Tag';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { generatePath } from 'react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import styles from './DataFilesTable.module.scss';
 
 interface Props {
@@ -28,7 +27,6 @@ interface Props {
   publicationId: string;
   releaseVersionId: string;
   onConfirmAction?: () => void;
-  onReplacementStatusChange: (updatedDataFile: DataFile) => void;
 }
 
 export default function DataFilesReplacementTableRow({
@@ -36,10 +34,8 @@ export default function DataFilesReplacementTableRow({
   publicationId,
   releaseVersionId,
   onConfirmAction,
-  onReplacementStatusChange,
 }: Props) {
-  const [fetchPlan, toggleFetchPlan] = useToggle(false);
-  const [canCancel, toggleCanCancel] = useToggle(false);
+  const queryClient = useQueryClient();
 
   const { data: replacementDataFile, isLoading } = useQuery({
     ...releaseDataFileQueries.getDataFile(
@@ -55,46 +51,35 @@ export default function DataFilesReplacementTableRow({
       dataFile.id,
       dataFile.replacedByDataFileId ?? '',
     ),
-    enabled: fetchPlan,
+    // A replacement plan can only be produced once the replacement file has
+    // finished importing.
+    enabled: replacementDataFile?.status === 'COMPLETE',
   });
-
-  useEffect(() => {
-    if (replacementDataFile?.status === 'COMPLETE') {
-      toggleFetchPlan.on();
-    }
-  }, [replacementDataFile?.status, toggleFetchPlan, toggleCanCancel]);
-
-  useEffect(() => {
-    onReplacementStatusChange({
-      ...dataFile,
-      ...(dataFile.replacedByDataFile && {
-        replacedByDataFile: {
-          ...dataFile.replacedByDataFile,
-          hasValidReplacementPlan: plan?.valid ?? false,
-        },
-      }),
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [plan, onReplacementStatusChange]);
 
   const handleStatusChange = async (
     _: DataFile,
     replacementImportStatus: DataFileImportStatus,
   ) => {
-    if (replacementImportStatus.status === 'COMPLETE') {
-      toggleFetchPlan.on();
-      toggleCanCancel.on();
-
-      onReplacementStatusChange({
-        ...dataFile,
-        ...(dataFile.replacedByDataFile && {
-          replacedByDataFile: {
-            ...dataFile.replacedByDataFile,
-            status: replacementImportStatus.status,
-          },
-        }),
-      });
+    if (replacementImportStatus.status !== 'COMPLETE') {
+      return;
     }
+
+    await Promise.all([
+      // Refresh the replacement file so its status becomes COMPLETE, which in
+      // turn enables the replacement plan query above.
+      queryClient.invalidateQueries({
+        queryKey: releaseDataFileQueries.getDataFile(
+          releaseVersionId,
+          dataFile.replacedByDataFileId ?? '',
+        ).queryKey,
+      }),
+      // Refresh the data file list so the server recalculates
+      // `hasValidReplacementPlan`, which drives the parent section's
+      // "Confirm all valid replacements" button.
+      queryClient.invalidateQueries({
+        queryKey: releaseDataFileQueries.list(releaseVersionId).queryKey,
+      }),
+    ]);
   };
 
   if (!replacementDataFile) {
@@ -150,7 +135,7 @@ export default function DataFilesReplacementTableRow({
             <VisuallyHidden>{` for ${dataFile.title}`}</VisuallyHidden>
           </Link>
           <>
-            {(canCancel || replacementDataFile.status === 'COMPLETE') && (
+            {replacementDataFile.status === 'COMPLETE' && (
               <ModalConfirm
                 title="Cancel data replacement"
                 triggerButton={

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -73,9 +73,7 @@ export default function DataFilesReplacementTableRow({
           dataFile.replacedByDataFileId ?? '',
         ).queryKey,
       }),
-      // Refresh the data file list so the server recalculates
-      // `hasValidReplacementPlan`, which drives the parent section's
-      // "Confirm all valid replacements" button.
+      // Refresh the main data file list too
       queryClient.invalidateQueries({
         queryKey: releaseDataFileQueries.list(releaseVersionId).queryKey,
       }),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -50,9 +50,9 @@ export default function DataFilesTableUploadRow({
       releaseVersionId,
       dataSetUpload.id,
     ),
-    // No point polling an upload that has already finished screening.
+    // Don't poll if the upload has finished screening.
     enabled: !terminalScreeningStatuses.includes(dataSetUpload.screeningStatus),
-    // Poll every 5 seconds until screening reaches a status it can't move on from.
+    // Poll every 5 seconds until screening finishes.
     refetchInterval: progress =>
       progress && terminalScreeningStatuses.includes(progress.status)
         ? false

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -1,10 +1,10 @@
+import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import releaseDataFileService, {
   DataSetUpload,
-  DataSetScreenerProgress,
 } from '@admin/services/releaseDataFileService';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
@@ -12,8 +12,8 @@ import ModalConfirm from '@common/components/ModalConfirm';
 import useToggle from '@common/hooks/useToggle';
 import logger from '@common/services/logger';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import { Dictionary } from '@common/types';
 import { useAuthContext } from '@admin/contexts/AuthContext';
+import { useQuery } from '@tanstack/react-query';
 import DataSetUploadSummaryList from './DataSetUploadSummaryList';
 import dataSetUploadTabIds from '../utils/dataSetUploadTabIds';
 import ScreenerResultsTable from './ScreenerResultsTable';
@@ -43,74 +43,88 @@ export default function DataFilesTableUploadRow({
   const [openDeleteConfirm, toggleOpenDeleteConfirm] = useToggle(false);
   const { user } = useAuthContext();
 
-  const [currentUpload, setCurrentUpload] =
-    useState<DataSetUpload>(dataSetUpload);
-
-  useEffect(() => {
-    setCurrentUpload(dataSetUpload);
-  }, [dataSetUpload]);
-
-  const handleScreenerStatusChange = useCallback(
-    (_upload: DataSetUpload, progress: DataSetScreenerProgress) => {
-      setCurrentUpload(upload => ({
-        ...upload,
-        screeningStatus: progress.status,
-      }));
-
-      if (terminalScreeningStatuses.includes(progress.status)) {
+  // The screener updates this upload's status out-of-band, so poll for it
+  // rather than relying on the status the list was fetched with.
+  const { data: screenerProgress } = useQuery({
+    ...releaseDataFileQueries.screeningStatus(
+      releaseVersionId,
+      dataSetUpload.id,
+    ),
+    // No point polling an upload that has already finished screening.
+    enabled: !terminalScreeningStatuses.includes(dataSetUpload.screeningStatus),
+    // Poll every 5 seconds until screening reaches a status it can't move on from.
+    refetchInterval: progress =>
+      progress && terminalScreeningStatuses.includes(progress.status)
+        ? false
+        : 5000,
+    onSuccess: progress => {
+      // Refresh the list so the row picks up the screener results that come
+      // with the finished upload.
+      if (
+        progress.status !== dataSetUpload.screeningStatus &&
+        terminalScreeningStatuses.includes(progress.status)
+      ) {
         onRefreshUploads();
       }
     },
-    [setCurrentUpload, onRefreshUploads],
-  );
+  });
 
-  const hasFailures = currentUpload.screenerResult?.testResults.some(
+  const screeningStatus =
+    screenerProgress?.status ?? dataSetUpload.screeningStatus;
+
+  const hasFailures = dataSetUpload.screenerResult?.testResults.some(
     testResult => testResult.result === 'FAIL',
   );
-  const hasWarnings = currentUpload.screenerResult?.testResults.some(
-    testResult => testResult.result === 'WARNING',
+  const warnings = useMemo(
+    () =>
+      dataSetUpload.screenerResult?.testResults.filter(
+        testResult => testResult.result === 'WARNING',
+      ) ?? [],
+    [dataSetUpload.screenerResult],
   );
+  const hasWarnings = warnings.length > 0;
 
-  const [warningAcknowledgements, setWarningAcknowledgements] = useState<
-    Dictionary<boolean>
-  >({});
+  const [acknowledgedWarnings, setAcknowledgedWarnings] = useState<Set<string>>(
+    new Set(),
+  );
 
   const canOverride = user?.permissions.isBauUser ?? false;
 
   const importBlocked =
     !canUpdateRelease ||
-    !currentUpload.screenerResult ||
-    currentUpload.screeningStatus === 'ScreenerError' ||
-    currentUpload.screeningStatus === 'FailedScreening' ||
+    !dataSetUpload.screenerResult ||
+    screeningStatus === 'ScreenerError' ||
+    screeningStatus === 'FailedScreening' ||
     hasFailures;
 
-  const importUnavailable = !Object.values(warningAcknowledgements).every(
-    acknowledgement => acknowledgement,
+  const importUnavailable = warnings.some(
+    warning => !acknowledgedWarnings.has(warning.id),
   );
 
-  useEffect(() => {
-    const warnings = currentUpload.screenerResult?.testResults.filter(
-      testResult => testResult.result === 'WARNING',
-    );
-
-    if (warnings) {
-      setWarningAcknowledgements(acknowledgements =>
-        Object.fromEntries(
-          warnings.map(warning => [
-            warning.id,
-            acknowledgements?.[warning.id] ?? false,
-          ]),
-        ),
-      );
-    }
-  }, [currentUpload]);
-
-  const acknowledgeWarning = useCallback(
-    (key: string, value: boolean) => {
-      setWarningAcknowledgements({ ...warningAcknowledgements, [key]: value });
-    },
-    [setWarningAcknowledgements, warningAcknowledgements],
+  const warningAcknowledgements = useMemo(
+    () =>
+      Object.fromEntries(
+        warnings.map(warning => [
+          warning.id,
+          acknowledgedWarnings.has(warning.id),
+        ]),
+      ),
+    [warnings, acknowledgedWarnings],
   );
+
+  const acknowledgeWarning = useCallback((key: string, value: boolean) => {
+    setAcknowledgedWarnings(acknowledged => {
+      const next = new Set(acknowledged);
+
+      if (value) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+
+      return next;
+    });
+  }, []);
 
   let tabTitle = '';
 
@@ -136,9 +150,9 @@ export default function DataFilesTableUploadRow({
     try {
       await releaseDataFileService.deleteDataSetUpload(
         releaseVersionId,
-        currentUpload.id,
+        dataSetUpload.id,
       );
-      onConfirmDelete(currentUpload.id);
+      onConfirmDelete(dataSetUpload.id);
     } catch (err) {
       logger.error(err);
     } finally {
@@ -146,7 +160,7 @@ export default function DataFilesTableUploadRow({
     }
   }, [
     releaseVersionId,
-    currentUpload.id,
+    dataSetUpload.id,
     toggleOpenDeleteConfirm,
     onConfirmDelete,
   ]);
@@ -159,44 +173,43 @@ export default function DataFilesTableUploadRow({
     confirmText = 'Continue import (override failures)';
   }
 
-  if (currentUpload.screeningStatus === 'ScreenerError') {
+  if (screeningStatus === 'ScreenerError') {
     confirmText = 'Continue import (bypass screening)';
   }
 
   return (
-    <tr key={currentUpload.dataSetTitle}>
+    <tr key={dataSetUpload.dataSetTitle}>
       <td
-        data-testid={`${currentUpload.dataSetTitle}-title`}
+        data-testid={`${dataSetUpload.dataSetTitle}-title`}
         className={styles.title}
       >
-        {currentUpload.dataSetTitle}
+        {dataSetUpload.dataSetTitle}
       </td>
       <td
-        data-testid={`${currentUpload.dataSetTitle}-size`}
+        data-testid={`${dataSetUpload.dataSetTitle}-size`}
         className={styles.fileSize}
       >
-        {currentUpload.dataFileSize}
+        {dataSetUpload.dataFileSize}
       </td>
-      <td data-testid={`${currentUpload.dataSetTitle}-status`}>
+      <td data-testid={`${dataSetUpload.dataSetTitle}-status`}>
         <ScreenerStatus
-          dataSetUpload={currentUpload}
-          releaseVersionId={releaseVersionId}
-          onStatusChange={handleScreenerStatusChange}
+          dataSetTitle={dataSetUpload.dataSetTitle}
+          percentageComplete={screenerProgress?.percentageComplete ?? 0}
+          status={screeningStatus}
         />
       </td>
-      <td data-testid={`${currentUpload.dataSetTitle}-actions`}>
+      <td data-testid={`${dataSetUpload.dataSetTitle}-actions`}>
         <ButtonGroup className={styles.actions}>
           <ModalConfirm
             title="Data set details"
             open={openImportConfirm}
             hideConfirm={
-              currentUpload.screeningStatus === 'Screening' ||
-              (importBlocked && !canOverride)
+              screeningStatus === 'Screening' || (importBlocked && !canOverride)
             }
             disableConfirm={
               importUnavailable && !(importBlocked && canOverride)
             }
-            onConfirm={() => onConfirmImport([currentUpload.id])}
+            onConfirm={() => onConfirmImport([dataSetUpload.id])}
             confirmText={confirmText}
             triggerButton={
               <ButtonText
@@ -204,7 +217,7 @@ export default function DataFilesTableUploadRow({
                 onClick={toggleOpenImportConfirm.on}
               >
                 View details
-                <VisuallyHidden>{` for ${currentUpload.dataSetTitle}`}</VisuallyHidden>
+                <VisuallyHidden>{` for ${dataSetUpload.dataSetTitle}`}</VisuallyHidden>
               </ButtonText>
             }
           >
@@ -223,29 +236,29 @@ export default function DataFilesTableUploadRow({
                   {hasFailures && failuresNoticeMessage}
                   {hasWarnings && !hasFailures && warningsNoticeMessage}
                   <ScreenerResultsTable
-                    screenerResult={currentUpload.screenerResult}
+                    screenerResult={dataSetUpload.screenerResult}
                     showAll={false}
                     onAcknowledgeWarning={acknowledgeWarning}
                     warningAcknowledgements={warningAcknowledgements}
                   />
                 </TabsSection>
               )}
-              {currentUpload.screeningStatus !== 'Screening' && (
+              {screeningStatus !== 'Screening' && (
                 <TabsSection
                   id={dataSetUploadTabIds.screenerResults}
                   testId={dataSetUploadTabIds.screenerResults}
                   title="All tests"
                   headingTitle={
-                    !currentUpload.screenerResult &&
-                    currentUpload.screeningStatus === 'ScreenerError'
+                    !dataSetUpload.screenerResult &&
+                    screeningStatus === 'ScreenerError'
                       ? 'No tests checked against this file'
-                      : `Full breakdown of ${currentUpload.screenerResult?.testResults.length} tests checked against this file`
+                      : `Full breakdown of ${dataSetUpload.screenerResult?.testResults.length} tests checked against this file`
                   }
                 >
                   {hasFailures && failuresNoticeMessage}
                   {hasWarnings && !hasFailures && warningsNoticeMessage}
                   <ScreenerResultsTable
-                    screenerResult={currentUpload.screenerResult}
+                    screenerResult={dataSetUpload.screenerResult}
                     showAll
                   />
                 </TabsSection>
@@ -260,51 +273,48 @@ export default function DataFilesTableUploadRow({
                 {hasWarnings && !hasFailures && warningsNoticeMessage}
                 <DataSetUploadSummaryList
                   releaseVersionId={releaseVersionId}
-                  dataSetUpload={currentUpload}
+                  dataSetUpload={dataSetUpload}
                 />
               </TabsSection>
             </Tabs>
           </ModalConfirm>
-          {currentUpload.screeningStatus !== 'Screening' &&
-            canUpdateRelease && (
-              <ModalConfirm
-                open={openDeleteConfirm}
-                title={
-                  dataSetUpload.replacingFileId
+          {screeningStatus !== 'Screening' && canUpdateRelease && (
+            <ModalConfirm
+              open={openDeleteConfirm}
+              title={
+                dataSetUpload.replacingFileId
+                  ? 'Cancel replacement'
+                  : 'Confirm deletion of selected data files'
+              }
+              triggerButton={
+                <ButtonText
+                  onClick={toggleOpenDeleteConfirm.on}
+                  variant="warning"
+                >
+                  {dataSetUpload.replacingFileId
                     ? 'Cancel replacement'
-                    : 'Confirm deletion of selected data files'
-                }
-                triggerButton={
-                  <ButtonText
-                    onClick={toggleOpenDeleteConfirm.on}
-                    variant="warning"
-                  >
-                    {dataSetUpload.replacingFileId
-                      ? 'Cancel replacement'
-                      : 'Delete files'}
-                    <VisuallyHidden>{` for ${currentUpload.dataSetTitle}`}</VisuallyHidden>
-                  </ButtonText>
-                }
-                onConfirm={handleDeleteConfirm}
-              >
-                {dataSetUpload.replacingFileId ? (
+                    : 'Delete files'}
+                  <VisuallyHidden>{` for ${dataSetUpload.dataSetTitle}`}</VisuallyHidden>
+                </ButtonText>
+              }
+              onConfirm={handleDeleteConfirm}
+            >
+              {dataSetUpload.replacingFileId ? (
+                <p>
+                  Are you sure you want to cancel this data replacement? The
+                  pending replacement data file will be deleted.
+                </p>
+              ) : (
+                <>
                   <p>
-                    Are you sure you want to cancel this data replacement? The
-                    pending replacement data file will be deleted.
+                    Are you sure you want to delete{' '}
+                    <strong>{dataSetUpload.dataSetTitle}</strong>?
                   </p>
-                ) : (
-                  <>
-                    <p>
-                      Are you sure you want to delete{' '}
-                      <strong>{currentUpload.dataSetTitle}</strong>?
-                    </p>
-                    <p>
-                      This version of the data set has not yet been imported.
-                    </p>
-                  </>
-                )}
-              </ModalConfirm>
-            )}
+                  <p>This version of the data set has not yet been imported.</p>
+                </>
+              )}
+            </ModalConfirm>
+          )}
         </ButtonGroup>
       </td>
     </tr>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadsGuidance.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadsGuidance.tsx
@@ -1,0 +1,52 @@
+import InsetText from '@common/components/InsetText';
+import WarningMessage from '@common/components/WarningMessage';
+import React from 'react';
+
+export default function DataUploadsGuidance() {
+  return (
+    <>
+      <InsetText>
+        <h3>Before you start</h3>
+        <p>
+          Data files will be displayed in the table tool and can be used to
+          create data blocks. They will also be attached to the release for
+          users to download. Please ensure:
+        </p>
+        <ul>
+          <li>
+            your data files have passed the checks in our{' '}
+            <a
+              href="https://rsconnect/rsc/dfe-published-data-qa/"
+              rel="noopener noreferrer nofollow"
+              target="_blank"
+            >
+              screening app (opens in new tab)
+            </a>
+          </li>
+          <li>
+            your data files meets these standards - if not you won't be able to
+            upload it to your release
+          </li>
+          <li>
+            if you have any issues uploading data files, or questions about data
+            standards contact:{' '}
+            <a href="mailto:explore.statistics@education.gov.uk">
+              explore.statistics@education.gov.uk
+            </a>
+          </li>
+        </ul>
+        <h4>Data replacement</h4>
+        <p>
+          Files are expected to have a unique title, any files that are uploaded
+          with a title that matches an existing file will start a data
+          replacement instead of importing as a separate file.
+        </p>
+      </InsetText>
+      <WarningMessage>
+        The system runs some basic screening checks during data import. Analysts
+        should still ensure that all data files undergo the full screening check
+        suite prior to being uploaded, as provided by the external screener app.
+      </WarningMessage>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -96,7 +96,6 @@ const ImporterStatus = ({
 }: ImporterStatusProps) => {
   const { data } = useQuery({
     ...releaseDataFileQueries.importStatus(releaseVersionId, dataFile.id),
-    // No point polling a file that has already finished importing.
     enabled: dataFile.status !== 'COMPLETE',
     // Poll every 5 seconds until the import reaches a status it can't move on from.
     refetchInterval: nextStatus =>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -1,4 +1,5 @@
-import releaseDataFileService, {
+import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
+import {
   DataFile,
   DataFileImportStatus,
   ImportStatusCode,
@@ -8,9 +9,8 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import ProgressBar from '@common/components/ProgressBar';
 import Tag, { TagProps } from '@common/components/Tag';
 import WarningMessage from '@common/components/WarningMessage';
-import useInterval from '@common/hooks/useInterval';
-import useMounted from '@common/hooks/useMounted';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
 
 const getImportStatusLabel = (
   statusCode: ImportStatusCode,
@@ -94,37 +94,26 @@ const ImporterStatus = ({
   releaseVersionId,
   onStatusChange,
 }: ImporterStatusProps) => {
-  const [currentStatus, setCurrentStatus] = useState<StatusState>({
+  const { data } = useQuery({
+    ...releaseDataFileQueries.importStatus(releaseVersionId, dataFile.id),
+    // No point polling a file that has already finished importing.
+    enabled: dataFile.status !== 'COMPLETE',
+    // Poll every 5 seconds until the import reaches a status it can't move on from.
+    refetchInterval: nextStatus =>
+      nextStatus && terminalImportStatuses.includes(nextStatus.status)
+        ? false
+        : 5000,
+    onSuccess: nextStatus => {
+      if (nextStatus.status !== dataFile.status) {
+        onStatusChange?.(dataFile, nextStatus);
+      }
+    },
+  });
+
+  const currentStatus: StatusState = data ?? {
     status: dataFile.status,
     percentageComplete: 0,
-  });
-
-  const fetchStatus = useCallback(async () => {
-    const nextStatus = await releaseDataFileService.getDataFileImportStatus(
-      releaseVersionId,
-      dataFile.id,
-    );
-
-    setCurrentStatus(nextStatus);
-
-    if (onStatusChange && nextStatus.status !== dataFile.status) {
-      onStatusChange(dataFile, nextStatus);
-    }
-  }, [releaseVersionId, dataFile, onStatusChange]);
-
-  const [cancelInterval] = useInterval(fetchStatus, 5000);
-
-  useMounted(() => {
-    if (dataFile.status !== 'COMPLETE') {
-      fetchStatus();
-    }
-  });
-
-  useEffect(() => {
-    if (terminalImportStatuses.includes(currentStatus.status)) {
-      cancelInterval();
-    }
-  }, [cancelInterval, currentStatus]);
+  };
 
   const hasTerminalStatus = terminalImportStatuses.includes(
     currentStatus.status,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -131,30 +131,6 @@ export default function ReleaseDataUploadsSection({
     [releaseVersionId, setAllDataFiles, refetchDataFiles],
   );
 
-  const handleReplacementStatusChange = useCallback(
-    async (updatedDataFile: DataFile) => {
-      try {
-        const permissions = await permissionService.getDataFilePermissions(
-          releaseVersionId,
-          updatedDataFile.id,
-        );
-        setAllDataFiles(currentDataFiles =>
-          currentDataFiles?.map(file =>
-            file.id !== updatedDataFile.id
-              ? file
-              : {
-                  ...updatedDataFile,
-                  permissions,
-                },
-          ),
-        );
-      } catch {
-        refetchDataFiles();
-      }
-    },
-    [releaseVersionId, setAllDataFiles, refetchDataFiles],
-  );
-
   const handleDataSetImport = useCallback(
     async (dataSetUploadIds: string[]) => {
       await releaseDataFileService.importDataSets(
@@ -322,7 +298,6 @@ export default function ReleaseDataUploadsSection({
                     onRefreshUploads={refetchDataSetUploads}
                     onDeleteUpload={handleDeleteUploadConfirm}
                     onDataSetImport={handleDataSetImport}
-                    onReplacementStatusChange={handleReplacementStatusChange}
                   />
                 )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -1,5 +1,6 @@
 import DataFilesReorderableList from '@admin/pages/release/data/components/DataFilesReorderableList';
 import DataFileUploadForm from '@admin/pages/release/data/components/DataFileUploadForm';
+import DataUploadsGuidance from '@admin/pages/release/data/components/DataUploadsGuidance';
 import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import dataReplacementService from '@admin/services/dataReplacementService';
 import permissionService from '@admin/services/permissionService';
@@ -16,20 +17,18 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery, useQueryClient, Updater } from '@tanstack/react-query';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 interface Props {
   publicationId: string;
   releaseVersionId: string;
   canUpdateRelease: boolean;
-  onDataFilesChange?: (dataFiles: DataFile[]) => void;
 }
 
 export default function ReleaseDataUploadsSection({
   publicationId,
   releaseVersionId,
   canUpdateRelease,
-  onDataFilesChange,
 }: Props) {
   const [isReordering, toggleReordering] = useToggle(false);
 
@@ -55,16 +54,14 @@ export default function ReleaseDataUploadsSection({
     refetch: refetchDataSetUploads,
   } = useQuery(releaseDataFileQueries.listUploads(releaseVersionId));
 
-  useEffect(() => {
-    onDataFilesChange?.(allDataFiles);
-  }, [allDataFiles, onDataFilesChange]);
-
-  const uploadsWithoutReplacements = allDataSetUploads.filter(
-    upload => !upload.replacingFileId,
+  const uploadsWithoutReplacements = useMemo(
+    () => allDataSetUploads.filter(upload => !upload.replacingFileId),
+    [allDataSetUploads],
   );
 
-  const uploadsWithReplacements = allDataSetUploads.filter(
-    upload => upload.replacingFileId,
+  const uploadsWithReplacements = useMemo(
+    () => allDataSetUploads.filter(upload => upload.replacingFileId),
+    [allDataSetUploads],
   );
 
   const dataFilesExcludingReplacements = useMemo(
@@ -105,6 +102,10 @@ export default function ReleaseDataUploadsSection({
     [releaseVersionId, queryClient],
   );
 
+  const refreshDataFileLists = useCallback(async () => {
+    await Promise.all([refetchDataFiles(), refetchDataSetUploads()]);
+  }, [refetchDataFiles, refetchDataSetUploads]);
+
   const handleStatusChange = useCallback(
     async (dataFile: DataFile, importStatus: DataFileImportStatus) => {
       try {
@@ -142,21 +143,10 @@ export default function ReleaseDataUploadsSection({
         uploads?.filter(upload => !dataSetUploadIds.includes(upload.id)),
       );
 
-      await refetchDataSetUploads();
-      await refetchDataFiles();
+      await refreshDataFileLists();
     },
-    [
-      releaseVersionId,
-      setAllDataUploads,
-      refetchDataFiles,
-      refetchDataSetUploads,
-    ],
+    [releaseVersionId, setAllDataUploads, refreshDataFileLists],
   );
-
-  const handleDeleteUploadConfirm = useCallback(async () => {
-    await refetchDataFiles();
-    await refetchDataSetUploads();
-  }, [refetchDataFiles, refetchDataSetUploads]);
 
   const handleDeleteConfirm = useCallback(
     async (deletedFileId: string) => {
@@ -166,11 +156,6 @@ export default function ReleaseDataUploadsSection({
     },
     [setAllDataFiles],
   );
-
-  const handleSubmit = async () => {
-    await refetchDataFiles();
-    await refetchDataSetUploads();
-  };
 
   const handleConfirmReordering = useCallback(
     async (nextDataFiles: DataFile[]) => {
@@ -199,55 +184,15 @@ export default function ReleaseDataUploadsSection({
     <>
       <h2>Add data file to release</h2>
 
-      <InsetText>
-        <h3>Before you start</h3>
-        <p>
-          Data files will be displayed in the table tool and can be used to
-          create data blocks. They will also be attached to the release for
-          users to download. Please ensure:
-        </p>
-        <ul>
-          <li>
-            your data files have passed the checks in our{' '}
-            <a
-              href="https://rsconnect/rsc/dfe-published-data-qa/"
-              rel="noopener noreferrer nofollow"
-              target="_blank"
-            >
-              screening app (opens in new tab)
-            </a>
-          </li>
-          <li>
-            your data files meets these standards - if not you won't be able to
-            upload it to your release
-          </li>
-          <li>
-            if you have any issues uploading data files, or questions about data
-            standards contact:{' '}
-            <a href="mailto:explore.statistics@education.gov.uk">
-              explore.statistics@education.gov.uk
-            </a>
-          </li>
-        </ul>
-        <h4>Data replacement</h4>
-        <p>
-          Files are expected to have a unique title, any files that are uploaded
-          with a title that matches an existing file will start a data
-          replacement instead of importing as a separate file.
-        </p>
-      </InsetText>
-      <WarningMessage>
-        The system runs some basic screening checks during data import. Analysts
-        should still ensure that all data files undergo the full screening check
-        suite prior to being uploaded, as provided by the external screener app.
-      </WarningMessage>
+      <DataUploadsGuidance />
+
       {canUpdateRelease ? (
         <DataFileUploadForm
           dataSetFileTitles={dataFilesExcludingReplacements.map(
             file => file.title,
           )}
           releaseVersionId={releaseVersionId}
-          onSubmit={handleSubmit}
+          onSubmit={refreshDataFileLists}
         />
       ) : (
         <WarningMessage>
@@ -296,7 +241,7 @@ export default function ReleaseDataUploadsSection({
                     testId="Data file replacements table"
                     onConfirmReplacement={refetchDataFiles}
                     onRefreshUploads={refetchDataSetUploads}
-                    onDeleteUpload={handleDeleteUploadConfirm}
+                    onDeleteUpload={refreshDataFileLists}
                     onDataSetImport={handleDataSetImport}
                   />
                 )}
@@ -312,10 +257,10 @@ export default function ReleaseDataUploadsSection({
                     releaseVersionId={releaseVersionId}
                     testId="Data files table"
                     onDeleteFile={handleDeleteConfirm}
-                    onDeleteUpload={handleDeleteUploadConfirm}
+                    onDeleteUpload={refreshDataFileLists}
                     onDataSetImport={handleDataSetImport}
-                    onEditFile={handleSubmit}
-                    onReplaceFile={handleSubmit}
+                    onEditFile={refreshDataFileLists}
+                    onReplaceFile={refreshDataFileLists}
                     onRefreshUploads={refetchDataSetUploads}
                     onStatusChange={handleStatusChange}
                   />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
@@ -1,25 +1,16 @@
-import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import {
-  DataSetScreenerProgress,
-  DataSetUpload,
   DataSetUploadScreeningStatus,
   ScreenerTestResult,
 } from '@admin/services/releaseDataFileService';
 import ProgressBar from '@common/components/ProgressBar';
-import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import Tag, { TagProps } from '@common/components/Tag';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 
-export type ScreenerStatusChangeHandler = (
-  dataSetUpload: DataSetUpload,
-  progress: DataSetScreenerProgress,
-) => void;
-
 interface Props {
-  dataSetUpload: DataSetUpload;
-  releaseVersionId: string;
-  onStatusChange?: ScreenerStatusChangeHandler;
+  dataSetTitle: string;
+  percentageComplete: number;
+  status: DataSetUploadScreeningStatus;
 }
 
 export const getScreenerTestResultStatusLabel = (
@@ -89,11 +80,6 @@ export const getDataSetUploadScreeningStatusColour = (
   }
 };
 
-type StatusState = Pick<
-  DataSetScreenerProgress,
-  'status' | 'percentageComplete' | 'stage' | 'completed'
->;
-
 export const terminalScreeningStatuses: DataSetUploadScreeningStatus[] = [
   'ScreenerError',
   'PendingReview',
@@ -102,44 +88,16 @@ export const terminalScreeningStatuses: DataSetUploadScreeningStatus[] = [
 ];
 
 export default function ScreenerStatus({
-  dataSetUpload,
-  releaseVersionId,
-  onStatusChange,
+  dataSetTitle,
+  percentageComplete,
+  status,
 }: Props) {
-  const { data } = useQuery({
-    ...releaseDataFileQueries.screeningStatus(
-      releaseVersionId,
-      dataSetUpload.id,
-    ),
-    // No point polling an upload that has already finished screening.
-    enabled: !terminalScreeningStatuses.includes(dataSetUpload.screeningStatus),
-    // Poll every 5 seconds until screening reaches a status it can't move on from.
-    refetchInterval: nextStatus =>
-      nextStatus && terminalScreeningStatuses.includes(nextStatus.status)
-        ? false
-        : 5000,
-    onSuccess: nextStatus => {
-      if (nextStatus.status !== dataSetUpload.screeningStatus) {
-        onStatusChange?.(dataSetUpload, nextStatus);
-      }
-    },
-  });
-
-  const currentStatus: StatusState = data ?? {
-    status: dataSetUpload.screeningStatus,
-    percentageComplete: 0,
-    stage: 'PENDING',
-    completed: false,
-  };
-
-  const hasTerminalStatus = terminalScreeningStatuses.includes(
-    currentStatus.status,
-  );
+  const hasTerminalStatus = terminalScreeningStatuses.includes(status);
 
   return (
     <>
-      <Tag colour={getDataSetUploadScreeningStatusColour(currentStatus.status)}>
-        {getDataSetUploadScreeningStatusLabel(currentStatus.status)}
+      <Tag colour={getDataSetUploadScreeningStatusColour(status)}>
+        {getDataSetUploadScreeningStatusLabel(status)}
       </Tag>
 
       {!hasTerminalStatus && (
@@ -148,9 +106,9 @@ export default function ScreenerStatus({
 
       {!hasTerminalStatus && (
         <ProgressBar
-          testId={`${dataSetUpload.dataSetTitle}-screener-progress-bar`}
+          testId={`${dataSetTitle}-screener-progress-bar`}
           className="govuk-!-margin-top-2"
-          value={currentStatus.percentageComplete}
+          value={percentageComplete}
           width={200}
         />
       )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
@@ -1,13 +1,13 @@
-import releaseDataFileService, {
+import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
+import {
   DataSetScreenerProgress,
   DataSetUpload,
   DataSetUploadScreeningStatus,
   ScreenerTestResult,
 } from '@admin/services/releaseDataFileService';
 import ProgressBar from '@common/components/ProgressBar';
-import useInterval from '@common/hooks/useInterval';
-import useMounted from '@common/hooks/useMounted';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
 import Tag, { TagProps } from '@common/components/Tag';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 
@@ -106,39 +106,31 @@ export default function ScreenerStatus({
   releaseVersionId,
   onStatusChange,
 }: Props) {
-  const [currentStatus, setCurrentStatus] = useState<StatusState>({
+  const { data } = useQuery({
+    ...releaseDataFileQueries.screeningStatus(
+      releaseVersionId,
+      dataSetUpload.id,
+    ),
+    // No point polling an upload that has already finished screening.
+    enabled: !terminalScreeningStatuses.includes(dataSetUpload.screeningStatus),
+    // Poll every 5 seconds until screening reaches a status it can't move on from.
+    refetchInterval: nextStatus =>
+      nextStatus && terminalScreeningStatuses.includes(nextStatus.status)
+        ? false
+        : 5000,
+    onSuccess: nextStatus => {
+      if (nextStatus.status !== dataSetUpload.screeningStatus) {
+        onStatusChange?.(dataSetUpload, nextStatus);
+      }
+    },
+  });
+
+  const currentStatus: StatusState = data ?? {
     status: dataSetUpload.screeningStatus,
     percentageComplete: 0,
     stage: 'PENDING',
     completed: false,
-  });
-
-  const fetchStatus = useCallback(async () => {
-    const nextStatus = await releaseDataFileService.getDataFileScreeningStatus(
-      releaseVersionId,
-      dataSetUpload.id,
-    );
-
-    setCurrentStatus(nextStatus);
-
-    if (onStatusChange && nextStatus.status !== dataSetUpload.screeningStatus) {
-      onStatusChange(dataSetUpload, nextStatus);
-    }
-  }, [releaseVersionId, dataSetUpload, onStatusChange]);
-
-  const [cancelInterval] = useInterval(fetchStatus, 5000);
-
-  useMounted(() => {
-    if (!terminalScreeningStatuses.includes(dataSetUpload.screeningStatus)) {
-      fetchStatus();
-    }
-  });
-
-  useEffect(() => {
-    if (terminalScreeningStatuses.includes(currentStatus.status)) {
-      cancelInterval();
-    }
-  }, [cancelInterval, currentStatus]);
+  };
 
   const hasTerminalStatus = terminalScreeningStatuses.includes(
     currentStatus.status,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -100,7 +100,6 @@ describe('DataFilesReplacementTableRow', () => {
                 dataFile={testDataFile}
                 publicationId="test-publication"
                 releaseVersionId="test-release-version"
-                onReplacementStatusChange={() => {}}
               />
             </tbody>
           </table>
@@ -150,7 +149,6 @@ describe('DataFilesReplacementTableRow', () => {
               dataFile={testDataFile}
               publicationId="test-publication"
               releaseVersionId="test-release-version"
-              onReplacementStatusChange={() => {}}
             />
           </tbody>
         </table>
@@ -196,7 +194,6 @@ describe('DataFilesReplacementTableRow', () => {
               dataFile={testDataFile}
               publicationId="test-publication"
               releaseVersionId="test-release-version"
-              onReplacementStatusChange={() => {}}
             />
           </tbody>
         </table>
@@ -222,6 +219,57 @@ describe('DataFilesReplacementTableRow', () => {
     expect(
       within(cells[3]).queryByRole('button', { name: 'Cancel replacement' }),
     ).not.toBeInTheDocument();
+  });
+
+  test('shows the replacement plan once the replacement import completes', async () => {
+    releaseDataFileService.getDataFile
+      .mockResolvedValueOnce({ ...testReplacementDataFile, status: 'STAGE_3' })
+      .mockResolvedValue(testReplacementDataFile);
+
+    releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
+      errors: [],
+      percentageComplete: 100,
+      stagePercentageComplete: 100,
+      status: 'COMPLETE',
+      totalRows: 100,
+    });
+
+    dataReplacementService.getReplacementPlan.mockResolvedValue(
+      testDataReplacementPlan,
+    );
+
+    render(
+      <MemoryRouter>
+        <table>
+          <tbody>
+            <DataFilesReplacementTableRow
+              dataFile={testDataFile}
+              publicationId="test-publication"
+              releaseVersionId="test-release-version"
+            />
+          </tbody>
+        </table>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Importing')).toBeInTheDocument();
+    expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+
+    // The importer reporting COMPLETE should refresh the replacement file,
+    // which enables the replacement plan query.
+    expect(await screen.findByText('Ready')).toBeInTheDocument();
+
+    const cells = screen.getAllByRole('cell');
+    expect(
+      within(cells[3]).getByRole('button', {
+        name: 'Confirm replacement for Test File',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(cells[3]).getByRole('button', {
+        name: 'Cancel replacement for Test File',
+      }),
+    ).toBeInTheDocument();
   });
 
   test('shows confirm button when user is an analyst and data file is linked to API', async () => {
@@ -254,7 +302,6 @@ describe('DataFilesReplacementTableRow', () => {
                 }}
                 publicationId="test-publication"
                 releaseVersionId="test-release-version"
-                onReplacementStatusChange={() => {}}
               />
             </AuthContext>
           </tbody>
@@ -317,7 +364,6 @@ describe('DataFilesReplacementTableRow', () => {
                 }}
                 publicationId="test-publication"
                 releaseVersionId="test-release-version"
-                onReplacementStatusChange={() => {}}
               />
             </AuthContext>
           </tbody>
@@ -380,7 +426,6 @@ describe('DataFilesReplacementTableRow', () => {
                 }}
                 publicationId="test-publication"
                 releaseVersionId="test-release-version"
-                onReplacementStatusChange={() => {}}
               />
             </tbody>
           </table>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
@@ -496,4 +496,50 @@ describe('DataFilesTableUploadsRow', () => {
       }),
     ).not.toBeInTheDocument();
   });
+
+  test('refreshes the uploads once screening reaches a terminal status', async () => {
+    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
+      percentageComplete: 100,
+      stage: 'screening',
+      status: 'PendingImport',
+      completed: true,
+    });
+
+    render(
+      <table>
+        <tbody>
+          <DataFilesTableUploadRow
+            {...rowBaseProps}
+            dataSetUpload={fileUploads.screening}
+          />
+        </tbody>
+      </table>,
+    );
+
+    expect(await screen.findByText('Pending import')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(rowBaseProps.onRefreshUploads).toHaveBeenCalled(),
+    );
+  });
+
+  test('does not poll for screening status when it is already terminal', async () => {
+    render(
+      <table>
+        <tbody>
+          <DataFilesTableUploadRow
+            {...rowBaseProps}
+            dataSetUpload={fileUploads.pass}
+          />
+        </tbody>
+      </table>,
+    );
+
+    expect(await screen.findByText('Pending import')).toBeInTheDocument();
+
+    expect(
+      releaseDataFileService.getDataFileScreeningStatus,
+    ).not.toHaveBeenCalled();
+    expect(rowBaseProps.onRefreshUploads).not.toHaveBeenCalled();
+  });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -2,8 +2,8 @@ import ImporterStatus from '@admin/pages/release/data/components/ImporterStatus'
 import _releaseDataFileService, {
   DataFile,
 } from '@admin/services/releaseDataFileService';
-import flushPromises from '@common-test/flushPromises';
-import { render, screen, within } from '@testing-library/react';
+import render from '@common-test/render';
+import { screen, within } from '@testing-library/react';
 
 jest.mock('@admin/services/releaseDataFileService');
 
@@ -186,10 +186,8 @@ describe('ImporterStatus', () => {
       />,
     );
 
-    expect(await screen.findByText('Queued')).toBeInTheDocument();
+    expect(screen.getByText('Queued')).toBeInTheDocument();
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
-
-    await flushPromises();
 
     expect(await screen.findByText('Failed')).toBeInTheDocument();
 
@@ -226,10 +224,8 @@ describe('ImporterStatus', () => {
       />,
     );
 
-    expect(await screen.findByText('Queued')).toBeInTheDocument();
+    expect(screen.getByText('Queued')).toBeInTheDocument();
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
-
-    await flushPromises();
 
     expect(await screen.findByText('Failed')).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -1232,6 +1232,11 @@ describe('ReleaseDataUploadsSection', () => {
         testCompleteImportStatus,
       );
       releaseDataFileService.getDataFile.mockResolvedValue(testDataFiles[1]);
+      // Uploading the replacement below flips `data-1` back to `QUEUED`, which
+      // restarts its importer polling and so triggers a status change.
+      permissionService.getDataFilePermissions.mockResolvedValue(
+        {} as DataFilePermissions,
+      );
 
       const { user } = renderWithTestConfig(
         <MemoryRouter>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
@@ -2,7 +2,8 @@ import ScreenerStatus from '@admin/pages/release/data/components/ScreenerStatus'
 import _releaseDataFileService, {
   DataSetUpload,
 } from '@admin/services/releaseDataFileService';
-import { render, screen, waitFor } from '@testing-library/react';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 
 jest.mock('@admin/services/releaseDataFileService');
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
@@ -1,42 +1,13 @@
 import ScreenerStatus from '@admin/pages/release/data/components/ScreenerStatus';
-import _releaseDataFileService, {
-  DataSetUpload,
-} from '@admin/services/releaseDataFileService';
-import render from '@common-test/render';
-import { screen, waitFor } from '@testing-library/react';
-
-jest.mock('@admin/services/releaseDataFileService');
-
-const releaseDataFileService = _releaseDataFileService as jest.Mocked<
-  typeof _releaseDataFileService
->;
+import { render, screen } from '@testing-library/react';
 
 describe('ScreenerStatus', () => {
-  const testDataSetUpload: DataSetUpload = {
-    id: 'upload-1',
-    dataSetTitle: 'Test data set',
-    dataFileName: 'data.csv',
-    dataFileSize: '200 B',
-    metaFileName: 'meta.csv',
-    metaFileSize: '100 B',
-    screeningStatus: 'PendingReview',
-    created: new Date(),
-    uploadedBy: 'test@test.com',
-  };
-
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  test('renders initial terminal status correctly', () => {
+  test('renders a terminal status without progress', () => {
     render(
       <ScreenerStatus
-        releaseVersionId="release-1"
-        dataSetUpload={testDataSetUpload}
+        dataSetTitle="Test data set"
+        percentageComplete={100}
+        status="PendingReview"
       />,
     );
 
@@ -44,133 +15,35 @@ describe('ScreenerStatus', () => {
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
-  test('does not fetch status from service if data set upload status is already terminal', () => {
-    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
-      status: 'PendingReview',
-      percentageComplete: 100,
-      stage: 'COMPLETE',
-      completed: true,
-    });
-
+  test('renders progress while screening is still in flight', () => {
     render(
       <ScreenerStatus
-        releaseVersionId="release-1"
-        dataSetUpload={testDataSetUpload}
-      />,
-    );
-
-    expect(
-      releaseDataFileService.getDataFileScreeningStatus,
-    ).not.toHaveBeenCalled();
-  });
-
-  test('renders with updated status from service', async () => {
-    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
-      status: 'Screening',
-      percentageComplete: 25,
-      stage: 'STAGE_1',
-      completed: false,
-    });
-
-    render(
-      <ScreenerStatus
-        releaseVersionId="release-1"
-        dataSetUpload={{
-          ...testDataSetUpload,
-          screeningStatus: 'Screening',
-        }}
+        dataSetTitle="Test data set"
+        percentageComplete={25}
+        status="Screening"
       />,
     );
 
     expect(screen.getByText('Screening')).toBeInTheDocument();
-    expect(
-      releaseDataFileService.getDataFileScreeningStatus,
-    ).toHaveBeenCalledTimes(1);
-
-    await waitFor(() =>
-      expect(screen.getByRole('progressbar')).toHaveAttribute(
-        'aria-valuenow',
-        '25',
-      ),
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '25',
     );
   });
 
-  test('renders with updated status from service at regular intervals', async () => {
-    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
-      status: 'Screening',
-      percentageComplete: 10,
-      stage: 'STAGE_1',
-      completed: false,
-    });
-
+  test.each([
+    ['ScreenerError', 'Screener error'],
+    ['PendingImport', 'Pending import'],
+    ['FailedScreening', 'Failed screening'],
+  ] as const)('renders the %s status as "%s"', (status, label) => {
     render(
       <ScreenerStatus
-        releaseVersionId="release-1"
-        dataSetUpload={{
-          ...testDataSetUpload,
-          screeningStatus: 'Screening',
-        }}
+        dataSetTitle="Test data set"
+        percentageComplete={100}
+        status={status}
       />,
     );
 
-    expect(screen.getByText('Screening')).toBeInTheDocument();
-    expect(
-      releaseDataFileService.getDataFileScreeningStatus,
-    ).toHaveBeenCalledTimes(1);
-
-    await waitFor(() =>
-      expect(screen.getByRole('progressbar')).toHaveAttribute(
-        'aria-valuenow',
-        '10',
-      ),
-    );
-
-    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
-      status: 'PendingImport',
-      percentageComplete: 100,
-      stage: 'COMPLETE',
-      completed: true,
-    });
-
-    jest.advanceTimersByTime(5000);
-
-    expect(
-      releaseDataFileService.getDataFileScreeningStatus,
-    ).toHaveBeenCalledTimes(2);
-
-    expect(await screen.findByText('Pending import')).toBeInTheDocument();
-    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-  });
-
-  test('calls onStatusChange when remote status changes', async () => {
-    releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
-      status: 'PendingImport',
-      percentageComplete: 100,
-      stage: 'COMPLETE',
-      completed: true,
-    });
-
-    const onStatusChange = jest.fn();
-
-    render(
-      <ScreenerStatus
-        releaseVersionId="release-1"
-        dataSetUpload={{
-          ...testDataSetUpload,
-          screeningStatus: 'Screening',
-        }}
-        onStatusChange={onStatusChange}
-      />,
-    );
-
-    expect(onStatusChange).not.toHaveBeenCalled();
-
-    expect(await screen.findByText('Pending import')).toBeInTheDocument();
-
-    expect(onStatusChange).toHaveBeenCalledTimes(1);
-    expect(onStatusChange).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'upload-1' }),
-      expect.objectContaining({ status: 'PendingImport' }),
-    );
+    expect(screen.getByText(label)).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
@@ -1,7 +1,7 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import dataReplacementService from '@admin/services/dataReplacementService';
 
-const dataFileReplacementQueries = createQueryKeys('user', {
+const dataFileReplacementQueries = createQueryKeys('dataFileReplacement', {
   getReplacementPlan(
     releaseVersionId: string,
     dataFileId: string,

--- a/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
@@ -21,6 +21,26 @@ const releaseDataFileQueries = createQueryKeys('releaseDataFile', {
       queryFn: () => releaseDataFileService.getDataSetUploads(releaseId),
     };
   },
+  importStatus(releaseVersionId: string, dataFileId: string) {
+    return {
+      queryKey: [releaseVersionId, dataFileId],
+      queryFn: () =>
+        releaseDataFileService.getDataFileImportStatus(
+          releaseVersionId,
+          dataFileId,
+        ),
+    };
+  },
+  screeningStatus(releaseVersionId: string, dataSetUploadId: string) {
+    return {
+      queryKey: [releaseVersionId, dataSetUploadId],
+      queryFn: () =>
+        releaseDataFileService.getDataFileScreeningStatus(
+          releaseVersionId,
+          dataSetUploadId,
+        ),
+    };
+  },
   getDeleteFilePlan(releaseVersionId: string, dataFileId: string) {
     return {
       queryKey: [releaseVersionId, dataFileId],

--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -222,22 +222,18 @@ def validate_environment_variables():
 # If running all tests, or admin, admin_and_public, admin_and_public_2, public_api or seed_data suites,
 # these change data on environments and require test themes and user authentication.
 #
-# We check for both explicit forward slashes AND OS-specific separators here, as in Windows
-# we can expect to get either scenario depending upon how we're running these tests e.g.
-# Git Bash versus Command Prompt versus IDEs.  {os.sep} in Windows always evaluates to
-# `\\` whereas any of these run options above may choose to either supply forward slashes or
-# back slashes.
+# We normalise the path to forward slashes before matching, as in Windows we can expect either
+# separator depending upon how we're running these tests e.g. Git Bash versus Command Prompt
+# versus IDEs. The path may also be relative (`.\tests`), trailing-slashed or absolute.
 def includes_data_changing_tests(arguments: argparse.Namespace):
+    tests_path = arguments.tests.replace("\\", "/").rstrip("/").removeprefix("./")
+
     return (
-        arguments.tests == "tests"
-        or arguments.tests == "tests/"
-        or arguments.tests == f"tests{os.sep}"
-        or f"{os.sep}admin" in arguments.tests
-        or "/admin" in arguments.tests
-        or f"{os.sep}public_api" in arguments.tests
-        or "/public_api" in arguments.tests
-        or f"{os.sep}seed_data" in arguments.tests
-        or "/seed_data" in arguments.tests
+        tests_path == "tests"
+        or tests_path.endswith("/tests")
+        or "/admin" in tests_path
+        or "/public_api" in tests_path
+        or "/seed_data" in tests_path
     )
 
 


### PR DESCRIPTION
This PR refactors the data uploads section in admin, focussing on reducing complexity and removing manual syncing of client state with server state. Instead, we make more use of tanstack query caches to store the data we need and are able invalidate the caches from any component. This way we are fetching the server state whenever necessary, which acts as the source of truth.
We now don't have to prop drill as many event handlers down to each table row, and have removed many (9!) `useEffect`s which caused extra renders and issues trying to understand what was going on.

The `ImporterStatus` and `ScreenerStatus` were also using custom polling and state handling:
- ImporterStatus now leverages tanstack query with refetch instead
- ScreenerStatus is now presentational, and the `Row` which uses it handles the query

Disclosure - this work has been done with Claude and me guiding/reviewing the output.

The individual commits are organised logically and have comments explaining each step of the refactor.

### Other changes
- fix a cache key which was not relevant (probably was a copy-paste error)
- amend robot test definition which caused issues trying to run on windows as `-f .\tests`