### PR TITLE
EES-7537 - Hide unfinalise link for initial draft finalised api data set. Ensure the data set information remains visible after user finalises and unfinalises.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -65,6 +65,11 @@ public static class ValidationMessages
         Message: "Only a finalised data set version can be unfinalised."
     );
 
+    public static readonly LocalizableMessage InitialDataSetVersionCanNotBeUnfinalised = new(
+        Code: nameof(InitialDataSetVersionCanNotBeUnfinalised),
+        Message: "The initial data set version cannot be unfinalised."
+    );
+
     public static readonly LocalizableMessage ImportInManualMappingStateNotFound = new(
         Code: nameof(ImportInManualMappingStateNotFound),
         Message: "An import in mapping state could not be found."

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/UnfinaliseDataSetVersionFunctionTests.cs
@@ -62,6 +62,7 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
             .WithImports(() => [import])
             .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
             .Generate();
+        var expectedMetaSummary = targetVersion.MetaSummary;
         var mapping = DataFixture
             .DefaultDataSetVersionMapping()
             .WithSourceDataSetVersion(sourceVersion)
@@ -109,7 +110,7 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
             .SingleAsync(version => version.Id == targetVersion.Id);
         Assert.Equal(DataSetVersionStatus.Mapping, updatedVersion.Status);
         Assert.Equal(0, updatedVersion.TotalResults);
-        Assert.Null(updatedVersion.MetaSummary);
+        updatedVersion.MetaSummary.AssertDeepEqualTo(expectedMetaSummary);
         Assert.Equal(DataSetVersionImportStage.ManualMapping, updatedVersion.Imports.Single().Stage);
         Assert.Null(updatedVersion.Imports.Single().Completed);
         Assert.Single(updatedVersion.PreviewTokens);
@@ -130,6 +131,47 @@ public class UnfinaliseDataSetVersionFunctionTests(UnfinaliseDataSetVersionFunct
                 .GetPublicDataDbContext()
                 .IndicatorMetas.AnyAsync(meta => meta.DataSetVersionId == targetVersion.Id)
         );
+    }
+
+    [Fact]
+    public async Task InitialVersion_ReturnsValidationProblemAndDoesNotModifyVersion()
+    {
+        var dataSet = DataFixture.DefaultDataSet().WithStatusDraft().Generate();
+        var import = DataFixture
+            .DefaultDataSetVersionImport()
+            .WithStage(DataSetVersionImportStage.Completing)
+            .Generate();
+        import.Completed = new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var version = DataFixture
+            .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+            .WithDataSet(dataSet)
+            .WithVersionNumber(major: 1, minor: 0)
+            .WithStatusDraft()
+            .WithImports(() => [import])
+            .Generate();
+        var expectedMetaSummary = version.MetaSummary;
+        var expectedTotalResults = version.TotalResults;
+        var expectedImportCompleted = import.Completed;
+
+        await fixture.GetPublicDataDbContext().AddTestData(context => context.DataSetVersions.Add(version));
+
+        var result = await fixture.Function.UnfinaliseDataSetVersion(null!, version.Id, CancellationToken.None);
+
+        var validationProblem = result.AssertBadRequestWithValidationProblem();
+        validationProblem.AssertHasError(
+            expectedPath: "dataSetVersionId",
+            expectedCode: ValidationMessages.InitialDataSetVersionCanNotBeUnfinalised.Code
+        );
+
+        var unchangedVersion = await fixture
+            .GetPublicDataDbContext()
+            .DataSetVersions.Include(dataSetVersion => dataSetVersion.Imports)
+            .SingleAsync(dataSetVersion => dataSetVersion.Id == version.Id);
+        Assert.Equal(DataSetVersionStatus.Draft, unchangedVersion.Status);
+        Assert.Equal(expectedTotalResults, unchangedVersion.TotalResults);
+        unchangedVersion.MetaSummary.AssertDeepEqualTo(expectedMetaSummary);
+        Assert.Equal(DataSetVersionImportStage.Completing, unchangedVersion.Imports.Single().Stage);
+        Assert.Equal(expectedImportCompleted, unchangedVersion.Imports.Single().Completed);
     }
 
     [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -151,7 +151,6 @@ internal class DataSetVersionService(
                     dataSetVersionImport.Stage = DataSetVersionImportStage.ManualMapping;
                     dataSetVersionImport.Completed = null;
 
-                    dataSetVersion.MetaSummary = null;
                     dataSetVersion.TotalResults = 0;
                     dataSetVersion.Status = DataSetVersionStatus.Mapping;
 
@@ -164,6 +163,19 @@ internal class DataSetVersionService(
 
     private static Either<ActionResult, Unit> CheckCanUnfinaliseDataSetVersion(DataSetVersion dataSetVersion)
     {
+        if (dataSetVersion.IsFirstVersion)
+        {
+            return ValidationUtils.ValidationResult(
+                new ErrorViewModel
+                {
+                    Code = ValidationMessages.InitialDataSetVersionCanNotBeUnfinalised.Code,
+                    Message = ValidationMessages.InitialDataSetVersionCanNotBeUnfinalised.Message,
+                    Detail = new InvalidErrorDetail<Guid>(dataSetVersion.Id),
+                    Path = "dataSetVersionId",
+                }
+            );
+        }
+
         if (dataSetVersion.Status == DataSetVersionStatus.Draft)
         {
             return Unit.Instance;

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -120,7 +120,9 @@ export default function ReleaseApiDataSetDetailsPage() {
   );
 
   const unfinaliseAction =
-    canUpdateRelease && dataSet?.draftVersion?.status === 'Draft' ? (
+    canUpdateRelease &&
+    dataSet?.draftVersion?.status === 'Draft' &&
+    dataSet.draftVersion.version !== '1.0' ? (
       <ModalConfirm
         title="Unfinalise this data set version"
         confirmText="Unfinalise data set version"

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -114,6 +114,18 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     type: 'Patch',
   };
 
+  const testMinorDraftVersion: ApiDataSetDraftVersion = {
+    ...testDraftVersion,
+    version: '1.1',
+    type: 'Minor',
+  };
+
+  const testInitialDraftVersion: ApiDataSetDraftVersion = {
+    ...testDraftVersion,
+    version: '1.0',
+    type: 'Major',
+  };
+
   const defaultTestConfig = {
     appInsightsKey: '',
     publicAppUrl: 'http://localhost',
@@ -1324,7 +1336,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
   test.each([
     ['patch', testPatchDraftVersion],
-    ['non-patch', testDraftVersion],
+    ['minor', testMinorDraftVersion],
+    ['major', testDraftVersion],
   ])('unfinalises a finalised %s version', async (_, draftVersion) => {
     apiDataSetService.getDataSet
       .mockResolvedValueOnce({
@@ -1383,6 +1396,28 @@ describe('ReleaseApiDataSetDetailsPage', () => {
           'Status',
         ),
       ).toHaveTextContent('Action required');
+      const draftVersionSummary = within(
+        screen.getByTestId('draft-version-summary'),
+      );
+      expect(
+        draftVersionSummary.getByTestId('Geographic levels'),
+      ).toHaveTextContent('National, Local authority');
+      expect(draftVersionSummary.getByTestId('Time periods')).toHaveTextContent(
+        '2018 to 2024',
+      );
+      expect(draftVersionSummary.getByTestId('Indicators')).toHaveTextContent(
+        'Test draft indicator',
+      );
+      expect(draftVersionSummary.getByTestId('Filters')).toHaveTextContent(
+        'Test draft filter',
+      );
+      if (draftVersion.type !== 'Patch') {
+        expect(
+          draftVersionSummary.getByRole('button', {
+            name: 'Remove draft version',
+          }),
+        ).toBeInTheDocument();
+      }
       expect(
         screen.queryByRole('button', {
           name: 'Unfinalise this data set version',
@@ -1403,6 +1438,25 @@ describe('ReleaseApiDataSetDetailsPage', () => {
         screen.getByRole('link', { name: 'Map indicators' }),
       ).toBeInTheDocument();
     });
+  });
+
+  test('does not show the unfinalise action for the initial version', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      status: 'Draft',
+      draftVersion: testInitialDraftVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Unfinalise this data set version',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test('does not show the unfinalise action for an approved release', async () => {


### PR DESCRIPTION
## Changes
 * Hidden unfinalise action for initial v1.0 drafts in `ReleaseApiDataSetDetailsPage.tsx` when an API data set is finalised
 * Added backend IsFirstVersion validation with a specific 400 error.
 * Preserved MetaSummary during unfinalise so draft geographic levels, time periods, indicators, and filters remain visible after reload.
 * Added frontend coverage for v1.0, minor, major, patch, metadata rows, and draft removal.
 * Added processor coverage for v1.0 rejection/no mutation and metadata preservation.