### PR TITLE
EES-7526 improve public api health discoverability

### DIFF
--- a/infrastructure/templates/common/components/monitoring/appInsights.bicep
+++ b/infrastructure/templates/common/components/monitoring/appInsights.bicep
@@ -101,3 +101,4 @@ module failedRequestsAlert '../alerts/dynamicMetricAlert.bicep' = if (alerts != 
 output applicationInsightsKey string = applicationInsights.properties.InstrumentationKey
 output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
 output applicationInsightsName string = applicationInsights.name
+output applicationInsightsId string = applicationInsights.id

--- a/infrastructure/templates/common/components/monitoring/availability-test.bicep
+++ b/infrastructure/templates/common/components/monitoring/availability-test.bicep
@@ -93,6 +93,12 @@ resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
       HttpVerb: 'GET'
       ParseDependentRequests: false
       FollowRedirects: true
+      Headers: [
+        {
+          key: 'ees-request-source'
+          value: 'Azure uptime monitoring'
+        }
+      ]
     }
     ValidationRules: {
       ExpectedHttpStatusCode: 200

--- a/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
+++ b/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
@@ -65,12 +65,7 @@ param tagValues object
 
 var severityLevel = severityMapping[alertSeverity]
 
-// Deep link straight to the Availability blade for this Application Insights resource, so
-// recipients can see failing locations, response codes and exceptions without having to
-// navigate there manually from Teams/Slack.
-var appInsightsAvailabilityBladeUrl = 'https://portal.azure.com/#resource${appInsightsId}/availability'
-
-var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}. Investigate failing locations, response codes and exceptions in the Availability blade: ${appInsightsAvailabilityBladeUrl}. This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. For more info, review [public API alert guidance on diagnosing availability test failures](https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation).'
+var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}.  This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. For more info, review guidance on diagnosing availability test failures https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation'
 
 resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
   name: name

--- a/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
+++ b/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
@@ -1,0 +1,147 @@
+import { severityMapping, Severity, EvaluationFrequency, WindowSize } from '../alerts/types.bicep'
+
+@description('Name of the availability test (also used as the alert resource name suffix).')
+param name string
+
+@description('Specifies the location for the availability test resource. Should match the Application Insights resource location.')
+param location string
+
+@description('Resource id of the Application Insights resource that this availability test is linked to.')
+param appInsightsId string
+
+@description('Full description of what this availability test is checking.')
+param testDescription string
+
+@description('The URL that the availability test will call.')
+param url string
+
+@description('''
+Webtest location Ids from which the test will be executed.
+See https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-standard-tests for the full list.
+''')
+param testLocations string[] = [
+  'emea-gb-db3-azr' // North Europe (Dublin)
+  'emea-nl-ams-azr' // West Europe (Amsterdam)
+  'emea-fr-pra-edge' // France Central (Paris)
+  'emea-ru-msa-edge' // UK South
+  'emea-se-sto-edge' // UK West
+]
+
+@description('How often (in seconds) the test is run from each test location. Supported values are 300, 600 and 900.')
+param frequencyInSeconds int = 300
+
+@description('The number of seconds to wait for a response before the test is considered to have failed.')
+param timeoutInSeconds int = 30
+
+@description('The string that must be present in the response body for the test to be considered successful.')
+param contentMatch string = 'paging'
+
+@description('''
+The number of test locations that must report a failure at the same time before the alert fires.
+Requiring failures from multiple locations avoids false alarms caused by an isolated monitoring location issue.
+''')
+param minFailedLocationsToAlert int = 3
+
+@description('Name of the Alerts Group used to send alert messages.')
+param alertsGroupName string
+
+@description('The alert severity.')
+param alertSeverity Severity = 'Critical'
+
+@description('The frequency with which the alert rule evaluates the availability test results against the threshold.')
+param alertEvaluationFrequency EvaluationFrequency = 'PT5M'
+
+@description('The timespan used to evaluate failed test location count against the threshold.')
+param alertWindowSize WindowSize = 'PT5M'
+
+@description('Flag that indicates whether the availability test and its alert are enabled.')
+param enabled bool = true
+
+@description('Whether to create or update the Azure Monitor alert for this availability test during this deploy.')
+param deployAlerts bool = false
+
+@description('Tags with which to tag the resource in Azure.')
+param tagValues object
+
+var severityLevel = severityMapping[alertSeverity]
+
+// Deep link straight to the Availability blade for this Application Insights resource, so
+// recipients can see failing locations, response codes and exceptions without having to
+// navigate there manually from Teams/Slack.
+var appInsightsAvailabilityBladeUrl = 'https://portal.azure.com/#resource${appInsightsId}/availability'
+
+var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}. Investigate failing locations, response codes and exceptions in the Availability blade: ${appInsightsAvailabilityBladeUrl}. This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. See https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation for guidance on diagnosing availability test failures.'
+
+resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
+  name: name
+  location: location
+  kind: 'standard'
+  tags: union(tagValues, {
+    'hidden-link:${appInsightsId}': 'Resource'
+  })
+  properties: {
+    SyntheticMonitorId: name
+    Name: name
+    Description: testDescription
+    Enabled: enabled
+    Frequency: frequencyInSeconds
+    Timeout: timeoutInSeconds
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      for testLocation in testLocations: {
+        Id: testLocation
+      }
+    ]
+    Request: {
+      RequestUrl: url
+      HttpVerb: 'GET'
+      ParseDependentRequests: false
+      FollowRedirects: true
+    }
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      SSLCheck: true
+      SSLCertRemainingLifetimeCheck: 7
+      ContentValidation: {
+        ContentMatch: contentMatch
+        IgnoreCase: true
+        PassIfTextFound: true
+      }
+    }
+  }
+}
+
+resource alertsActionGroup 'Microsoft.Insights/actionGroups@2023-01-01' existing = if (deployAlerts) {
+  name: alertsGroupName
+}
+
+resource availabilityAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = if (deployAlerts) {
+  name: '${name}-availability'
+  location: 'Global'
+  properties: {
+    enabled: enabled
+    description: alertFullDescription
+    severity: severityLevel
+    evaluationFrequency: alertEvaluationFrequency
+    windowSize: alertWindowSize
+    scopes: [
+      availabilityTest.id
+      appInsightsId
+    ]
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
+      webTestId: availabilityTest.id
+      componentId: appInsightsId
+      failedLocationCount: minFailedLocationsToAlert
+    }
+    actions: [
+      {
+        actionGroupId: alertsActionGroup.id
+      }
+    ]
+  }
+  tags: tagValues
+}
+
+output availabilityTestId string = availabilityTest.id

--- a/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
+++ b/infrastructure/templates/common/components/monitoring/availabilityTest.bicep
@@ -70,7 +70,7 @@ var severityLevel = severityMapping[alertSeverity]
 // navigate there manually from Teams/Slack.
 var appInsightsAvailabilityBladeUrl = 'https://portal.azure.com/#resource${appInsightsId}/availability'
 
-var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}. Investigate failing locations, response codes and exceptions in the Availability blade: ${appInsightsAvailabilityBladeUrl}. This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. See https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation for guidance on diagnosing availability test failures.'
+var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}. Investigate failing locations, response codes and exceptions in the Availability blade: ${appInsightsAvailabilityBladeUrl}. This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. For more info, review [public API alert guidance on diagnosing availability test failures](https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation).'
 
 resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
   name: name

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
@@ -42,7 +42,7 @@ module applicationInsightsModule '../../../common/components/monitoring/appInsig
 // genuine, publication-list-independent, read-only endpoint that depends on both PostgreSQL and
 // Azure AI Search. This detects when the public route, the Public API app, PostgreSQL or
 // Azure AI Search prevent the request from completing successfully.
-module availabilityTestModule '../../../common/components/monitoring/availabilityTest.bicep' = {
+module availabilityTestModule '../../../common/components/monitoring/availability-test.bicep' = {
   name: 'publicApiAvailabilityTestDeploy'
   params: {
     name: '${resourceNames.publicApi.appInsights}-publications'

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
@@ -6,6 +6,15 @@ param resourceNames ResourceNames
 @description('Specifies the location for all resources.')
 param location string
 
+@description('Environment name e.g. Development, used to give the availability test a clear, environment-specific name and description.')
+param environmentName string
+
+@description('Public URL of the Public API, used as the target of the availability test.')
+param publicApiUrl string
+
+@description('Do Azure Monitor alerts need creating or updating?')
+param deployAlerts bool = false
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -25,6 +34,24 @@ module applicationInsightsModule '../../../common/components/monitoring/appInsig
       failedRequests: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     }
+    tagValues: tagValues
+  }
+}
+
+// Availability test that behaves like an anonymous external Public API consumer, calling a
+// genuine, publication-list-independent, read-only endpoint that depends on both PostgreSQL and
+// Azure AI Search. This detects when the public route, the Public API app, PostgreSQL or
+// Azure AI Search prevent the request from completing successfully.
+module availabilityTestModule '../../../common/components/monitoring/availabilityTest.bicep' = {
+  name: 'publicApiAvailabilityTestDeploy'
+  params: {
+    name: '${resourceNames.publicApi.appInsights}-publications'
+    location: location
+    appInsightsId: applicationInsightsModule.outputs.applicationInsightsId
+    testDescription: '${environmentName} Public API availability test - anonymous GET of the publications list'
+    url: '${publicApiUrl}/v1/publications?pageSize=1'
+    alertsGroupName: resourceNames.existingResources.alertsGroup
+    deployAlerts: deployAlerts
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -273,6 +273,9 @@ module appInsightsModule 'application/public-api/publicApiAppInsights.bicep' = {
   params: {
     location: location
     resourceNames: resourceNames
+    environmentName: environmentName
+    publicApiUrl: publicUrls.publicApi
+    deployAlerts: deployAlerts
     tagValues: tagValues
   }
 }


### PR DESCRIPTION
## Summary

Adds a Standard availability test and Azure Monitor alert (publications-availability) to the Public API's Application Insights resource, so we get notified if the public API becomes unavailable to an anonymous external consumer.

## What it tests

Anonymous `GET {publicApiUrl}/v1/publications?pageSize=1` — chosen because it's public, read-only, not tied to a specific dataset, goes through the same public route as real consumers, and depends on both PostgreSQL and Azure AI Search.

* 5 test locations: North Europe (Dublin), West Europe (Amsterdam), France Central (Paris), UK South, UK West
* Frequency: every 5 minutes per location, 30s timeout
* Validates: TLS certificate validity + remaining lifetime, HTTP 200, and "paging" present in the response body
## Alert
* Fires when 3 or more of the 5 locations fail at the same time, to avoid false alarms from a single flaky monitoring location
* Routed to the existing alerted-users action group
* Description includes the exact URL under test and a link to the [investigation runbook](https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation)
* Gated behind the existing deployAlerts pipeline parameter (default No) — the availability test itself always deploys, but the alert only creates/updates when alerts are explicitly enabled for that deploy
## Changes
* `common/components/monitoring/availabilityTest.bicep` (new) — reusable webtest + metric alert module
* `common/components/monitoring/appInsights.bicep` — exposes applicationInsightsId output
public-api/application/public-api/publicApiAppInsights.bicep — wires the availability test to the Public API's App Insights resource
* `public-api/main.bicep` — passes environmentName, publicUrls.publicApi, and deployAlerts through
## Testing
* `az bicep build` on `main.bicep` — compiles cleanly, no new warnings
* Deployed to dev with `deployAlerts`: Yes; confirmed the test runs and alert fires/resolves as expected. 

<img width="1821" height="896" alt="image" src="https://github.com/user-attachments/assets/45e5c11a-282e-4119-9b30-c164c7deed7e" />
<img width="623" height="461" alt="image" src="https://github.com/user-attachments/assets/f5a2444c-12cb-42ed-be09-6ba0fdfcac9a" />
