### PR TITLE
EES-7548 Remove UnmappedReplacementFilters

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
@@ -6,6 +6,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 
@@ -20,6 +22,7 @@ public class DataSetMappingServicePermissionTests
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
         contentDbContext.ReleaseVersions.Add(releaseVersion);
         await contentDbContext.SaveChangesAsync();
@@ -31,6 +34,7 @@ public class DataSetMappingServicePermissionTests
             {
                 var service = SetupDataSetMappingService(
                     contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext,
                     userService: userService.Object
                 );
                 return service.UpdateFilterMappings(
@@ -48,6 +52,7 @@ public class DataSetMappingServicePermissionTests
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
         contentDbContext.ReleaseVersions.Add(releaseVersion);
         await contentDbContext.SaveChangesAsync();
@@ -59,6 +64,7 @@ public class DataSetMappingServicePermissionTests
             {
                 var service = SetupDataSetMappingService(
                     contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext,
                     userService: userService.Object
                 );
                 return service.UpdateIndicatorMappings(
@@ -76,6 +82,7 @@ public class DataSetMappingServicePermissionTests
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
         contentDbContext.ReleaseVersions.Add(releaseVersion);
         await contentDbContext.SaveChangesAsync();
@@ -87,6 +94,7 @@ public class DataSetMappingServicePermissionTests
             {
                 var service = SetupDataSetMappingService(
                     contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext,
                     userService: userService.Object
                 );
                 return service.UpdateLocationMappings(
@@ -99,9 +107,14 @@ public class DataSetMappingServicePermissionTests
 
     private static DataSetMappingService SetupDataSetMappingService(
         ContentDbContext contentDbContext,
+        StatisticsDbContext statisticsDbContext,
         IUserService? userService = null
     )
     {
-        return new DataSetMappingService(contentDbContext, userService ?? Mock.Of<IUserService>(MockBehavior.Strict));
+        return new DataSetMappingService(
+            contentDbContext,
+            statisticsDbContext,
+            userService ?? Mock.Of<IUserService>(MockBehavior.Strict)
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -1,13 +1,18 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
@@ -18,6 +23,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
         var originalIndicator2Id = Guid.NewGuid();
@@ -36,7 +42,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -265,6 +276,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -275,7 +287,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -410,6 +427,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
 
@@ -424,7 +442,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -488,6 +511,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
 
@@ -502,7 +526,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -572,6 +601,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var loc1Id = Guid.NewGuid();
         var loc2Id = Guid.NewGuid();
@@ -641,7 +671,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -749,6 +784,7 @@ public class DataSetMappingServiceTests
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
@@ -791,6 +827,7 @@ public class DataSetMappingServiceTests
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
@@ -839,6 +876,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
 
@@ -857,7 +895,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -897,6 +940,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -907,7 +951,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var locId = Guid.NewGuid();
@@ -961,6 +1010,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -971,7 +1021,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var locId = Guid.NewGuid();
@@ -1030,6 +1085,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalFilter1Id = Guid.NewGuid();
         var originalFilter1Group1Id = Guid.NewGuid();
@@ -1056,7 +1112,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -1141,32 +1202,65 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementFilters =
-            [
-                new UnmappedFilter
-                {
-                    Id = replacementFilter1Id,
-                    Label = "Replacement filter 1",
-                    ColumnName = "replacement_filter_1",
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementFilter1Group1Id,
-                            Label = "Original filter 1 group 1",
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem
-                                {
-                                    Id = replacementFilter1Group1Item1Id,
-                                    Label = "Original filter 1 group 1 item 1",
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilter1Id,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter 1",
+                Name = "replacement_filter_1",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementFilter1Group1Id,
+                        FilterId = replacementFilter1Id,
+                        Label = "Original filter 1 group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = replacementFilter1Group1Item1Id,
+                                FilterGroupId = replacementFilter1Group1Id,
+                                Label = "Original filter 1 group 1 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+            new Filter
+            {
+                Id = previouslyMappedReplacementFilter2Id,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter 2",
+                Name = "replacement_filter_2",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = previouslyMappedReplacementFilter2Group1Id,
+                        FilterId = previouslyMappedReplacementFilter2Id,
+                        Label = "Replacement filter 2 group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = previouslyMappedReplacementFilter2Group1Item1Id,
+                                FilterGroupId = previouslyMappedReplacementFilter2Group1Id,
+                                Label = "Replacement filter 2 group 1 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1179,7 +1273,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -1240,18 +1334,6 @@ public class DataSetMappingServiceTests
             var filter2Group1Item1 = filter2Group1.FilterItemMappings[originalFilter2Group1Item1Id];
             Assert.Null(filter2Group1Item1.ReplacementId);
             Assert.Equal(MapStatus.ParentNotMapped, filter2Group1Item1.Status);
-
-            Assert.Single(dbMapping.UnmappedReplacementFilters);
-            var newlyUnmappedFilter = dbMapping.UnmappedReplacementFilters.Single();
-            Assert.Equal(previouslyMappedReplacementFilter2Id, newlyUnmappedFilter.Id);
-            Assert.Equal("Replacement filter 2", newlyUnmappedFilter.Label);
-            var newlyUnmappedGroup = Assert.Single(newlyUnmappedFilter.UnmappedReplacementFilterGroups);
-            Assert.Equal(previouslyMappedReplacementFilter2Group1Id, newlyUnmappedGroup.Id);
-            Assert.Single(newlyUnmappedGroup.UnmappedReplacementFilterItems);
-            Assert.Equal(
-                previouslyMappedReplacementFilter2Group1Item1Id,
-                newlyUnmappedGroup.UnmappedReplacementFilterItems.Single().Id
-            );
         }
     }
 
@@ -1260,6 +1342,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1270,7 +1353,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -1333,32 +1421,65 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementFilters =
-            [
-                new UnmappedFilter
-                {
-                    Id = newReplacementFilterId,
-                    Label = "New replacement filter",
-                    ColumnName = "new_replacement_filter",
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = newReplacementFilterGroup1Id,
-                            Label = "Original filter group 1",
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem
-                                {
-                                    Id = newReplacementFilterGroup1Item1Id,
-                                    Label = "Original filter group 1 item 1",
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = oldReplacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Old replacement filter",
+                Name = "old_replacement_filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = oldReplacementFilterGroup1Id,
+                        FilterId = oldReplacementFilterId,
+                        Label = "Old replacement filter group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = oldReplacementFilterGroup1Item1Id,
+                                FilterGroupId = oldReplacementFilterGroup1Id,
+                                Label = "Old replacement filter group 1 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+            new Filter
+            {
+                Id = newReplacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "New replacement filter",
+                Name = "new_replacement_filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = newReplacementFilterGroup1Id,
+                        FilterId = newReplacementFilterId,
+                        Label = "Original filter group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = newReplacementFilterGroup1Item1Id,
+                                FilterGroupId = newReplacementFilterGroup1Id,
+                                Label = "Original filter group 1 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1371,7 +1492,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -1419,20 +1540,6 @@ public class DataSetMappingServiceTests
             Assert.Equal(newReplacementFilterGroup1Item1Id, item1.ReplacementId);
             Assert.Equal("Original filter group 1 item 1", item1.ReplacementLabel);
             Assert.Equal(MapStatus.AutoSet, item1.Status);
-
-            Assert.Single(dbMapping.UnmappedReplacementFilters);
-            var unmappedFilter = dbMapping.UnmappedReplacementFilters.Single();
-            Assert.Equal(oldReplacementFilterId, unmappedFilter.Id);
-            Assert.Equal("Old replacement filter", unmappedFilter.Label);
-            Assert.Equal("old_replacement_filter", unmappedFilter.ColumnName);
-
-            var unmappedGroup = Assert.Single(unmappedFilter.UnmappedReplacementFilterGroups);
-            Assert.Equal(oldReplacementFilterGroup1Id, unmappedGroup.Id);
-            Assert.Equal("Old replacement filter group 1", unmappedGroup.Label);
-
-            var unmappedItem = Assert.Single(unmappedGroup.UnmappedReplacementFilterItems);
-            Assert.Equal(oldReplacementFilterGroup1Item1Id, unmappedItem.Id);
-            Assert.Equal("Old replacement filter group 1 item 1", unmappedItem.Label);
         }
     }
 
@@ -1457,6 +1564,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1467,7 +1575,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -1475,7 +1588,6 @@ public class DataSetMappingServiceTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             FilterMappings = new Dictionary<Guid, FilterMapping>(),
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1511,6 +1623,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1521,7 +1634,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var filterDoesNotExistId = Guid.NewGuid();
@@ -1531,7 +1649,6 @@ public class DataSetMappingServiceTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             FilterMappings = new Dictionary<Guid, FilterMapping>(),
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1572,6 +1689,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1582,7 +1700,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -1599,7 +1722,6 @@ public class DataSetMappingServiceTests
                     new FilterMapping { OriginalId = originalFilterId }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1643,6 +1765,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1653,7 +1776,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -1685,7 +1813,6 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1726,6 +1853,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -1736,7 +1864,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -1780,7 +1913,6 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1821,6 +1953,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalFilterId = Guid.NewGuid();
         var originalFilterGroup1Id = Guid.NewGuid();
@@ -1845,7 +1978,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -1912,27 +2050,57 @@ public class DataSetMappingServiceTests
                                 }
                             },
                         },
-                        UnmappedReplacementFilterGroups =
-                        [
-                            new UnmappedFilterGroup
-                            {
-                                Id = newReplacementFilterGroup1Id,
-                                Label = "New replacement filter group 1",
-                                UnmappedReplacementFilterItems =
-                                [
-                                    new UnmappedFilterItem
-                                    {
-                                        Id = newReplacementFilterGroup1Item1Id,
-                                        Label = "Original filter group 1 item 1",
-                                    },
-                                ],
-                            },
-                        ],
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = newReplacementFilterGroup1Id,
+                        FilterId = replacementFilterId,
+                        Label = "New replacement filter group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = newReplacementFilterGroup1Item1Id,
+                                FilterGroupId = newReplacementFilterGroup1Id,
+                                Label = "Original filter group 1 item 1",
+                            },
+                        ],
+                    },
+                    new FilterGroup
+                    {
+                        Id = oldReplacementFilterGroup2Id,
+                        FilterId = replacementFilterId,
+                        Label = "Old replacement filter group 2",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = oldReplacementFilterGroup2Item1Id,
+                                FilterGroupId = oldReplacementFilterGroup2Id,
+                                Label = "Old replacement filter group 2 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1945,7 +2113,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -1997,16 +2165,6 @@ public class DataSetMappingServiceTests
             var group2Item1 = group2.FilterItemMappings[originalFilterGroup2Item1Id];
             Assert.Null(group2Item1.ReplacementId);
             Assert.Equal(MapStatus.ParentNotMapped, group2Item1.Status);
-
-            Assert.Single(filter.UnmappedReplacementFilterGroups);
-            var newlyUnmappedGroup = filter.UnmappedReplacementFilterGroups.Single();
-            Assert.Equal(oldReplacementFilterGroup2Id, newlyUnmappedGroup.Id);
-            Assert.Equal("Old replacement filter group 2", newlyUnmappedGroup.Label);
-            Assert.Single(newlyUnmappedGroup.UnmappedReplacementFilterItems);
-            Assert.Equal(
-                oldReplacementFilterGroup2Item1Id,
-                newlyUnmappedGroup.UnmappedReplacementFilterItems.Single().Id
-            );
         }
     }
 
@@ -2015,6 +2173,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2025,7 +2184,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -2037,6 +2201,8 @@ public class DataSetMappingServiceTests
 
         var newReplacementFilterGroup1Id = Guid.NewGuid();
         var newReplacementFilterGroup1Item1Id = Guid.NewGuid();
+
+        var replacementFilterId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
@@ -2050,7 +2216,7 @@ public class DataSetMappingServiceTests
                     {
                         OriginalId = originalFilterId,
                         OriginalLabel = "Original filter",
-                        ReplacementId = Guid.NewGuid(),
+                        ReplacementId = replacementFilterId,
                         ReplacementLabel = "Replacement filter",
                         Status = MapStatus.AutoSet,
                         FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
@@ -2081,27 +2247,57 @@ public class DataSetMappingServiceTests
                                 }
                             },
                         },
-                        UnmappedReplacementFilterGroups =
-                        [
-                            new UnmappedFilterGroup
-                            {
-                                Id = newReplacementFilterGroup1Id,
-                                Label = "New replacement filter group 1",
-                                UnmappedReplacementFilterItems =
-                                [
-                                    new UnmappedFilterItem
-                                    {
-                                        Id = newReplacementFilterGroup1Item1Id,
-                                        Label = "Original filter group 1 item 1",
-                                    },
-                                ],
-                            },
-                        ],
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = newReplacementFilterGroup1Id,
+                        FilterId = replacementFilterId,
+                        Label = "New replacement filter group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = newReplacementFilterGroup1Item1Id,
+                                FilterGroupId = newReplacementFilterGroup1Id,
+                                Label = "Original filter group 1 item 1",
+                            },
+                        ],
+                    },
+                    new FilterGroup
+                    {
+                        Id = oldReplacementFilterGroup1Id,
+                        FilterId = replacementFilterId,
+                        Label = "Old replacement filter group 1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = oldReplacementFilterGroup1Item1Id,
+                                FilterGroupId = oldReplacementFilterGroup1Id,
+                                Label = "Old replacement filter group 1 item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2114,7 +2310,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -2150,13 +2346,6 @@ public class DataSetMappingServiceTests
             var item1 = group1.FilterItemMappings[originalFilterGroup1Item1Id];
             Assert.Equal(newReplacementFilterGroup1Item1Id, item1.ReplacementId);
             Assert.Equal(MapStatus.AutoSet, item1.Status);
-
-            Assert.Single(filter.UnmappedReplacementFilterGroups);
-            var unmappedGroup = filter.UnmappedReplacementFilterGroups.Single();
-            Assert.Equal(oldReplacementFilterGroup1Id, unmappedGroup.Id);
-            Assert.Equal("Old replacement filter group 1", unmappedGroup.Label);
-            Assert.Single(unmappedGroup.UnmappedReplacementFilterItems);
-            Assert.Equal(oldReplacementFilterGroup1Item1Id, unmappedGroup.UnmappedReplacementFilterItems.Single().Id);
         }
     }
 
@@ -2165,6 +2354,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2175,7 +2365,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var groupDoesNotExistId = Guid.NewGuid();
@@ -2185,7 +2380,6 @@ public class DataSetMappingServiceTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             FilterMappings = new Dictionary<Guid, FilterMapping>(),
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -2226,6 +2420,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2236,7 +2431,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -2263,11 +2463,9 @@ public class DataSetMappingServiceTests
                                 new FilterGroupMapping { OriginalId = originalFilterGroupId, Status = MapStatus.Unset }
                             },
                         },
-                        UnmappedReplacementFilterGroups = [],
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -2311,6 +2509,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalFilterId = Guid.NewGuid();
         var originalFilterGroupId = Guid.NewGuid();
@@ -2331,7 +2530,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var mapping = new DataSetMapping
@@ -2383,22 +2587,51 @@ public class DataSetMappingServiceTests
                                             }
                                         },
                                     },
-                                    UnmappedReplacementFilterItems =
-                                    [
-                                        new UnmappedFilterItem
-                                        {
-                                            Id = newReplacementFilterItem1Id,
-                                            Label = "New replacement filter item 1",
-                                        },
-                                    ],
                                 }
                             },
                         },
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementFilterGroupId,
+                        FilterId = replacementFilterId,
+                        Label = "Replacement filter group",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = newReplacementFilterItem1Id,
+                                FilterGroupId = replacementFilterGroupId,
+                                Label = "New replacement filter item 1",
+                            },
+                            new FilterItem
+                            {
+                                Id = oldReplacementFilterItem2Id,
+                                FilterGroupId = replacementFilterGroupId,
+                                Label = "Old replacement filter item 2",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2411,7 +2644,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -2458,11 +2691,6 @@ public class DataSetMappingServiceTests
             var item2 = group.FilterItemMappings[originalFilterItem2Id];
             Assert.Null(item2.ReplacementId);
             Assert.Equal(MapStatus.ManuallySet, item2.Status);
-
-            Assert.Single(group.UnmappedReplacementFilterItems);
-            var newlyUnmappedItem = group.UnmappedReplacementFilterItems.Single();
-            Assert.Equal(oldReplacementFilterItem2Id, newlyUnmappedItem.Id);
-            Assert.Equal("Old replacement filter item 2", newlyUnmappedItem.Label);
         }
     }
 
@@ -2471,6 +2699,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2481,7 +2710,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -2490,6 +2724,9 @@ public class DataSetMappingServiceTests
 
         var oldReplacementFilterItem1Id = Guid.NewGuid();
         var newReplacementFilterItem1Id = Guid.NewGuid();
+
+        var replacementFilterId = Guid.NewGuid();
+        var replacementFilterGroupId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
@@ -2503,7 +2740,7 @@ public class DataSetMappingServiceTests
                     {
                         OriginalId = originalFilterId,
                         OriginalLabel = "Original filter",
-                        ReplacementId = Guid.NewGuid(),
+                        ReplacementId = replacementFilterId,
                         ReplacementLabel = "Replacement filter",
                         Status = MapStatus.AutoSet,
                         FilterGroupMappings = new Dictionary<Guid, FilterGroupMapping>
@@ -2514,7 +2751,7 @@ public class DataSetMappingServiceTests
                                 {
                                     OriginalId = originalFilterGroupId,
                                     OriginalLabel = "Original filter group",
-                                    ReplacementId = Guid.NewGuid(),
+                                    ReplacementId = replacementFilterGroupId,
                                     ReplacementLabel = "Replacement filter group",
                                     Status = MapStatus.AutoSet,
                                     FilterItemMappings = new Dictionary<Guid, FilterItemMapping>
@@ -2531,22 +2768,51 @@ public class DataSetMappingServiceTests
                                             }
                                         },
                                     },
-                                    UnmappedReplacementFilterItems =
-                                    [
-                                        new UnmappedFilterItem
-                                        {
-                                            Id = newReplacementFilterItem1Id,
-                                            Label = "New replacement filter item 1",
-                                        },
-                                    ],
                                 }
                             },
                         },
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementFilterGroupId,
+                        FilterId = replacementFilterId,
+                        Label = "Replacement filter group",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = newReplacementFilterItem1Id,
+                                FilterGroupId = replacementFilterGroupId,
+                                Label = "New replacement filter item 1",
+                            },
+                            new FilterItem
+                            {
+                                Id = oldReplacementFilterItem1Id,
+                                FilterGroupId = replacementFilterGroupId,
+                                Label = "Old replacement filter item 1",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2559,7 +2825,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -2592,11 +2858,6 @@ public class DataSetMappingServiceTests
             Assert.Equal(newReplacementFilterItem1Id, item1.ReplacementId);
             Assert.Equal("New replacement filter item 1", item1.ReplacementLabel);
             Assert.Equal(MapStatus.ManuallySet, item1.Status);
-
-            Assert.Single(group.UnmappedReplacementFilterItems);
-            var unmappedItem = group.UnmappedReplacementFilterItems.Single();
-            Assert.Equal(oldReplacementFilterItem1Id, unmappedItem.Id);
-            Assert.Equal("Old replacement filter item 1", unmappedItem.Label);
         }
     }
 
@@ -2605,6 +2866,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2615,7 +2877,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var itemDoesNotExistId = Guid.NewGuid();
@@ -2625,7 +2892,6 @@ public class DataSetMappingServiceTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             FilterMappings = new Dictionary<Guid, FilterMapping>(),
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -2666,6 +2932,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2676,7 +2943,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -2717,14 +2989,12 @@ public class DataSetMappingServiceTests
                                             }
                                         },
                                     },
-                                    UnmappedReplacementFilterItems = [],
                                 }
                             },
                         },
                     }
                 },
             },
-            UnmappedReplacementFilters = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -2768,6 +3038,7 @@ public class DataSetMappingServiceTests
     {
         var originalDataFileId = Guid.NewGuid();
         var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -2778,7 +3049,12 @@ public class DataSetMappingServiceTests
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { Id = replacementDataFileId },
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
         };
 
         var originalFilterId = Guid.NewGuid();
@@ -2829,28 +3105,40 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementFilters =
-            [
-                new UnmappedFilter
-                {
-                    Id = replacementFilterId,
-                    Label = "Replacement filter label",
-                    ColumnName = "replacement_filter",
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementFilterGroupId,
-                            Label = "Different group label",
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem { Id = replacementFilterItemId, Label = "Different item label" },
-                            ],
-                        },
-                    ],
-                },
-            ],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterId,
+                SubjectId = replacementSubjectId,
+                Label = "Replacement filter label",
+                Name = "replacement_filter",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementFilterGroupId,
+                        FilterId = replacementFilterId,
+                        Label = "Different group label",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = replacementFilterItemId,
+                                FilterGroupId = replacementFilterGroupId,
+                                Label = "Different item label",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        await using var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+        statisticsDbContext.Filter.AddRange(replacementFilters);
+        await statisticsDbContext.SaveChangesAsync();
 
         var contentDbContextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2863,7 +3151,7 @@ public class DataSetMappingServiceTests
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateFilterMappings(
                 releaseVersion.Id,
@@ -2912,18 +3200,19 @@ public class DataSetMappingServiceTests
             var item = group.FilterItemMappings[originalFilterItemId];
             Assert.Equal(replacementFilterItemId, item.ReplacementId);
             Assert.Equal(MapStatus.ManuallySet, item.Status);
-
-            Assert.Empty(dbMapping.UnmappedReplacementFilters);
-            Assert.Empty(filter.UnmappedReplacementFilterGroups);
-            Assert.Empty(group.UnmappedReplacementFilterItems);
         }
     }
 
     private static DataSetMappingService SetupDataSetMappingService(
         ContentDbContext contentDbContext,
+        StatisticsDbContext? statisticsDbContext = null,
         IUserService? userService = null
     )
     {
-        return new DataSetMappingService(contentDbContext, userService ?? MockUtils.AlwaysTrueUserService().Object);
+        return new DataSetMappingService(
+            contentDbContext,
+            statisticsDbContext ?? StatisticsDbUtils.InMemoryStatisticsDbContext(),
+            userService ?? MockUtils.AlwaysTrueUserService().Object
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -416,30 +416,6 @@ public class ReplacementPlanServiceTests
                     },
                 }
             )
-            .WithUnmappedReplacementFilters([
-                new UnmappedFilter
-                {
-                    Id = replacementFilter.Id,
-                    ColumnName = replacementFilter.Name,
-                    Label = replacementFilter.Label,
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementFilterGroup.Id,
-                            Label = replacementFilterGroup.Label,
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem
-                                {
-                                    Id = replacementFilterItem.Id,
-                                    Label = replacementFilterItem.Label,
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ])
             .WithIndicatorMappings(
                 new Dictionary<Guid, IndicatorMapping>
                 {
@@ -1157,11 +1133,7 @@ public class ReplacementPlanServiceTests
                                                 originalDefaultFilterItem.Id,
                                                 new FilterItemMapping { OriginalId = originalDefaultFilterItem.Id }
                                             },
-                                        },
-                                        unmappedReplacementFilterItems:
-                                        [
-                                            new UnmappedFilterItem { Id = replacementDefaultFilterItem.Id },
-                                        ]
+                                        }
                                     )
                                 },
                             }
@@ -1436,31 +1408,7 @@ public class ReplacementPlanServiceTests
                         )
                     },
                 }
-            )
-            .WithUnmappedReplacementFilters([
-                new UnmappedFilter
-                {
-                    Id = replacementNewlyIntroducedFilter.Id,
-                    ColumnName = replacementNewlyIntroducedFilter.Name,
-                    Label = replacementNewlyIntroducedFilter.Label,
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementNewlyIntroducedFilterGroup.Id,
-                            Label = replacementNewlyIntroducedFilterGroup.Label,
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem
-                                {
-                                    Id = replacementNewlyIntroducedFiltersFilterItem.Id,
-                                    Label = replacementNewlyIntroducedFiltersFilterItem.Label,
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ]);
+            );
 
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
         timePeriodService
@@ -1651,31 +1599,7 @@ public class ReplacementPlanServiceTests
                         )
                     },
                 }
-            )
-            .WithUnmappedReplacementFilters([
-                new UnmappedFilter
-                {
-                    Id = replacementNewlyIntroducedFilter.Id,
-                    ColumnName = replacementNewlyIntroducedFilter.Name,
-                    Label = replacementNewlyIntroducedFilter.Label,
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementNewlyIntroducedFilterGroup.Id,
-                            Label = replacementNewlyIntroducedFilterGroup.Label,
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem
-                                {
-                                    Id = replacementNewlyIntroducedFiltersFilterItem.Id,
-                                    Label = replacementNewlyIntroducedFiltersFilterItem.Label,
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ]);
+            );
 
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
         timePeriodService
@@ -3869,6 +3793,7 @@ public class ReplacementPlanServiceTests
         var userService = AlwaysTrueUserService().Object;
         return new ReplacementPlanService(
             contentDbContext,
+            statisticsDbContext,
             new FootnoteRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),
@@ -3882,7 +3807,6 @@ public class ReplacementPlanServiceTests
         Filter original,
         Filter? replacement = null,
         Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
-        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -3895,7 +3819,6 @@ public class ReplacementPlanServiceTests
             ReplacementColumnName = replacement?.Name,
             ReplacementLabel = replacement?.Label,
             FilterGroupMappings = filterGroupMappings ?? [],
-            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
             Status = status,
         };
     }
@@ -3904,7 +3827,6 @@ public class ReplacementPlanServiceTests
         FilterGroup original,
         FilterGroup? replacement = null,
         Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
-        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -3915,7 +3837,6 @@ public class ReplacementPlanServiceTests
             ReplacementId = replacement?.Id,
             ReplacementLabel = replacement?.Label,
             FilterItemMappings = filterItemMappings ?? [],
-            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
             Status = status,
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -84,14 +84,6 @@ public class ReplacementServiceHelperTests
                                             }
                                         },
                                     },
-                                    UnmappedReplacementFilterItems =
-                                    [
-                                        new UnmappedFilterItem
-                                        {
-                                            Id = replacementIndicatorA1CId,
-                                            Label = "Indicator A1C",
-                                        },
-                                    ],
                                 }
                             },
                         },
@@ -147,17 +139,6 @@ public class ReplacementServiceHelperTests
                                 }
                             },
                         },
-                        UnmappedReplacementFilterGroups =
-                        [
-                            new UnmappedFilterGroup
-                            {
-                                Id = replacementGroupB3Id,
-                                UnmappedReplacementFilterItems =
-                                [
-                                    new UnmappedFilterItem { Id = replacementIndicatorB3AId },
-                                ],
-                            },
-                        ],
                     }
                 },
                 {
@@ -185,27 +166,82 @@ public class ReplacementServiceHelperTests
                     }
                 },
             },
-            UnmappedReplacementFilters =
-            [
-                new UnmappedFilter
-                {
-                    Id = replacementFilterCId,
-                    Label = "Filter C",
-                    UnmappedReplacementFilterGroups =
-                    [
-                        new UnmappedFilterGroup
-                        {
-                            Id = replacementGroupC1Id,
-                            Label = "Group C1",
-                            UnmappedReplacementFilterItems =
-                            [
-                                new UnmappedFilterItem { Id = replacementIndicatorC1AId, Label = "Indicator C1A" },
-                            ],
-                        },
-                    ],
-                },
-            ],
         };
+
+        List<Filter> replacementFilters =
+        [
+            new Filter
+            {
+                Id = replacementFilterAId,
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementGroupA1Id,
+                        FilterId = replacementFilterAId,
+                        FilterItems =
+                        [
+                            new FilterItem { Id = replacementIndicatorA1AId, FilterGroupId = replacementGroupA1Id },
+                            new FilterItem { Id = replacementIndicatorA1BId, FilterGroupId = replacementGroupA1Id },
+                            new FilterItem
+                            {
+                                Id = replacementIndicatorA1CId,
+                                FilterGroupId = replacementGroupA1Id,
+                                Label = "Indicator A1C",
+                            },
+                        ],
+                    },
+                ],
+            },
+            new Filter
+            {
+                Id = replacementFilterBId,
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementGroupB1Id,
+                        FilterId = replacementFilterBId,
+                        FilterItems =
+                        [
+                            new FilterItem { Id = replacementIndicatorB1AId, FilterGroupId = replacementGroupB1Id },
+                        ],
+                    },
+                    new FilterGroup
+                    {
+                        Id = replacementGroupB3Id,
+                        FilterId = replacementFilterBId,
+                        FilterItems =
+                        [
+                            new FilterItem { Id = replacementIndicatorB3AId, FilterGroupId = replacementGroupB3Id },
+                        ],
+                    },
+                ],
+            },
+            new Filter
+            {
+                Id = replacementFilterCId,
+                Label = "Filter C",
+                FilterGroups =
+                [
+                    new FilterGroup
+                    {
+                        Id = replacementGroupC1Id,
+                        FilterId = replacementFilterCId,
+                        Label = "Group C1",
+                        FilterItems =
+                        [
+                            new FilterItem
+                            {
+                                Id = replacementIndicatorC1AId,
+                                FilterGroupId = replacementGroupC1Id,
+                                Label = "Indicator C1A",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
 
         List<FilterSequenceEntry> indicatorSequence =
         [
@@ -231,7 +267,11 @@ public class ReplacementServiceHelperTests
             ),
         ];
 
-        var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(indicatorSequence, mapping);
+        var updatedSequence = ReplacementServiceHelper.ReplaceFilterSequence(
+            indicatorSequence,
+            mapping,
+            replacementFilters
+        );
 
         Assert.NotNull(updatedSequence);
         Assert.Equal(3, updatedSequence.Count);
@@ -1194,48 +1234,6 @@ public class ReplacementServiceHelperTests
             ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = indicatorsMappings,
             UnmappedReplacementIndicators = unmappedReplacementIndicators,
-        };
-    }
-
-    private static FilterMapping CreateFilterMapping(
-        Filter original,
-        Filter? replacement = null,
-        Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
-        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
-        MapStatus status = MapStatus.Unset
-    )
-    {
-        return new FilterMapping
-        {
-            OriginalId = original.Id,
-            OriginalColumnName = original.Name,
-            OriginalLabel = original.Label,
-            ReplacementId = replacement?.Id,
-            ReplacementColumnName = replacement?.Name,
-            ReplacementLabel = replacement?.Label,
-            FilterGroupMappings = filterGroupMappings ?? [],
-            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
-            Status = status,
-        };
-    }
-
-    private static FilterGroupMapping CreateFilterGroupMapping(
-        FilterGroup original,
-        FilterGroup? replacement = null,
-        Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
-        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
-        MapStatus status = MapStatus.Unset
-    )
-    {
-        return new FilterGroupMapping
-        {
-            OriginalId = original.Id,
-            OriginalLabel = original.Label,
-            ReplacementId = replacement?.Id,
-            ReplacementLabel = replacement?.Label,
-            FilterItemMappings = filterItemMappings ?? [],
-            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
-            Status = status,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -20,7 +20,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
@@ -248,30 +247,35 @@ public class ReplacementServiceTests
 
         var originalFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem1 },
         };
 
         var originalFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { originalFilterItem2 },
         };
 
         var replacementFilterGroup1 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem1 },
         };
 
         var replacementFilterGroup2 = new FilterGroup
         {
+            Id = Guid.NewGuid(),
             Label = "Default group - not changing",
             FilterItems = new List<FilterItem> { replacementFilterItem2 },
         };
 
         var originalFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -280,6 +284,7 @@ public class ReplacementServiceTests
 
         var originalFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = originalReleaseSubject.Subject,
@@ -288,6 +293,7 @@ public class ReplacementServiceTests
 
         var replacementFilter1 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 1 - not changing",
             Name = "test_filter_1_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -296,6 +302,7 @@ public class ReplacementServiceTests
 
         var replacementFilter2 = new Filter
         {
+            Id = Guid.NewGuid(),
             Label = "Test filter 2 - not changing",
             Name = "test_filter_2_not_changing",
             Subject = replacementReleaseSubject.Subject,
@@ -502,6 +509,71 @@ public class ReplacementServiceTests
                     .DefaultDataSetMapping()
                     .WithOriginalDataFile(originalFile)
                     .WithReplacementDataFile(replacementFile)
+                    .WithFilterMappings(
+                        new Dictionary<Guid, FilterMapping>
+                        {
+                            {
+                                originalFilter1.Id,
+                                CreateFilterMapping(
+                                    original: originalFilter1,
+                                    replacement: replacementFilter1,
+                                    filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                                    {
+                                        {
+                                            originalFilterGroup1.Id,
+                                            CreateFilterGroupMapping(
+                                                original: originalFilterGroup1,
+                                                replacement: replacementFilterGroup1,
+                                                filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                                {
+                                                    {
+                                                        originalFilterItem1.Id,
+                                                        new FilterItemMapping
+                                                        {
+                                                            OriginalId = originalFilterItem1.Id,
+                                                            OriginalLabel = originalFilterItem1.Label,
+                                                            ReplacementId = replacementFilterItem1.Id,
+                                                            ReplacementLabel = replacementFilterItem1.Label,
+                                                        }
+                                                    },
+                                                }
+                                            )
+                                        },
+                                    }
+                                )
+                            },
+                            {
+                                originalFilter2.Id,
+                                CreateFilterMapping(
+                                    original: originalFilter2,
+                                    replacement: replacementFilter2,
+                                    filterGroupMappings: new Dictionary<Guid, FilterGroupMapping>
+                                    {
+                                        {
+                                            originalFilterGroup2.Id,
+                                            CreateFilterGroupMapping(
+                                                original: originalFilterGroup2,
+                                                replacement: replacementFilterGroup2,
+                                                filterItemMappings: new Dictionary<Guid, FilterItemMapping>
+                                                {
+                                                    {
+                                                        originalFilterItem2.Id,
+                                                        new FilterItemMapping
+                                                        {
+                                                            OriginalId = originalFilterItem2.Id,
+                                                            OriginalLabel = originalFilterItem2.Label,
+                                                            ReplacementId = replacementFilterItem2.Id,
+                                                            ReplacementLabel = replacementFilterItem2.Label,
+                                                        }
+                                                    },
+                                                }
+                                            )
+                                        },
+                                    }
+                                )
+                            },
+                        }
+                    )
             );
             await contentDbContext.SaveChangesAsync();
         }
@@ -3130,6 +3202,7 @@ public class ReplacementServiceTests
         var userService = AlwaysTrueUserService().Object;
         return new ReplacementPlanService(
             contentDbContext,
+            statisticsDbContext,
             new FootnoteRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),
@@ -3164,7 +3237,6 @@ public class ReplacementServiceTests
         Filter original,
         Filter? replacement = null,
         Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
-        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -3177,7 +3249,6 @@ public class ReplacementServiceTests
             ReplacementColumnName = replacement?.Name,
             ReplacementLabel = replacement?.Label,
             FilterGroupMappings = filterGroupMappings ?? [],
-            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
             Status = status,
         };
     }
@@ -3186,7 +3257,6 @@ public class ReplacementServiceTests
         FilterGroup original,
         FilterGroup? replacement = null,
         Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
-        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -3197,7 +3267,6 @@ public class ReplacementServiceTests
             ReplacementId = replacement?.Id,
             ReplacementLabel = replacement?.Label,
             FilterItemMappings = filterItemMappings ?? [],
-            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
             Status = status,
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
@@ -45,8 +45,6 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 .Select(f => f.SubjectId!.Value)
                 .SingleAsync(cancellationToken);
 
-            // NOTE: Basically copied from DataSetMappingService.GenerateInitialFilterMapping, although we save
-            // filterMappings unmappedReplacementFilters rather than return them
             var originalFilters = await statisticsDbContext
                 .Filter.AsNoTracking()
                 .Include(f => f.FilterGroups)
@@ -61,7 +59,7 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 .Where(f => f.SubjectId == replacementSubjectId)
                 .ToListAsync(cancellationToken);
 
-            // Create dictionaries to speed up performance when creating filterMappings/unmappedReplacementFilters
+            // Create dictionaries to speed up performance when matching originals to replacements
             var replacementFiltersMap = replacementFilters.ToDictionary(f => f.Name, f => f); // automap filters by column name
 
             var replacementFilterIdToGroupLabelToGroupMap = replacementFilters
@@ -75,7 +73,7 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 .GroupBy(x => x.FilterGroupId)
                 .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterItem.Label, g => g.FilterItem)); // automap items by label
 
-            // Now we created FilterMappings
+            // Now we create FilterMappings
             var filterMappings = new Dictionary<Guid, FilterMapping>();
             foreach (var originalFilter in originalFilters)
             {
@@ -86,7 +84,7 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                         ? replacementFilterIdToGroupLabelToGroupMap.GetValueOrDefault(replacementFilter.Id)
                         : null;
 
-                var (filterGroupMappings, unmappedReplacementGroups) = GenerateInitialFilterGroupMapping(
+                var filterGroupMappings = GenerateInitialFilterGroupMapping(
                     originalFilter.FilterGroups,
                     replacementGroupLabelToGroupMap,
                     replacementGroupIdToItemLabelToItemMap
@@ -103,7 +101,6 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                     ReplacementLabel = replacementFilter?.Label,
 
                     FilterGroupMappings = filterGroupMappings,
-                    UnmappedReplacementFilterGroups = unmappedReplacementGroups,
 
                     Status = replacementFilter == null ? MapStatus.Unset : MapStatus.AutoSet,
                 };
@@ -111,41 +108,14 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 filterMappings.Add(filterMapping.OriginalId, filterMapping);
             }
 
-            // Now we create UnmappedReplacementFilters
-            var mappedReplacementFilterIds = filterMappings
-                .Values.Where(m => m.ReplacementId.HasValue)
-                .Select(m => m.ReplacementId!.Value);
-
-            var unmappedReplacementFilters = replacementFiltersMap
-                .Values.ExceptBy(mappedReplacementFilterIds, filter => filter.Id)
-                .Select(filter => new UnmappedFilter
-                {
-                    Id = filter.Id,
-                    Label = filter.Label,
-                    ColumnName = filter.Name,
-
-                    UnmappedReplacementFilterGroups = filter
-                        .FilterGroups.Select(group => new UnmappedFilterGroup
-                        {
-                            Id = group.Id,
-                            Label = group.Label,
-                            UnmappedReplacementFilterItems = group
-                                .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                                .ToList(),
-                        })
-                        .ToList(),
-                })
-                .ToList();
-
             mapping.FilterMappings = filterMappings;
-            mapping.UnmappedReplacementFilters = unmappedReplacementFilters;
         }
 
         await contentDbContext.SaveChangesAsync(cancellationToken);
         return Ok("All DataSetMapping.FilterMappings created");
     }
 
-    private static (Dictionary<Guid, FilterGroupMapping>, List<UnmappedFilterGroup>) GenerateInitialFilterGroupMapping(
+    private static Dictionary<Guid, FilterGroupMapping> GenerateInitialFilterGroupMapping(
         List<FilterGroup> originalFilterGroups,
         Dictionary<string, FilterGroup>? replacementGroupLabelToGroupMap,
         Dictionary<Guid, Dictionary<string, FilterItem>> replacementGroupIdToItemLabelToItemMap
@@ -162,7 +132,7 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 replacementFilterGroup != null
                     ? replacementGroupIdToItemLabelToItemMap.GetValueOrDefault(replacementFilterGroup.Id)
                     : null;
-            var (filterItemMappings, unmappedReplacementItems) = GenerateInitialFilterItemMapping(
+            var filterItemMappings = GenerateInitialFilterItemMapping(
                 originalFilterGroup.FilterItems,
                 replacementItemLabelToItemMap
             );
@@ -176,7 +146,6 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
                 ReplacementLabel = replacementFilterGroup?.Label,
 
                 FilterItemMappings = filterItemMappings,
-                UnmappedReplacementFilterItems = unmappedReplacementItems,
 
                 Status =
                     replacementGroupLabelToGroupMap == null
@@ -187,34 +156,10 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
             filterGroupMappings.Add(filterGroupMapping.OriginalId, filterGroupMapping);
         }
 
-        // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
-        // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
-        var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
-        if (replacementGroupLabelToGroupMap != null)
-        {
-            // parent is mapped
-            var mappedReplacementGroupIds = filterGroupMappings
-                .Values.Where(m => m.ReplacementId.HasValue)
-                .Select(m => m.ReplacementId!.Value);
-
-            unmappedReplacementGroups = replacementGroupLabelToGroupMap
-                .Values.ExceptBy(mappedReplacementGroupIds, group => group.Id)
-                .Select(group => new UnmappedFilterGroup
-                {
-                    Id = group.Id,
-                    Label = group.Label,
-
-                    UnmappedReplacementFilterItems = group
-                        .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                        .ToList(),
-                })
-                .ToList();
-        }
-
-        return (filterGroupMappings, unmappedReplacementGroups);
+        return filterGroupMappings;
     }
 
-    private static (Dictionary<Guid, FilterItemMapping>, List<UnmappedFilterItem>) GenerateInitialFilterItemMapping(
+    private static Dictionary<Guid, FilterItemMapping> GenerateInitialFilterItemMapping(
         List<FilterItem> originalFilterItems,
         Dictionary<string, FilterItem>? replacementItemLabelToItemMap
     )
@@ -243,22 +188,6 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
             filterItemMappings.Add(filterItemMapping.OriginalId, filterItemMapping);
         }
 
-        // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
-        // if parent is mapped, we can figure out which replacement items for this group are unmapped
-        var unmappedReplacementItems = new List<UnmappedFilterItem>();
-        if (replacementItemLabelToItemMap != null)
-        {
-            // parent is mapped
-            var mappedReplacementItemIds = filterItemMappings
-                .Values.Where(m => m.ReplacementId.HasValue)
-                .Select(m => m.ReplacementId!.Value);
-
-            unmappedReplacementItems = replacementItemLabelToItemMap
-                .Values.ExceptBy(mappedReplacementItemIds, item => item.Id)
-                .Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                .ToList();
-        }
-
-        return (filterItemMappings, unmappedReplacementItems);
+        return filterItemMappings;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/CreateFilterMappingsForPreexsitingDataSetMappingsController.cs
@@ -20,6 +20,7 @@ public class CreateFilterMappingsForPreexistingDataSetMappingsController(
     StatisticsDbContext statisticsDbContext
 ) : ControllerBase
 {
+    // TODO EES-7370 Remove
     [HttpPut("create-filter-mappings")]
     public async Task<ActionResult> CreateFilterMappings(CancellationToken cancellationToken = default)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260818143845_Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260818143845_Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818143845_Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping")]
+    partial class Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260818143845_Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260818143845_Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7548RemoveUnmappedReplacementFiltersFromDataSetMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "UnmappedReplacementFilters", table: "DataSetMappings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UnmappedReplacementFilters",
+                table: "DataSetMappings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: ""
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -9,6 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
@@ -16,7 +18,11 @@ using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
-public class DataSetMappingService(ContentDbContext contentDbContext, IUserService userService) : IDataSetMappingService
+public class DataSetMappingService(
+    ContentDbContext contentDbContext,
+    StatisticsDbContext statisticsDbContext,
+    IUserService userService
+) : IDataSetMappingService
 {
     public async Task<Either<ActionResult, FiltersMappingDto>> UpdateFilterMappings(
         Guid releaseVersionId,
@@ -29,14 +35,32 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             .SingleOrNotFound()
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccess(async releaseVersion =>
-                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
+                await ValidateMapping(
+                    releaseVersion,
+                    request.OriginalDataFileId,
+                    request.ReplacementDataFileId,
+                    cancellationToken
+                )
             )
-            .OnSuccess(async mapping =>
+            .OnSuccess(async validated =>
             {
+                var (mapping, replacementReleaseFile) = validated;
+
+                var replacementFilters = await statisticsDbContext
+                    .Filter.AsNoTracking()
+                    .Include(f => f.FilterGroups)
+                        .ThenInclude(fg => fg.FilterItems)
+                    .Where(f => f.SubjectId == replacementReleaseFile.File.SubjectId!.Value)
+                    .ToListAsync(cancellationToken);
+
                 // Filters
                 var updatedFilterMappings = request
                     .FilterUpdates.Select(filterUpdate =>
-                        UpdateFilterMapping(mapping, filterUpdate.OriginalId, filterUpdate.NewReplacementId)
+                        mapping.UpdateFilterMapping(
+                            replacementFilters,
+                            filterUpdate.OriginalId,
+                            filterUpdate.NewReplacementId
+                        )
                     )
                     .ToList();
 
@@ -66,9 +90,9 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
 
                 var updatedGroupMappings = request
                     .FilterGroupUpdates.Select(groupUpdate =>
-                        UpdateFilterGroupMapping(
-                            mapping,
+                        mapping.UpdateFilterGroupMapping(
                             originalGroupIdToGroupsMap,
+                            replacementFilters,
                             groupUpdate.OriginalId,
                             groupUpdate.NewReplacementId
                         )
@@ -99,9 +123,9 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
 
                 var updatedItemMappings = request
                     .FilterItemUpdates.Select(itemUpdate =>
-                        UpdateFilterItemMapping(
-                            mapping,
+                        mapping.UpdateFilterItemMapping(
                             originalItemIdToItem,
+                            replacementFilters,
                             itemUpdate.OriginalId,
                             itemUpdate.NewReplacementId
                         )
@@ -121,483 +145,16 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
                     .Select(updated => FilterItemMappingDto.FromModel(updated.FilterItemMapping!))
                     .ToList();
 
+                // The mutations above all happen on the in-memory object graph beneath FilterMappings. EF can't see
+                // through the JSON column conversion on that property, so we must mark it dirty explicitly for the
+                // changes to be persisted. ReplacementFilters/ReplacementFilterGroups/ReplacementFilterItems are
+                // never mutated here, so they don't need marking.
+                contentDbContext.Entry(mapping).Property(x => x.FilterMappings).IsModified = true;
+
                 await contentDbContext.SaveChangesAsync(cancellationToken);
 
                 return filterMappingDto;
             });
-    }
-
-    private (FilterMapping? FilterMapping, ErrorViewModel? Error) UpdateFilterMapping(
-        DataSetMapping dataSetMapping,
-        Guid originalId,
-        Guid? newReplacementId = null
-    )
-    {
-        if (!dataSetMapping.FilterMappings.TryGetValue(originalId, out var filterMapping))
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "FilterMatchingOriginalIdNotFound",
-                    Message =
-                        $"Could not find filter mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (filterMapping.ReplacementId == newReplacementId && filterMapping.Status == MapStatus.ManuallySet)
-        {
-            return (filterMapping, null); // already set, nothing to do
-        }
-
-        var availableUnmappedFilter = dataSetMapping.UnmappedReplacementFilters.SingleOrDefault(unmappedFilter =>
-            unmappedFilter.Id == newReplacementId
-        );
-
-        if (newReplacementId != null && availableUnmappedFilter == null)
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedFilterMatchingReplacementIdNotFound",
-                    Message =
-                        $"No available unmapped filter matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (availableUnmappedFilter != null)
-        {
-            // remove availableUnmappedFilter from UnmappedReplacementFilters as it's about to become mapped
-            dataSetMapping.UnmappedReplacementFilters.Remove(availableUnmappedFilter);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
-        }
-
-        if (filterMapping.ReplacementId != null && filterMapping.ReplacementId != newReplacementId)
-        {
-            UnmapFilterMapping(dataSetMapping, filterMapping);
-        }
-
-        // If a replacement is set, we need to automap all child groups and items
-        var (filterGroupMappings, unmappedReplacementGroups) = AutoMapFilterGroupMappings(
-            filterMapping.FilterGroupMappings.Values.ToList(),
-            availableUnmappedFilter?.UnmappedReplacementFilterGroups
-        );
-
-        // mapping.Original* properties should never change
-        filterMapping.ReplacementId = availableUnmappedFilter?.Id;
-        filterMapping.ReplacementColumnName = availableUnmappedFilter?.ColumnName;
-        filterMapping.ReplacementLabel = availableUnmappedFilter?.Label;
-        filterMapping.Status = MapStatus.ManuallySet;
-
-        filterMapping.FilterGroupMappings = filterGroupMappings;
-        filterMapping.UnmappedReplacementFilterGroups = unmappedReplacementGroups;
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-
-        return (filterMapping, null);
-    }
-
-    private (FilterGroupMapping? FilterGroupMapping, ErrorViewModel? Error) UpdateFilterGroupMapping(
-        DataSetMapping dataSetMapping,
-        Dictionary<Guid, (FilterMapping FilterMap, FilterGroupMapping GroupMap)> originalGroupIdToGroupMap,
-        Guid originalId,
-        Guid? newReplacementId = null
-    )
-    {
-        if (!originalGroupIdToGroupMap.TryGetValue(originalId, out var pair))
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "FilterGroupMatchingOriginalIdNotFound",
-                    Message =
-                        $"Could not find filter group mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        var filterMapping = pair.FilterMap;
-        var groupMapping = pair.GroupMap;
-
-        if (groupMapping.Status == MapStatus.ParentNotMapped)
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "FilterGroupParentNotMapped",
-                    Message =
-                        $"Cannot map a group whose parent filter isn't mapped. OriginalId: \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (groupMapping.ReplacementId == newReplacementId && groupMapping.Status == MapStatus.ManuallySet)
-        {
-            return (groupMapping, null); // already set, nothing to do
-        }
-
-        var availableUnmappedGroup = filterMapping.UnmappedReplacementFilterGroups.SingleOrDefault(unmappedGroup =>
-            unmappedGroup.Id == newReplacementId
-        );
-
-        if (newReplacementId != null && availableUnmappedGroup == null)
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedFilterGroupMatchingReplacementIdNotFound",
-                    Message =
-                        $"No available unmapped filter group matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (availableUnmappedGroup != null)
-        {
-            // remove availableUnmappedGroup from UnmappedReplacementFilterGroups as it's about to become mapped
-            filterMapping.UnmappedReplacementFilterGroups.Remove(availableUnmappedGroup);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-        }
-
-        if (groupMapping.ReplacementId != null && groupMapping.ReplacementId != newReplacementId)
-        {
-            UnmapFilterGroupMapping(dataSetMapping, filterMapping, groupMapping);
-        }
-
-        // If a replacement is set, we need to automap all child groups and items
-        var (filterItemMappings, unmappedReplacementItems) = AutoMapFilterItemMappings(
-            groupMapping.FilterItemMappings.Values.ToList(),
-            availableUnmappedGroup?.UnmappedReplacementFilterItems
-        );
-
-        // mapping.Original* properties should never change
-        groupMapping.ReplacementId = availableUnmappedGroup?.Id;
-        groupMapping.ReplacementLabel = availableUnmappedGroup?.Label;
-        groupMapping.Status = MapStatus.ManuallySet;
-
-        groupMapping.FilterItemMappings = filterItemMappings;
-        groupMapping.UnmappedReplacementFilterItems = unmappedReplacementItems;
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-
-        return (groupMapping, null);
-    }
-
-    private (FilterItemMapping? FilterItemMapping, ErrorViewModel? Error) UpdateFilterItemMapping(
-        DataSetMapping dataSetMapping,
-        Dictionary<Guid, (FilterGroupMapping FilterGroup, FilterItemMapping FilterItem)> originalItemIdToItemMap,
-        Guid originalId,
-        Guid? newReplacementId = null
-    )
-    {
-        if (!originalItemIdToItemMap.TryGetValue(originalId, out var pair))
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "FilterItemMatchingOriginalIdNotFound",
-                    Message =
-                        $"Could not find filter item mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        var filterGroupMapping = pair.FilterGroup;
-        var filterItemMapping = pair.FilterItem;
-
-        if (filterItemMapping.Status == MapStatus.ParentNotMapped)
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "FilterItemParentNotMapped",
-                    Message =
-                        $"Cannot map a filter item whose parent group isn't mapped. OriginalId: \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (filterItemMapping.ReplacementId == newReplacementId && filterItemMapping.Status == MapStatus.ManuallySet)
-        {
-            return (filterItemMapping, null); // it is already mapped
-        }
-
-        var availableUnmappedItem = filterGroupMapping.UnmappedReplacementFilterItems.SingleOrDefault(unmappedItem =>
-            unmappedItem.Id == newReplacementId
-        );
-
-        if (newReplacementId != null && availableUnmappedItem == null)
-        {
-            return (
-                null,
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedFilterItemMatchingReplacementIdNotFound",
-                    Message =
-                        $"No available unmapped filter item matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (availableUnmappedItem != null)
-        {
-            filterGroupMapping.UnmappedReplacementFilterItems.Remove(availableUnmappedItem);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-        }
-
-        if (filterItemMapping.ReplacementId != null && filterItemMapping.ReplacementId != newReplacementId)
-        {
-            // We need to move the preexisting mapped item into UnmappedReplacementFilterItems, as it will be overwritten
-            var newlyUnmappedItem = new UnmappedFilterItem
-            {
-                Id = filterItemMapping.ReplacementId.Value,
-                Label = filterItemMapping.ReplacementLabel!,
-            };
-            filterGroupMapping.UnmappedReplacementFilterItems.Add(newlyUnmappedItem);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-        }
-
-        filterItemMapping.ReplacementId = availableUnmappedItem?.Id;
-        filterItemMapping.ReplacementLabel = availableUnmappedItem?.Label;
-        filterItemMapping.Status = MapStatus.ManuallySet;
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-
-        return (filterItemMapping, null);
-    }
-
-    private void UnmapFilterMapping(DataSetMapping dataSetMapping, FilterMapping filterMapping)
-    {
-        if (!filterMapping.ReplacementId.HasValue)
-        {
-            throw new Exception(
-                $"Cannot unmap replacement for filterMapping as no replacement is mapped. Filter OriginalId: {filterMapping.OriginalId}. DataSetMapping.Id: {dataSetMapping.Id}"
-            );
-        }
-
-        // We need to move the preexisting mapped filter into UnmappedReplacementFilters, as it will be overwritten
-        // and that must include all child groups and items
-        var newlyUnmappedFilter = new UnmappedFilter
-        {
-            Id = filterMapping.ReplacementId.Value,
-            ColumnName = filterMapping.ReplacementColumnName!,
-            Label = filterMapping.ReplacementLabel!,
-            UnmappedReplacementFilterGroups = filterMapping
-                .FilterGroupMappings.Values.Where(groupMapping => groupMapping.ReplacementId != null)
-                .Select(groupMapping => new UnmappedFilterGroup
-                {
-                    Id = groupMapping.ReplacementId!.Value,
-                    Label = groupMapping.ReplacementLabel!,
-                    UnmappedReplacementFilterItems = groupMapping
-                        .FilterItemMappings.Values.Where(itemMapping => itemMapping.ReplacementId != null)
-                        .Select(itemMapping => new UnmappedFilterItem
-                        {
-                            Id = itemMapping.ReplacementId!.Value,
-                            Label = itemMapping.ReplacementLabel!,
-                        })
-                        .Concat(groupMapping.UnmappedReplacementFilterItems)
-                        .ToList(),
-                })
-                .Concat(filterMapping.UnmappedReplacementFilterGroups)
-                .ToList(),
-        };
-        dataSetMapping.UnmappedReplacementFilters.Add(newlyUnmappedFilter);
-        contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
-
-        // Now remove it from filterMapping
-        filterMapping.ReplacementId = null;
-        filterMapping.ReplacementColumnName = null;
-        filterMapping.ReplacementLabel = null;
-        filterMapping.Status = MapStatus.Unset;
-        filterMapping.UnmappedReplacementFilterGroups = [];
-        filterMapping.FilterGroupMappings.Values.ForEach(groupMapping =>
-        {
-            groupMapping.ReplacementId = null;
-            groupMapping.ReplacementLabel = null;
-            groupMapping.Status = MapStatus.ParentNotMapped;
-            groupMapping.UnmappedReplacementFilterItems = [];
-            groupMapping.FilterItemMappings.Values.ForEach(itemMapping =>
-            {
-                itemMapping.ReplacementId = null;
-                itemMapping.ReplacementLabel = null;
-                itemMapping.Status = MapStatus.ParentNotMapped;
-            });
-        });
-        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-    }
-
-    private (
-        Dictionary<Guid, FilterGroupMapping> FilterGroupMappings,
-        List<UnmappedFilterGroup> UnmappedReplacementGroups
-    ) AutoMapFilterGroupMappings(
-        List<FilterGroupMapping> groupMappings,
-        List<UnmappedFilterGroup>? unmappedReplacementGroups
-    )
-    {
-        if (unmappedReplacementGroups == null)
-        {
-            // groups' parent filter replacement has been unset, so no automapping required, as the parent filter
-            // would have been unmapped before this method was called, and so all groups/items would be set correctly
-            // (i.e. ReplacementId == null && Status == ParentNotMapped)
-            return (groupMappings.ToDictionary(groupMap => groupMap.OriginalId, groupMap => groupMap), []);
-        }
-
-        var unmappedGroupLabelToUnmappedGroupMap = unmappedReplacementGroups.ToDictionary(
-            unmappedReplacementGroup => unmappedReplacementGroup.Label,
-            unmappedReplacementGroup => unmappedReplacementGroup
-        );
-
-        var newGroupMappings = new Dictionary<Guid, FilterGroupMapping>(groupMappings.Count);
-        foreach (var groupMapping in groupMappings)
-        {
-            if (
-                unmappedGroupLabelToUnmappedGroupMap.Remove(
-                    groupMapping.OriginalLabel,
-                    out var autoMappableReplacementGroup
-                )
-            )
-            {
-                groupMapping.ReplacementId = autoMappableReplacementGroup.Id;
-                groupMapping.ReplacementLabel = autoMappableReplacementGroup.Label;
-                groupMapping.Status = MapStatus.AutoSet;
-
-                var (autoMappedItems, unmappedReplacementItems) = AutoMapFilterItemMappings(
-                    groupMapping.FilterItemMappings.Values.ToList(),
-                    autoMappableReplacementGroup.UnmappedReplacementFilterItems
-                );
-                groupMapping.FilterItemMappings = autoMappedItems;
-                groupMapping.UnmappedReplacementFilterItems = unmappedReplacementItems;
-            }
-            else
-            {
-                groupMapping.ReplacementId = null;
-                groupMapping.ReplacementLabel = null;
-                groupMapping.Status = MapStatus.Unset;
-            }
-
-            newGroupMappings.Add(groupMapping.OriginalId, groupMapping);
-        }
-
-        // remaining replacement groups in unmappedGroupLabelToUnmappedGroupMap are unmapped
-        var newUnmappedReplacementGroups = unmappedGroupLabelToUnmappedGroupMap.Values.ToList();
-
-        return (newGroupMappings, newUnmappedReplacementGroups);
-    }
-
-    private void UnmapFilterGroupMapping(
-        DataSetMapping dataSetMapping,
-        FilterMapping filterMapping,
-        FilterGroupMapping groupMapping
-    )
-    {
-        if (!groupMapping.ReplacementId.HasValue)
-        {
-            throw new Exception(
-                $"Cannot unmap replacement for filter group mapping as no replacement is mapped. FilterGroup OriginalId: {groupMapping.OriginalId}, DataSetMapping.Id: {dataSetMapping.Id}"
-            );
-        }
-
-        // We need to move the preexisting mapped filter into UnmappedReplacementFilters, as it will be overwritten
-        var newlyUnmappedGroup = new UnmappedFilterGroup
-        {
-            Id = groupMapping.ReplacementId.Value,
-            Label = groupMapping.ReplacementLabel!,
-            UnmappedReplacementFilterItems = groupMapping
-                .FilterItemMappings.Values.Where(itemMapping => itemMapping.ReplacementId != null)
-                .Select(itemMapping => new UnmappedFilterItem
-                {
-                    Id = itemMapping.ReplacementId!.Value,
-                    Label = itemMapping.ReplacementLabel!,
-                })
-                .Concat(groupMapping.UnmappedReplacementFilterItems)
-                .ToList(),
-        };
-
-        filterMapping.UnmappedReplacementFilterGroups.Add(newlyUnmappedGroup);
-        contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementFilters).IsModified = true;
-
-        // Now remove it from groupMapping
-        groupMapping.ReplacementId = null;
-        groupMapping.ReplacementLabel = null;
-        groupMapping.Status = MapStatus.Unset;
-        groupMapping.FilterItemMappings.Values.ForEach(itemMapping =>
-        {
-            itemMapping.ReplacementId = null;
-            itemMapping.ReplacementLabel = null;
-            itemMapping.Status = MapStatus.ParentNotMapped;
-        });
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.FilterMappings).IsModified = true;
-    }
-
-    private (
-        Dictionary<Guid, FilterItemMapping> FilterItemMappings,
-        List<UnmappedFilterItem> UnmappedReplacementItems
-    ) AutoMapFilterItemMappings(
-        List<FilterItemMapping> itemMappings,
-        List<UnmappedFilterItem>? unmappedReplacementItems
-    )
-    {
-        if (unmappedReplacementItems == null)
-        {
-            // items' parent group replacement has been unset, so no automapping required, as the parent group
-            // would have been unmapped before this method was called, and so all items would be set correctly
-            // (i.e. ReplacementId == null && Status == ParentNotMapped)
-            return (itemMappings.ToDictionary(itemMap => itemMap.OriginalId, itemMap => itemMap), []);
-        }
-
-        var unmappedItemLabelToUnmappedLabelMap = unmappedReplacementItems.ToDictionary(
-            unmappedItem => unmappedItem.Label,
-            unmappedItem => unmappedItem
-        );
-
-        var newItemMappings = new Dictionary<Guid, FilterItemMapping>(itemMappings.Count);
-        foreach (var itemMap in itemMappings)
-        {
-            if (unmappedItemLabelToUnmappedLabelMap.Remove(itemMap.OriginalLabel, out var autoMappableReplacementItem))
-            {
-                itemMap.ReplacementId = autoMappableReplacementItem.Id;
-                itemMap.ReplacementLabel = autoMappableReplacementItem.Label;
-                itemMap.Status = MapStatus.AutoSet;
-            }
-            else
-            {
-                itemMap.ReplacementId = null;
-                itemMap.ReplacementLabel = null;
-                itemMap.Status = MapStatus.Unset;
-            }
-
-            newItemMappings.Add(itemMap.OriginalId, itemMap);
-        }
-
-        // remaining replacement items are unmapped
-        var newUnmappedReplacementItems = unmappedItemLabelToUnmappedLabelMap.Values.ToList();
-
-        return (newItemMappings, newUnmappedReplacementItems);
     }
 
     public async Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
@@ -611,10 +168,17 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             .SingleOrNotFound()
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccess(async releaseVersion =>
-                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
+                await ValidateMapping(
+                    releaseVersion,
+                    request.OriginalDataFileId,
+                    request.ReplacementDataFileId,
+                    cancellationToken
+                )
             )
-            .OnSuccess(async mapping =>
+            .OnSuccess(async validated =>
             {
+                var mapping = validated.Mapping;
+
                 var updatedMappings = request
                     .Updates.Select(update =>
                         UpdateIndicatorMapping(mapping, update.OriginalId, update.NewReplacementId)
@@ -718,10 +282,17 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
             .SingleOrNotFound()
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccess(async releaseVersion =>
-                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
+                await ValidateMapping(
+                    releaseVersion,
+                    request.OriginalDataFileId,
+                    request.ReplacementDataFileId,
+                    cancellationToken
+                )
             )
-            .OnSuccess(async mapping =>
+            .OnSuccess(async validated =>
             {
+                var mapping = validated.Mapping;
+
                 var updatedMappings = request
                     .Updates.Select(update =>
                         UpdateLocationMapping(mapping, update.OriginalId, update.NewReplacementId)
@@ -831,50 +402,59 @@ public class DataSetMappingService(ContentDbContext contentDbContext, IUserServi
         return locationMapping;
     }
 
-    private async Task<Either<ActionResult, DataSetMapping>> ValidateMapping(
+    private async Task<Either<ActionResult, (DataSetMapping Mapping, ReleaseFile ReplacementFile)>> ValidateMapping(
         ReleaseVersion releaseVersion,
         Guid originalDataFileId,
-        Guid replacementDataFileId
+        Guid replacementDataFileId,
+        CancellationToken cancellationToken
     )
     {
-        var mapping = await contentDbContext.DataSetMappings.SingleOrDefaultAsync(map =>
-            map.OriginalDataFileId == originalDataFileId && map.ReplacementDataFileId == replacementDataFileId
+        var mapping = await contentDbContext.DataSetMappings.SingleOrDefaultAsync(
+            map => map.OriginalDataFileId == originalDataFileId && map.ReplacementDataFileId == replacementDataFileId,
+            cancellationToken
         );
 
         if (mapping == null)
         {
-            return new Either<ActionResult, DataSetMapping>(new NotFoundResult());
+            return new NotFoundResult();
         }
 
-        var originalReleaseFileExists = await contentDbContext.ReleaseFiles.AnyAsync(rf =>
-            rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.OriginalDataFileId
+        // NOTE: We assume that both data files have been validated as FileType.Data previously.
+
+        var originalReleaseFileExists = await contentDbContext.ReleaseFiles.AnyAsync(
+            rf => rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.OriginalDataFileId,
+            cancellationToken
         );
         if (!originalReleaseFileExists)
         {
             return ValidationResult(
                 new ErrorViewModel
                 {
-                    Path = $"{nameof(IndicatorMappingUpdatesRequest.OriginalDataFileId)}",
+                    Path = nameof(IndicatorMappingUpdatesRequest.OriginalDataFileId),
                     Code = "OriginalDataFileIdNotLinkedToReleaseVersion",
-                    Message = $"The original data file is not linked to the release version",
-                }
-            );
-        }
-        var replacementReleaseFileExists = await contentDbContext.ReleaseFiles.AnyAsync(rf =>
-            rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.ReplacementDataFileId
-        );
-        if (!replacementReleaseFileExists)
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path = $"{nameof(IndicatorMappingUpdatesRequest.ReplacementDataFileId)}",
-                    Code = "ReplacementDataFileIdNotLinkedToReleaseVersion",
-                    Message = $"The replacement data set is not linked to the release version",
+                    Message = "The original data file is not linked to the release version",
                 }
             );
         }
 
-        return mapping;
+        var replacementReleaseFile = await contentDbContext
+            .ReleaseFiles.Include(rf => rf.File)
+            .SingleOrDefaultAsync(
+                rf => rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.ReplacementDataFileId,
+                cancellationToken
+            );
+        if (replacementReleaseFile == null)
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path = nameof(IndicatorMappingUpdatesRequest.ReplacementDataFileId),
+                    Code = "ReplacementDataFileIdNotLinkedToReleaseVersion",
+                    Message = "The replacement data set is not linked to the release version",
+                }
+            );
+        }
+
+        return (mapping, replacementReleaseFile);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -81,17 +81,9 @@ public class DataSetMappingService(
                 };
 
                 // FilterGroups
-                var originalGroupIdToGroupsMap = mapping
-                    .FilterMappings.Values.SelectMany(
-                        fm => fm.FilterGroupMappings.Values,
-                        (fm, gm) => (FilterMap: fm, GroupMap: gm)
-                    )
-                    .ToDictionary(x => x.GroupMap.OriginalId);
-
                 var updatedGroupMappings = request
                     .FilterGroupUpdates.Select(groupUpdate =>
                         mapping.UpdateFilterGroupMapping(
-                            originalGroupIdToGroupsMap,
                             replacementFilters,
                             groupUpdate.OriginalId,
                             groupUpdate.NewReplacementId
@@ -113,18 +105,9 @@ public class DataSetMappingService(
                     .ToList();
 
                 // FilterItems
-                var originalItemIdToItem = mapping
-                    .FilterMappings.Values.SelectMany(fm => fm.FilterGroupMappings.Values)
-                    .SelectMany(
-                        fg => fg.FilterItemMappings.Values,
-                        (group, item) => (FilterGroup: group, FilterItem: item)
-                    )
-                    .ToDictionary(x => x.FilterItem.OriginalId);
-
                 var updatedItemMappings = request
                     .FilterItemUpdates.Select(itemUpdate =>
                         mapping.UpdateFilterItemMapping(
-                            originalItemIdToItem,
                             replacementFilters,
                             itemUpdate.OriginalId,
                             itemUpdate.NewReplacementId

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
@@ -12,7 +12,7 @@ internal static class FilterGroupMappingExtensions
     public static (FilterGroupMapping? FilterGroupMapping, ErrorViewModel? Error) UpdateFilterGroupMapping(
         this DataSetMapping dataSetMapping,
         Dictionary<Guid, (FilterMapping FilterMap, FilterGroupMapping GroupMap)> originalGroupIdToGroupMap,
-        List<Filter> replacementFilters,
+        IReadOnlyList<Filter> replacementFilters,
         Guid originalId,
         Guid? newReplacementId = null
     )
@@ -96,7 +96,7 @@ internal static class FilterGroupMappingExtensions
     private static bool IsFilterGroupCandidateAvailable(
         this DataSetMapping dataSetMapping,
         FilterGroupMapping groupMapping,
-        List<FilterGroup> replacementFilterGroups,
+        IReadOnlyList<FilterGroup> replacementFilterGroups,
         Guid candidateId
     )
     {
@@ -111,7 +111,7 @@ internal static class FilterGroupMappingExtensions
 
     internal static void AutoMapChildItems(
         this FilterGroupMapping groupMapping,
-        List<FilterItem> replacementFilterItems
+        IReadOnlyList<FilterItem> replacementFilterItems
     )
     {
         if (groupMapping.ReplacementId == null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
@@ -1,0 +1,146 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+internal static class FilterGroupMappingExtensions
+{
+    public static (FilterGroupMapping? FilterGroupMapping, ErrorViewModel? Error) UpdateFilterGroupMapping(
+        this DataSetMapping dataSetMapping,
+        Dictionary<Guid, (FilterMapping FilterMap, FilterGroupMapping GroupMap)> originalGroupIdToGroupMap,
+        List<Filter> replacementFilters,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        if (!originalGroupIdToGroupMap.TryGetValue(originalId, out var pair))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterGroupMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter group mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        var (filterMapping, groupMapping) = pair;
+
+        if (groupMapping.Status == MapStatus.ParentNotMapped)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterGroupParentNotMapped",
+                    Message =
+                        $"Cannot map a group whose parent filter isn't mapped. OriginalId: \"{groupMapping.OriginalId}\"",
+                }
+            );
+        }
+
+        if (groupMapping.ReplacementId == newReplacementId && groupMapping.Status == MapStatus.ManuallySet)
+        {
+            return (groupMapping, null); // already set, nothing to do
+        }
+
+        var replacementFilterGroups = replacementFilters
+            .Where(f => f.Id == filterMapping.ReplacementId)
+            .SelectMany(f => f.FilterGroups)
+            .ToList();
+
+        if (
+            newReplacementId != null
+            && !dataSetMapping.IsFilterGroupCandidateAvailable(
+                groupMapping,
+                replacementFilterGroups,
+                newReplacementId.Value
+            )
+        )
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterGroupUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterGroupMatchingReplacementIdNotFound",
+                    Message = $"No available unmapped filter group matching replacement id \"{newReplacementId}\".",
+                }
+            );
+        }
+
+        var replacementGroup =
+            newReplacementId == null ? null : replacementFilterGroups.Single(group => group.Id == newReplacementId);
+
+        // mapping.Original* properties should never change
+        groupMapping.ReplacementId = replacementGroup?.Id;
+        groupMapping.ReplacementLabel = replacementGroup?.Label;
+        groupMapping.Status = MapStatus.ManuallySet;
+
+        groupMapping.AutoMapChildItems(replacementGroup?.FilterItems ?? []);
+
+        return (groupMapping, null);
+    }
+
+    private static bool IsFilterGroupCandidateAvailable(
+        this DataSetMapping dataSetMapping,
+        FilterGroupMapping groupMapping,
+        List<FilterGroup> replacementFilterGroups,
+        Guid candidateId
+    )
+    {
+        var candidateGroupExists = replacementFilterGroups.Any(candidateGroup => candidateGroup.Id == candidateId);
+
+        var alreadyClaimed = dataSetMapping
+            .FilterMappings.Values.SelectMany(filterMap => filterMap.FilterGroupMappings.Values)
+            .Any(other => other.OriginalId != groupMapping.OriginalId && other.ReplacementId == candidateId);
+
+        return candidateGroupExists && !alreadyClaimed;
+    }
+
+    internal static void AutoMapChildItems(
+        this FilterGroupMapping groupMapping,
+        List<FilterItem> replacementFilterItems
+    )
+    {
+        if (groupMapping.ReplacementId == null)
+        {
+            groupMapping.FilterItemMappings.Values.ForEach(itemMapping =>
+            {
+                itemMapping.ReplacementId = null;
+                itemMapping.ReplacementLabel = null;
+                itemMapping.Status = MapStatus.ParentNotMapped;
+            });
+            return;
+        }
+
+        var candidateItemsByLabel = replacementFilterItems.ToDictionary(candidateItem => candidateItem.Label);
+
+        foreach (var itemMapping in groupMapping.FilterItemMappings.Values)
+        {
+            if (candidateItemsByLabel.Remove(itemMapping.OriginalLabel, out var match))
+            {
+                itemMapping.ReplacementId = match.Id;
+                itemMapping.ReplacementLabel = match.Label;
+                itemMapping.Status = MapStatus.AutoSet;
+            }
+            else
+            {
+                itemMapping.ReplacementId = null;
+                itemMapping.ReplacementLabel = null;
+                itemMapping.Status = MapStatus.Unset;
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterGroupMappingExtensions.cs
@@ -11,13 +11,16 @@ internal static class FilterGroupMappingExtensions
 {
     public static (FilterGroupMapping? FilterGroupMapping, ErrorViewModel? Error) UpdateFilterGroupMapping(
         this DataSetMapping dataSetMapping,
-        Dictionary<Guid, (FilterMapping FilterMap, FilterGroupMapping GroupMap)> originalGroupIdToGroupMap,
         IReadOnlyList<Filter> replacementFilters,
         Guid originalId,
         Guid? newReplacementId = null
     )
     {
-        if (!originalGroupIdToGroupMap.TryGetValue(originalId, out var pair))
+        var filterMapping = dataSetMapping.FilterMappings.Values.SingleOrDefault(filterMap =>
+            filterMap.FilterGroupMappings.ContainsKey(originalId)
+        );
+
+        if (filterMapping == null)
         {
             return (
                 null,
@@ -32,7 +35,7 @@ internal static class FilterGroupMappingExtensions
             );
         }
 
-        var (filterMapping, groupMapping) = pair;
+        var groupMapping = filterMapping.FilterGroupMappings[originalId];
 
         if (groupMapping.Status == MapStatus.ParentNotMapped)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
@@ -1,0 +1,112 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+internal static class FilterItemMappingExtensions
+{
+    public static (FilterItemMapping? FilterItemMapping, ErrorViewModel? Error) UpdateFilterItemMapping(
+        this DataSetMapping dataSetMapping,
+        Dictionary<Guid, (FilterGroupMapping FilterGroup, FilterItemMapping FilterItem)> originalItemIdToItemMap,
+        List<Filter> replacementFilters,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        if (!originalItemIdToItemMap.TryGetValue(originalId, out var pair))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterItemMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter item mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        var (groupMapping, itemMapping) = pair;
+
+        if (itemMapping.Status == MapStatus.ParentNotMapped)
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterItemParentNotMapped",
+                    Message =
+                        $"Cannot map a filter item whose parent group isn't mapped. OriginalId: \"{itemMapping.OriginalId}\"",
+                }
+            );
+        }
+
+        if (itemMapping.ReplacementId == newReplacementId && itemMapping.Status == MapStatus.ManuallySet)
+        {
+            return (itemMapping, null); // it is already mapped
+        }
+
+        var replacementFilterItems =
+            replacementFilters
+                .SelectMany(f => f.FilterGroups)
+                .Where(g => g.Id == groupMapping.ReplacementId)
+                .Select(g => g.FilterItems)
+                .SingleOrDefault()
+            ?? [];
+
+        if (
+            newReplacementId != null
+            && !dataSetMapping.IsFilterItemCandidateAvailable(
+                itemMapping,
+                replacementFilterItems,
+                newReplacementId.Value
+            )
+        )
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterItemUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterItemMatchingReplacementIdNotFound",
+                    Message = $"No available unmapped filter item matching replacement id \"{newReplacementId}\".",
+                }
+            );
+        }
+
+        var replacementItem =
+            newReplacementId == null ? null : replacementFilterItems.Single(item => item.Id == newReplacementId);
+
+        // mapping.Original* properties should never change
+        itemMapping.ReplacementId = replacementItem?.Id;
+        itemMapping.ReplacementLabel = replacementItem?.Label;
+        itemMapping.Status = MapStatus.ManuallySet;
+
+        return (itemMapping, null);
+    }
+
+    private static bool IsFilterItemCandidateAvailable(
+        this DataSetMapping dataSetMapping,
+        FilterItemMapping itemMapping,
+        List<FilterItem> replacementFilterItems,
+        Guid candidateId
+    )
+    {
+        var candidateItemExists = replacementFilterItems.Any(candidateItem => candidateItem.Id == candidateId);
+
+        var alreadyClaimed = dataSetMapping
+            .FilterMappings.Values.SelectMany(filterMap => filterMap.FilterGroupMappings.Values)
+            .SelectMany(groupMap => groupMap.FilterItemMappings.Values)
+            .Any(other => other.OriginalId != itemMapping.OriginalId && other.ReplacementId == candidateId);
+
+        return candidateItemExists && !alreadyClaimed;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
@@ -10,13 +10,16 @@ internal static class FilterItemMappingExtensions
 {
     public static (FilterItemMapping? FilterItemMapping, ErrorViewModel? Error) UpdateFilterItemMapping(
         this DataSetMapping dataSetMapping,
-        Dictionary<Guid, (FilterGroupMapping FilterGroup, FilterItemMapping FilterItem)> originalItemIdToItemMap,
         IReadOnlyList<Filter> replacementFilters,
         Guid originalId,
         Guid? newReplacementId = null
     )
     {
-        if (!originalItemIdToItemMap.TryGetValue(originalId, out var pair))
+        var groupMapping = dataSetMapping
+            .FilterMappings.Values.SelectMany(filterMap => filterMap.FilterGroupMappings.Values)
+            .SingleOrDefault(groupMap => groupMap.FilterItemMappings.ContainsKey(originalId));
+
+        if (groupMapping == null)
         {
             return (
                 null,
@@ -31,7 +34,7 @@ internal static class FilterItemMappingExtensions
             );
         }
 
-        var (groupMapping, itemMapping) = pair;
+        var itemMapping = groupMapping.FilterItemMappings[originalId];
 
         if (itemMapping.Status == MapStatus.ParentNotMapped)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterItemMappingExtensions.cs
@@ -11,7 +11,7 @@ internal static class FilterItemMappingExtensions
     public static (FilterItemMapping? FilterItemMapping, ErrorViewModel? Error) UpdateFilterItemMapping(
         this DataSetMapping dataSetMapping,
         Dictionary<Guid, (FilterGroupMapping FilterGroup, FilterItemMapping FilterItem)> originalItemIdToItemMap,
-        List<Filter> replacementFilters,
+        IReadOnlyList<Filter> replacementFilters,
         Guid originalId,
         Guid? newReplacementId = null
     )
@@ -96,7 +96,7 @@ internal static class FilterItemMappingExtensions
     private static bool IsFilterItemCandidateAvailable(
         this DataSetMapping dataSetMapping,
         FilterItemMapping itemMapping,
-        List<FilterItem> replacementFilterItems,
+        IReadOnlyList<FilterItem> replacementFilterItems,
         Guid candidateId
     )
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMappingExtensions.cs
@@ -11,7 +11,7 @@ internal static class FilterMappingExtensions
 {
     public static (FilterMapping? FilterMapping, ErrorViewModel? Error) UpdateFilterMapping(
         this DataSetMapping dataSetMapping,
-        List<Filter> replacementFilters,
+        IReadOnlyList<Filter> replacementFilters,
         Guid originalId,
         Guid? newReplacementId = null
     )
@@ -71,7 +71,7 @@ internal static class FilterMappingExtensions
     private static bool IsFilterCandidateAvailable(
         DataSetMapping dataSetMapping,
         FilterMapping filterMapping,
-        List<Filter> replacementFilters,
+        IReadOnlyList<Filter> replacementFilters,
         Guid candidateId
     )
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FilterMappingExtensions.cs
@@ -1,0 +1,123 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+internal static class FilterMappingExtensions
+{
+    public static (FilterMapping? FilterMapping, ErrorViewModel? Error) UpdateFilterMapping(
+        this DataSetMapping dataSetMapping,
+        List<Filter> replacementFilters,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        if (!dataSetMapping.FilterMappings.TryGetValue(originalId, out var filterMapping))
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "FilterMatchingOriginalIdNotFound",
+                    Message =
+                        $"Could not find filter mapping matching original id \"{originalId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        if (filterMapping.ReplacementId == newReplacementId && filterMapping.Status == MapStatus.ManuallySet)
+        {
+            return (filterMapping, null); // already set, nothing to do
+        }
+
+        if (
+            newReplacementId != null
+            && !IsFilterCandidateAvailable(dataSetMapping, filterMapping, replacementFilters, newReplacementId.Value)
+        )
+        {
+            return (
+                null,
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(FilterMappingUpdatesRequest.FilterUpdates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedFilterMatchingReplacementIdNotFound",
+                    Message =
+                        $"No available unmapped filter matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        var replacement =
+            newReplacementId == null ? null : replacementFilters.Single(filter => filter.Id == newReplacementId);
+
+        // mapping.Original* properties should never change
+        filterMapping.ReplacementId = replacement?.Id;
+        filterMapping.ReplacementColumnName = replacement?.Name;
+        filterMapping.ReplacementLabel = replacement?.Label;
+        filterMapping.Status = MapStatus.ManuallySet;
+
+        filterMapping.AutoMapChildGroups(replacement?.FilterGroups ?? []);
+
+        return (filterMapping, null);
+    }
+
+    private static bool IsFilterCandidateAvailable(
+        DataSetMapping dataSetMapping,
+        FilterMapping filterMapping,
+        List<Filter> replacementFilters,
+        Guid candidateId
+    )
+    {
+        var candidateExists = replacementFilters.Any(candidate => candidate.Id == candidateId);
+
+        var alreadyClaimed = dataSetMapping.FilterMappings.Values.Any(other =>
+            other.OriginalId != filterMapping.OriginalId && other.ReplacementId == candidateId
+        );
+
+        return candidateExists && !alreadyClaimed;
+    }
+
+    private static void AutoMapChildGroups(this FilterMapping filterMapping, List<FilterGroup> replacementFilterGroups)
+    {
+        if (filterMapping.ReplacementId == null)
+        {
+            filterMapping.FilterGroupMappings.Values.ForEach(groupMapping =>
+            {
+                groupMapping.ReplacementId = null;
+                groupMapping.ReplacementLabel = null;
+                groupMapping.Status = MapStatus.ParentNotMapped;
+                groupMapping.AutoMapChildItems([]); // Set child items to ReplacementId = null, Status = ParentNotMapped
+            });
+            return;
+        }
+
+        var candidateGroupsByLabel = replacementFilterGroups.ToDictionary(candidateGroup => candidateGroup.Label);
+
+        foreach (var groupMapping in filterMapping.FilterGroupMappings.Values)
+        {
+            if (candidateGroupsByLabel.Remove(groupMapping.OriginalLabel, out var match))
+            {
+                groupMapping.ReplacementId = match.Id;
+                groupMapping.ReplacementLabel = match.Label;
+                groupMapping.Status = MapStatus.AutoSet;
+
+                groupMapping.AutoMapChildItems(match.FilterItems);
+            }
+            else
+            {
+                groupMapping.ReplacementId = null;
+                groupMapping.ReplacementLabel = null;
+                groupMapping.Status = MapStatus.Unset;
+
+                groupMapping.AutoMapChildItems([]); // Set child items to ReplacementId = null, Status = ParentNotMapped
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
@@ -23,6 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
 public class ReplacementPlanService(
     ContentDbContext contentDbContext,
+    StatisticsDbContext statisticsDbContext,
     IFootnoteRepository footnoteRepository,
     IDataSetVersionService dataSetVersionService,
     ITimePeriodService timePeriodService,
@@ -143,7 +145,14 @@ public class ReplacementPlanService(
                     ? null
                     : await GetApiVersionPlanViewModel(replacementApiDataSetVersion, cancellationToken);
 
-                var mappingPlan = ReplacementPlanMappingViewModel.FromModel(mapping);
+                var replacementFilters = await statisticsDbContext
+                    .Filter.AsNoTracking()
+                    .Include(f => f.FilterGroups)
+                        .ThenInclude(g => g.FilterItems)
+                    .Where(f => f.SubjectId == replacementSubjectId)
+                    .ToListAsync(cancellationToken);
+
+                var mappingPlan = ReplacementPlanMappingViewModel.FromModel(mapping, replacementFilters);
 
                 return new DataReplacementPlanViewModel
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -118,7 +118,12 @@ public class ReplacementService(
                     && mapping.ReplacementDataFileId == replacementReleaseFile.FileId
                 );
 
-                replacementReleaseFile.FilterSequence = ReplaceFilterSequence(originalReleaseFile, mapping);
+                replacementReleaseFile.FilterSequence = await ReplaceFilterSequence(
+                    originalReleaseFile,
+                    replacementSubjectId,
+                    mapping,
+                    cancellationToken
+                );
                 replacementReleaseFile.IndicatorSequence = ReplaceIndicatorSequence(originalReleaseFile, mapping);
                 replacementReleaseFile.Summary = originalReleaseFile.Summary; // Set Data guidance
 
@@ -637,9 +642,11 @@ public class ReplacementService(
         );
     }
 
-    private static List<FilterSequenceEntry>? ReplaceFilterSequence(
+    private async Task<List<FilterSequenceEntry>?> ReplaceFilterSequence(
         ReleaseFile originalReleaseFile,
-        DataSetMapping mapping
+        Guid replacementSubjectId,
+        DataSetMapping mapping,
+        CancellationToken cancellationToken
     )
     {
         // If the sequence is null then leave it so we continue to fallback to ordering by label alphabetically
@@ -648,9 +655,17 @@ public class ReplacementService(
             return null;
         }
 
+        var replacementFilters = await statisticsDbContext
+            .Filter.AsNoTracking()
+            .Include(f => f.FilterGroups)
+                .ThenInclude(g => g.FilterItems)
+            .Where(f => f.SubjectId == replacementSubjectId)
+            .ToListAsync(cancellationToken);
+
         return ReplacementServiceHelper.ReplaceFilterSequence(
             originalSequence: originalReleaseFile.FilterSequence,
-            mapping: mapping
+            mapping: mapping,
+            replacementFilters
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -18,10 +18,12 @@ public abstract class ReplacementServiceHelper
     {
         // Add mapped replacement filters
         var replacementSequence = new List<FilterSequenceEntry>();
-        var filterIdsWithMapping = mapping
+        var filterMappingsWithReplacement = mapping
             .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
-            .Select(filterMap => filterMap.OriginalId)
-            .ToHashSet();
+            .Select(filterMap => new { filterMap.OriginalId, ReplacementId = filterMap.ReplacementId!.Value })
+            .ToList();
+
+        var filterIdsWithMapping = filterMappingsWithReplacement.Select(filterMap => filterMap.OriginalId).ToHashSet();
         foreach (var filterSequenceEntry in originalSequence)
         {
             if (filterIdsWithMapping.Contains(filterSequenceEntry.Id))
@@ -48,10 +50,7 @@ public abstract class ReplacementServiceHelper
         }
 
         // Add remaining replacement filters - those that are unmapped
-        var claimedFilterIds = mapping
-            .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
-            .Select(filterMap => filterMap.ReplacementId!.Value)
-            .ToHashSet();
+        var claimedFilterIds = filterMappingsWithReplacement.Select(filterMap => filterMap.ReplacementId).ToHashSet();
         replacementSequence.AddRange(
             replacementFilters
                 .Where(replacementFilter => !claimedFilterIds.Contains(replacementFilter.Id))
@@ -82,10 +81,12 @@ public abstract class ReplacementServiceHelper
     {
         // Add mapped replacement groups
         var replacementGroupSequence = new List<FilterGroupSequenceEntry>();
-        var groupIdsWithMapping = filterMapping
+        var groupMappingsWithReplacement = filterMapping
             .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
-            .Select(groupMap => groupMap.OriginalId)
-            .ToHashSet();
+            .Select(groupMap => new { groupMap.OriginalId, ReplacementId = groupMap.ReplacementId!.Value })
+            .ToList();
+
+        var groupIdsWithMapping = groupMappingsWithReplacement.Select(groupMap => groupMap.OriginalId).ToHashSet();
         foreach (var groupSequenceEntry in originalFilterSequenceEntry.FilterGroupSequence)
         {
             if (groupIdsWithMapping.Contains(groupSequenceEntry.Id))
@@ -112,10 +113,7 @@ public abstract class ReplacementServiceHelper
         }
 
         // Add remaining replacement groups - those that are unmapped
-        var claimedGroupIds = filterMapping
-            .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
-            .Select(groupMap => groupMap.ReplacementId!.Value)
-            .ToHashSet();
+        var claimedGroupIds = groupMappingsWithReplacement.Select(groupMap => groupMap.ReplacementId).ToHashSet();
         replacementGroupSequence.AddRange(
             replacementFilterGroups
                 .Where(replacementGroup => !claimedGroupIds.Contains(replacementGroup.Id))
@@ -140,10 +138,12 @@ public abstract class ReplacementServiceHelper
     {
         // Add mapped replacement items
         var replacementItemSequence = new List<Guid>();
-        var itemIdsWithMapping = groupMapping
+        var itemMappingsWithReplacement = groupMapping
             .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
-            .Select(itemMap => itemMap.OriginalId)
-            .ToHashSet();
+            .Select(itemMap => new { itemMap.OriginalId, ReplacementId = itemMap.ReplacementId!.Value })
+            .ToList();
+
+        var itemIdsWithMapping = itemMappingsWithReplacement.Select(itemMap => itemMap.OriginalId).ToHashSet();
 
         foreach (var sequenceItemId in originalGroupSequenceEntry.FilterItemSequence)
         {
@@ -154,10 +154,7 @@ public abstract class ReplacementServiceHelper
         }
 
         // Add remaining replacement items - those that are currently unmapped
-        var claimedItemIds = groupMapping
-            .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
-            .Select(itemMap => itemMap.ReplacementId!.Value)
-            .ToHashSet();
+        var claimedItemIds = itemMappingsWithReplacement.Select(itemMap => itemMap.ReplacementId).ToHashSet();
         replacementItemSequence.AddRange(
             replacementFilterItems
                 .Where(replacementItem => !claimedItemIds.Contains(replacementItem.Id))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -11,10 +12,11 @@ public abstract class ReplacementServiceHelper
 
     public static List<FilterSequenceEntry> ReplaceFilterSequence(
         List<FilterSequenceEntry> originalSequence,
-        DataSetMapping mapping
+        DataSetMapping mapping,
+        List<Filter> replacementFilters
     )
     {
-        // 1. Add mapped replacement filters
+        // Add mapped replacement filters
         var replacementSequence = new List<FilterSequenceEntry>();
         var filterIdsWithMapping = mapping
             .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
@@ -24,8 +26,15 @@ public abstract class ReplacementServiceHelper
         {
             if (filterIdsWithMapping.Contains(filterSequenceEntry.Id))
             {
+                var filterMapping = mapping.FilterMappings[filterSequenceEntry.Id];
+                var replacementFilterGroups = replacementFilters
+                    .Where(f => f.Id == filterMapping.ReplacementId)
+                    .Select(f => f.FilterGroups)
+                    .Single();
+
                 var replacementGroupSequence = GenerateReplacementGroupSequence(
-                    mapping.FilterMappings[filterSequenceEntry.Id],
+                    filterMapping,
+                    replacementFilterGroups,
                     filterSequenceEntry
                 );
 
@@ -38,22 +47,24 @@ public abstract class ReplacementServiceHelper
             }
         }
 
-        // 2. Add unmapped replacement filters
+        // Add remaining replacement filters - those that are unmapped
+        var claimedFilterIds = mapping
+            .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
+            .Select(filterMap => filterMap.ReplacementId!.Value)
+            .ToHashSet();
         replacementSequence.AddRange(
-            mapping
-                .UnmappedReplacementFilters.OrderBy(unmappedFilter => unmappedFilter.Label, LabelComparer)
-                .Select(unmappedFilter => new FilterSequenceEntry(
-                    Id: unmappedFilter.Id,
-                    FilterGroupSequence: unmappedFilter
-                        .UnmappedReplacementFilterGroups.OrderBy(unmappedGroup => unmappedGroup.Label, LabelComparer)
-                        .Select(unmappedGroup => new FilterGroupSequenceEntry(
-                            Id: unmappedGroup.Id,
-                            FilterItemSequence: unmappedGroup
-                                .UnmappedReplacementFilterItems.OrderBy(
-                                    unmappedItem => unmappedItem.Label,
-                                    LabelComparer
-                                )
-                                .Select(unmappedItem => unmappedItem.Id)
+            replacementFilters
+                .Where(replacementFilter => !claimedFilterIds.Contains(replacementFilter.Id))
+                .OrderBy(replacementFilter => replacementFilter.Label, LabelComparer)
+                .Select(replacementFilter => new FilterSequenceEntry(
+                    Id: replacementFilter.Id,
+                    FilterGroupSequence: replacementFilter
+                        .FilterGroups.OrderBy(replacementGroup => replacementGroup.Label, LabelComparer)
+                        .Select(replacementGroup => new FilterGroupSequenceEntry(
+                            Id: replacementGroup.Id,
+                            FilterItemSequence: replacementGroup
+                                .FilterItems.OrderBy(replacementItem => replacementItem.Label, LabelComparer)
+                                .Select(replacementItem => replacementItem.Id)
                                 .ToList()
                         ))
                         .ToList()
@@ -65,9 +76,11 @@ public abstract class ReplacementServiceHelper
 
     private static List<FilterGroupSequenceEntry> GenerateReplacementGroupSequence(
         FilterMapping filterMapping,
+        List<FilterGroup> replacementFilterGroups,
         FilterSequenceEntry originalFilterSequenceEntry
     )
     {
+        // Add mapped replacement groups
         var replacementGroupSequence = new List<FilterGroupSequenceEntry>();
         var groupIdsWithMapping = filterMapping
             .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
@@ -77,8 +90,15 @@ public abstract class ReplacementServiceHelper
         {
             if (groupIdsWithMapping.Contains(groupSequenceEntry.Id))
             {
+                var filterGroupMapping = filterMapping.FilterGroupMappings[groupSequenceEntry.Id];
+                var replacementItems = replacementFilterGroups
+                    .Where(g => g.Id == filterGroupMapping.ReplacementId)
+                    .Select(g => g.FilterItems)
+                    .Single();
+
                 var replacementItemSequence = GenerateReplacementItemSequence(
-                    filterMapping.FilterGroupMappings[groupSequenceEntry.Id],
+                    filterGroupMapping,
+                    replacementItems,
                     groupSequenceEntry
                 );
 
@@ -91,14 +111,20 @@ public abstract class ReplacementServiceHelper
             }
         }
 
+        // Add remaining replacement groups - those that are unmapped
+        var claimedGroupIds = filterMapping
+            .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
+            .Select(groupMap => groupMap.ReplacementId!.Value)
+            .ToHashSet();
         replacementGroupSequence.AddRange(
-            filterMapping
-                .UnmappedReplacementFilterGroups.OrderBy(unmappedGroup => unmappedGroup.Label)
-                .Select(unmappedGroup => new FilterGroupSequenceEntry(
-                    Id: unmappedGroup.Id,
-                    FilterItemSequence: unmappedGroup
-                        .UnmappedReplacementFilterItems.OrderBy(unmappedItem => unmappedItem.Label)
-                        .Select(unmappedItem => unmappedItem.Id)
+            replacementFilterGroups
+                .Where(replacementGroup => !claimedGroupIds.Contains(replacementGroup.Id))
+                .OrderBy(replacementGroup => replacementGroup.Label)
+                .Select(replacementGroup => new FilterGroupSequenceEntry(
+                    Id: replacementGroup.Id,
+                    FilterItemSequence: replacementGroup
+                        .FilterItems.OrderBy(replacementItem => replacementItem.Label)
+                        .Select(replacementItem => replacementItem.Id)
                         .ToList()
                 ))
         );
@@ -108,9 +134,11 @@ public abstract class ReplacementServiceHelper
 
     private static List<Guid> GenerateReplacementItemSequence(
         FilterGroupMapping groupMapping,
+        List<FilterItem> replacementFilterItems,
         FilterGroupSequenceEntry originalGroupSequenceEntry
     )
     {
+        // Add mapped replacement items
         var replacementItemSequence = new List<Guid>();
         var itemIdsWithMapping = groupMapping
             .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
@@ -125,8 +153,15 @@ public abstract class ReplacementServiceHelper
             }
         }
 
+        // Add remaining replacement items - those that are currently unmapped
+        var claimedItemIds = groupMapping
+            .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
+            .Select(itemMap => itemMap.ReplacementId!.Value)
+            .ToHashSet();
         replacementItemSequence.AddRange(
-            groupMapping.UnmappedReplacementFilterItems.Select(unmappedItem => unmappedItem.Id)
+            replacementFilterItems
+                .Where(replacementItem => !claimedItemIds.Contains(replacementItem.Id))
+                .Select(replacementItem => replacementItem.Id)
         );
 
         return replacementItemSequence;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -305,11 +306,11 @@ public record ReplacementPlanMappingViewModel
 
     public ReplacementPlanFilterMappingsViewModel Filters { get; init; } = null!;
 
-    public static ReplacementPlanMappingViewModel FromModel(DataSetMapping mapping)
+    public static ReplacementPlanMappingViewModel FromModel(DataSetMapping mapping, List<Filter> replacementFilters)
     {
         var indicatorMappings = ReplacementPlanIndicatorMappingsViewModel.FromModel(mapping);
         var locationMappings = ReplacementPlanLocationMappingsViewModel.FromModel(mapping);
-        var filterMappings = ReplacementPlanFilterMappingsViewModel.FromModel(mapping);
+        var filterMappings = ReplacementPlanFilterMappingsViewModel.FromModel(mapping, replacementFilters);
 
         return new ReplacementPlanMappingViewModel
         {
@@ -476,9 +477,12 @@ public record ReplacementPlanFilterMappingsViewModel
     // Key is replacement filter id
     public Dictionary<Guid, ReplacementPlanFilterViewModel> Candidates { get; init; } = new();
 
-    public static ReplacementPlanFilterMappingsViewModel FromModel(DataSetMapping mapping)
+    public static ReplacementPlanFilterMappingsViewModel FromModel(
+        DataSetMapping dataSetMapping,
+        List<Filter> replacementFilters
+    )
     {
-        var filterMappings = mapping.FilterMappings.Values.ToDictionary(
+        var filterMappings = dataSetMapping.FilterMappings.Values.ToDictionary(
             filterMap => filterMap.OriginalId,
             filterMap => new ReplacementPlanFilterMappingViewModel
             {
@@ -490,34 +494,26 @@ public record ReplacementPlanFilterMappingsViewModel
                 },
                 CandidateKey = filterMap.ReplacementId,
                 Type = filterMap.Status,
-                FilterGroups = ReplacementPlanFilterGroupMappingsViewModel.FromModel(filterMap),
+                FilterGroups = ReplacementPlanFilterGroupMappingsViewModel.FromModel(
+                    filterMap,
+                    replacementFilters
+                        .Where(f => f.Id == filterMap.ReplacementId)
+                        .Select(f => f.FilterGroups)
+                        .SingleOrDefault()
+                        ?? []
+                ),
             }
         );
-        var filterCandidates = mapping
-            .FilterMappings.Values.Where(filterMap => filterMap.ReplacementId != null)
-            .Select(filterMap => new
+
+        var filterCandidates = replacementFilters.ToDictionary(
+            replacementFilter => replacementFilter.Id,
+            replacementFilter => new ReplacementPlanFilterViewModel
             {
-                Id = filterMap.ReplacementId!.Value,
-                Label = filterMap.ReplacementLabel!,
-                Name = filterMap.ReplacementColumnName!,
-            })
-            .Concat(
-                mapping.UnmappedReplacementFilters.Select(unmappedFilter => new
-                {
-                    unmappedFilter.Id,
-                    unmappedFilter.Label,
-                    Name = unmappedFilter.ColumnName,
-                })
-            )
-            .ToDictionary(
-                x => x.Id,
-                x => new ReplacementPlanFilterViewModel
-                {
-                    Id = x.Id,
-                    Label = x.Label,
-                    Name = x.Name,
-                }
-            );
+                Id = replacementFilter.Id,
+                Label = replacementFilter.Label,
+                Name = replacementFilter.Name,
+            }
+        );
 
         return new ReplacementPlanFilterMappingsViewModel { Mappings = filterMappings, Candidates = filterCandidates };
     }
@@ -550,7 +546,10 @@ public record ReplacementPlanFilterGroupMappingsViewModel
     // Key is replacement filter group id
     public Dictionary<Guid, ReplacementPlanFilterGroupViewModel> Candidates { get; init; } = new();
 
-    public static ReplacementPlanFilterGroupMappingsViewModel FromModel(FilterMapping filterMapping)
+    public static ReplacementPlanFilterGroupMappingsViewModel FromModel(
+        FilterMapping filterMapping,
+        List<FilterGroup> replacementFilterGroups
+    )
     {
         var filterGroupMappings = filterMapping.FilterGroupMappings.Values.ToDictionary(
             groupMap => groupMap.OriginalId,
@@ -563,20 +562,25 @@ public record ReplacementPlanFilterGroupMappingsViewModel
                 },
                 CandidateKey = groupMap.ReplacementId,
                 Type = groupMap.Status,
-                FilterItems = ReplacementPlanFilterItemMappingsViewModel.FromModel(groupMap),
+                FilterItems = ReplacementPlanFilterItemMappingsViewModel.FromModel(
+                    groupMap,
+                    replacementFilterGroups
+                        .Where(group => group.Id == groupMap.ReplacementId)
+                        .Select(g => g.FilterItems)
+                        .SingleOrDefault()
+                        ?? []
+                ),
             }
         );
-        var filterGroupCandidates = filterMapping
-            .FilterGroupMappings.Values.Where(groupMap => groupMap.ReplacementId != null)
-            .Select(groupMap => new { Id = groupMap.ReplacementId!.Value, Label = groupMap.ReplacementLabel! })
-            .Concat(
-                filterMapping.UnmappedReplacementFilterGroups.Select(unmappedGroup => new
-                {
-                    unmappedGroup.Id,
-                    unmappedGroup.Label,
-                })
-            )
-            .ToDictionary(x => x.Id, x => new ReplacementPlanFilterGroupViewModel { Id = x.Id, Label = x.Label });
+
+        var filterGroupCandidates = replacementFilterGroups.ToDictionary(
+            replacementGroup => replacementGroup.Id,
+            replacementGroup => new ReplacementPlanFilterGroupViewModel
+            {
+                Id = replacementGroup.Id,
+                Label = replacementGroup.Label,
+            }
+        );
 
         return new ReplacementPlanFilterGroupMappingsViewModel
         {
@@ -612,7 +616,10 @@ public record ReplacementPlanFilterItemMappingsViewModel
     // Key is replacement filter item id
     public Dictionary<Guid, ReplacementPlanFilterItemViewModel> Candidates { get; init; } = new();
 
-    public static ReplacementPlanFilterItemMappingsViewModel FromModel(FilterGroupMapping groupMapping)
+    public static ReplacementPlanFilterItemMappingsViewModel FromModel(
+        FilterGroupMapping groupMapping,
+        List<FilterItem> replacementFilterItems
+    )
     {
         var itemMappings = groupMapping.FilterItemMappings.Values.ToDictionary(
             itemMap => itemMap.OriginalId,
@@ -627,17 +634,15 @@ public record ReplacementPlanFilterItemMappingsViewModel
                 Type = itemMap.Status,
             }
         );
-        var itemCandidates = groupMapping
-            .FilterItemMappings.Values.Where(itemMap => itemMap.ReplacementId != null)
-            .Select(itemMap => new { Id = itemMap.ReplacementId!.Value, Label = itemMap.ReplacementLabel! })
-            .Concat(
-                groupMapping.UnmappedReplacementFilterItems.Select(unmappedItem => new
-                {
-                    unmappedItem.Id,
-                    unmappedItem.Label,
-                })
-            )
-            .ToDictionary(x => x.Id, x => new ReplacementPlanFilterItemViewModel { Id = x.Id, Label = x.Label });
+
+        var itemCandidates = replacementFilterItems.ToDictionary(
+            replacementItem => replacementItem.Id,
+            replacementItem => new ReplacementPlanFilterItemViewModel
+            {
+                Id = replacementItem.Id,
+                Label = replacementItem.Label,
+            }
+        );
 
         return new ReplacementPlanFilterItemMappingsViewModel { Mappings = itemMappings, Candidates = itemCandidates };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
@@ -35,11 +35,6 @@ public static class DataSetMappingGeneratorExtensions
         Dictionary<Guid, FilterMapping> filterMappings
     ) => generator.ForInstance(m => m.SetFilterMappings(filterMappings));
 
-    public static Generator<DataSetMapping> WithUnmappedReplacementFilters(
-        this Generator<DataSetMapping> generator,
-        List<UnmappedFilter> unmappedFilters
-    ) => generator.ForInstance(m => m.SetUnmappedReplacementFilters(unmappedFilters));
-
     public static Generator<DataSetMapping> WithIndicatorMappings(
         this Generator<DataSetMapping> generator,
         Dictionary<Guid, IndicatorMapping> indicatorMappings
@@ -92,11 +87,6 @@ public static class DataSetMappingGeneratorExtensions
         this InstanceSetters<DataSetMapping> setters,
         Dictionary<Guid, FilterMapping> filterMappings
     ) => setters.Set(m => m.FilterMappings, filterMappings);
-
-    public static InstanceSetters<DataSetMapping> SetUnmappedReplacementFilters(
-        this InstanceSetters<DataSetMapping> setters,
-        List<UnmappedFilter> unmappedFilters
-    ) => setters.Set(m => m.UnmappedReplacementFilters, unmappedFilters);
 
     public static InstanceSetters<DataSetMapping> SetIndicatorMappings(
         this InstanceSetters<DataSetMapping> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -24,7 +24,6 @@ public record DataSetMapping
     public List<UnmappedLocation> UnmappedReplacementLocations { get; init; } = [];
 
     public Dictionary<Guid, FilterMapping> FilterMappings { get; set; } = null!; // EES-7370 Change set -> init
-    public List<UnmappedFilter> UnmappedReplacementFilters { get; set; } = []; // EES-7370 Change set -> init
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -104,16 +103,6 @@ public record DataSetMapping
                     ValueComparer.CreateDefault<Dictionary<Guid, FilterMapping>>(false)
                 )
                 .HasColumnType("nvarchar(max)");
-
-            builder
-                .Property(x => x.UnmappedReplacementFilters)
-                .HasConversion(
-                    unmappedFilters => JsonSerializer.Serialize(unmappedFilters, JsonOptions),
-                    unmappedFiltersString =>
-                        JsonSerializer.Deserialize<List<UnmappedFilter>>(unmappedFiltersString, JsonOptions)
-                        ?? new List<UnmappedFilter>(),
-                    ValueComparer.CreateDefault<List<UnmappedFilter>>(false)
-                );
         }
     }
 }
@@ -175,16 +164,6 @@ public record LocationMapping
     public MapStatus Status { get; set; }
 }
 
-public record UnmappedFilter
-{
-    public Guid Id { get; set; }
-    public string Label { get; set; } = "";
-    public string ColumnName { get; set; } = "";
-
-    // All child groups of an unmapped filter must also be unmapped
-    public List<UnmappedFilterGroup> UnmappedReplacementFilterGroups { get; set; } = [];
-}
-
 public record UnmappedFilterGroup
 {
     public Guid Id { get; set; }
@@ -211,7 +190,9 @@ public record FilterMapping
     public string? ReplacementColumnName { get; set; }
 
     public Dictionary<Guid, FilterGroupMapping> FilterGroupMappings { get; set; } = [];
-    public List<UnmappedFilterGroup> UnmappedReplacementFilterGroups { get; set; } = [];
+
+    // TODO Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
+    public List<UnmappedFilterGroup>? UnmappedReplacementFilterGroups { get; set; } = [];
 
     public MapStatus Status { get; set; }
 }
@@ -225,7 +206,9 @@ public record FilterGroupMapping
     public string? ReplacementLabel { get; set; }
 
     public Dictionary<Guid, FilterItemMapping> FilterItemMappings { get; set; } = [];
-    public List<UnmappedFilterItem> UnmappedReplacementFilterItems { get; set; } = [];
+
+    // TODO Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
+    public List<UnmappedFilterItem>? UnmappedReplacementFilterItems { get; set; } = [];
 
     public MapStatus Status { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -191,7 +191,7 @@ public record FilterMapping
 
     public Dictionary<Guid, FilterGroupMapping> FilterGroupMappings { get; set; } = [];
 
-    // TODO Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
+    // TODO EES-7559 Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
     public List<UnmappedFilterGroup>? UnmappedReplacementFilterGroups { get; set; } = [];
 
     public MapStatus Status { get; set; }
@@ -207,7 +207,7 @@ public record FilterGroupMapping
 
     public Dictionary<Guid, FilterItemMapping> FilterItemMappings { get; set; } = [];
 
-    // TODO Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
+    // TODO EES-7559 Remove - We need to keep this until no preexisting DataSetMapping.FilterMappings entries have this - to ensure json still parses
     public List<UnmappedFilterItem>? UnmappedReplacementFilterItems { get; set; } = [];
 
     public MapStatus Status { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
@@ -208,15 +208,7 @@ public class DataSetMappingServiceTests
                                                     Status = MapStatus.Unset,
                                                 }
                                             },
-                                        },
-                                        unmappedReplacementFilterItems:
-                                        [
-                                            new UnmappedFilterItem
-                                            {
-                                                Id = replacementFilterItem1A2.Id,
-                                                Label = replacementFilterItem1A2.Label,
-                                            },
-                                        ]
+                                        }
                                     )
                                 },
                                 {
@@ -238,23 +230,7 @@ public class DataSetMappingServiceTests
                                         }
                                     )
                                 },
-                            },
-                            unmappedReplacementFilterGroups:
-                            [
-                                new UnmappedFilterGroup
-                                {
-                                    Id = replacementFilterGroup1B.Id,
-                                    Label = replacementFilterGroup1B.Label,
-                                    UnmappedReplacementFilterItems =
-                                    [
-                                        new UnmappedFilterItem
-                                        {
-                                            Id = replacementFilterItem1B1.Id,
-                                            Label = replacementFilterItem1B1.Label,
-                                        },
-                                    ],
-                                },
-                            ]
+                            }
                         )
                     },
                     {
@@ -287,31 +263,6 @@ public class DataSetMappingServiceTests
                         )
                     },
                 },
-                UnmappedReplacementFilters =
-                [
-                    new UnmappedFilter
-                    {
-                        Id = replacementFilter2.Id,
-                        ColumnName = replacementFilter2.Name,
-                        Label = replacementFilter2.Label,
-                        UnmappedReplacementFilterGroups =
-                        [
-                            new UnmappedFilterGroup
-                            {
-                                Id = replacementFilterGroup2A.Id,
-                                Label = replacementFilterGroup2A.Label,
-                                UnmappedReplacementFilterItems =
-                                [
-                                    new UnmappedFilterItem
-                                    {
-                                        Id = replacementFilterItem2A1.Id,
-                                        Label = replacementFilterItem2A1.Label,
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                ],
             };
             result.AssertDeepEqualTo(expectedMapping, ignoreProperties: [mapping => mapping.Id]);
         }
@@ -738,7 +689,6 @@ public class DataSetMappingServiceTests
         Filter original,
         Filter? replacement = null,
         Dictionary<Guid, FilterGroupMapping>? filterGroupMappings = null,
-        List<UnmappedFilterGroup>? unmappedReplacementFilterGroups = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -751,7 +701,6 @@ public class DataSetMappingServiceTests
             ReplacementColumnName = replacement?.Name,
             ReplacementLabel = replacement?.Label,
             FilterGroupMappings = filterGroupMappings ?? [],
-            UnmappedReplacementFilterGroups = unmappedReplacementFilterGroups ?? [],
             Status = status,
         };
     }
@@ -760,7 +709,6 @@ public class DataSetMappingServiceTests
         FilterGroup original,
         FilterGroup? replacement = null,
         Dictionary<Guid, FilterItemMapping>? filterItemMappings = null,
-        List<UnmappedFilterItem>? unmappedReplacementFilterItems = null,
         MapStatus status = MapStatus.Unset
     )
     {
@@ -771,7 +719,6 @@ public class DataSetMappingServiceTests
             ReplacementId = replacement?.Id,
             ReplacementLabel = replacement?.Label,
             FilterItemMappings = filterItemMappings ?? [],
-            UnmappedReplacementFilterItems = unmappedReplacementFilterItems ?? [],
             Status = status,
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -41,7 +41,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             replacementFile.SubjectId!.Value
         );
 
-        var (filterMappings, unmappedReplacementFilters) = await GenerateInitialFilterMapping(
+        var filterMappings = await GenerateInitialFilterMapping(
             statisticsDbContext,
             originalFile.SubjectId!.Value,
             replacementFile.SubjectId!.Value
@@ -56,7 +56,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             LocationMappings = locationMappings,
             UnmappedReplacementLocations = unmappedReplacementLocations,
             FilterMappings = filterMappings,
-            UnmappedReplacementFilters = unmappedReplacementFilters,
         };
 
         contentDbContext.DataSetMappings.Add(newMapping);
@@ -207,7 +206,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         return (locationMappings, unmappedReplacementLocations);
     }
 
-    private static async Task<(Dictionary<Guid, FilterMapping>, List<UnmappedFilter>)> GenerateInitialFilterMapping(
+    private static async Task<Dictionary<Guid, FilterMapping>> GenerateInitialFilterMapping(
         StatisticsDbContext statisticsDbContext,
         Guid originalSubjectId,
         Guid replacementSubjectId
@@ -224,7 +223,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
 
         var replacementFilters = filters.Where(f => f.SubjectId == replacementSubjectId).ToList();
 
-        // Create dictionaries to speed up performance when creating filterMappings/unmappedReplacementFilters
+        // Create dictionaries to speed up performance when matching originals to replacements
         var replacementFiltersMap = replacementFilters.ToDictionary(f => f.Name, f => f); // automap filters by column name
 
         var replacementFilterIdToGroupLabelToGroupMap = replacementFilters
@@ -238,7 +237,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             .GroupBy(x => x.FilterGroupId)
             .ToDictionary(x => x.Key, x => x.ToDictionary(g => g.FilterItem.Label, g => g.FilterItem)); // automap items by label
 
-        // Now we created FilterMappings
+        // Now we create FilterMappings
         var filterMappings = new Dictionary<Guid, FilterMapping>();
         foreach (var originalFilter in originalFilters)
         {
@@ -249,7 +248,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
                     ? replacementFilterIdToGroupLabelToGroupMap.GetValueOrDefault(replacementFilter.Id)
                     : null;
 
-            var (filterGroupMappings, unmappedReplacementGroups) = GenerateInitialFilterGroupMapping(
+            var filterGroupMappings = GenerateInitialFilterGroupMapping(
                 originalFilter.FilterGroups,
                 replacementGroupLabelToGroupMap,
                 replacementGroupIdToItemLabelToItemMap
@@ -266,7 +265,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
                 ReplacementLabel = replacementFilter?.Label,
 
                 FilterGroupMappings = filterGroupMappings,
-                UnmappedReplacementFilterGroups = unmappedReplacementGroups,
 
                 Status = replacementFilter == null ? MapStatus.Unset : MapStatus.AutoSet,
             };
@@ -274,36 +272,10 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             filterMappings.Add(filterMapping.OriginalId, filterMapping);
         }
 
-        // Now we create UnmappedReplacementFilters
-        var mappedReplacementFilterIds = filterMappings
-            .Values.Where(m => m.ReplacementId.HasValue)
-            .Select(m => m.ReplacementId!.Value);
-
-        var unmappedReplacementFilters = replacementFiltersMap
-            .Values.ExceptBy(mappedReplacementFilterIds, filter => filter.Id)
-            .Select(filter => new UnmappedFilter
-            {
-                Id = filter.Id,
-                Label = filter.Label,
-                ColumnName = filter.Name,
-
-                UnmappedReplacementFilterGroups = filter
-                    .FilterGroups.Select(group => new UnmappedFilterGroup
-                    {
-                        Id = group.Id,
-                        Label = group.Label,
-                        UnmappedReplacementFilterItems = group
-                            .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                            .ToList(),
-                    })
-                    .ToList(),
-            })
-            .ToList();
-
-        return (filterMappings, unmappedReplacementFilters);
+        return filterMappings;
     }
 
-    private static (Dictionary<Guid, FilterGroupMapping>, List<UnmappedFilterGroup>) GenerateInitialFilterGroupMapping(
+    private static Dictionary<Guid, FilterGroupMapping> GenerateInitialFilterGroupMapping(
         List<FilterGroup> originalFilterGroups,
         Dictionary<string, FilterGroup>? replacementGroupLabelToGroupMap,
         Dictionary<Guid, Dictionary<string, FilterItem>> replacementGroupIdToItemLabelToItemMap
@@ -320,7 +292,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
                 replacementFilterGroup != null
                     ? replacementGroupIdToItemLabelToItemMap.GetValueOrDefault(replacementFilterGroup.Id)
                     : null;
-            var (filterItemMappings, unmappedReplacementItems) = GenerateInitialFilterItemMapping(
+            var filterItemMappings = GenerateInitialFilterItemMapping(
                 originalFilterGroup.FilterItems,
                 replacementItemLabelToItemMap
             );
@@ -334,7 +306,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
                 ReplacementLabel = replacementFilterGroup?.Label,
 
                 FilterItemMappings = filterItemMappings,
-                UnmappedReplacementFilterItems = unmappedReplacementItems,
 
                 Status =
                     replacementGroupLabelToGroupMap == null
@@ -345,34 +316,10 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             filterGroupMappings.Add(filterGroupMapping.OriginalId, filterGroupMapping);
         }
 
-        // if parent is unmapped, we don't know what the replacement groups will be, so return empty unmapped list
-        // if parent is mapped, we can figure out which replacement groups for this filter are unmapped
-        var unmappedReplacementGroups = new List<UnmappedFilterGroup>();
-        if (replacementGroupLabelToGroupMap != null)
-        {
-            // parent filter is mapped
-            var mappedReplacementGroupIds = filterGroupMappings
-                .Values.Where(m => m.ReplacementId.HasValue)
-                .Select(m => m.ReplacementId!.Value);
-
-            unmappedReplacementGroups = replacementGroupLabelToGroupMap
-                .Values.ExceptBy(mappedReplacementGroupIds, group => group.Id)
-                .Select(group => new UnmappedFilterGroup
-                {
-                    Id = group.Id,
-                    Label = group.Label,
-
-                    UnmappedReplacementFilterItems = group
-                        .FilterItems.Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                        .ToList(),
-                })
-                .ToList();
-        }
-
-        return (filterGroupMappings, unmappedReplacementGroups);
+        return filterGroupMappings;
     }
 
-    private static (Dictionary<Guid, FilterItemMapping>, List<UnmappedFilterItem>) GenerateInitialFilterItemMapping(
+    private static Dictionary<Guid, FilterItemMapping> GenerateInitialFilterItemMapping(
         List<FilterItem> originalFilterItems,
         Dictionary<string, FilterItem>? replacementItemLabelToItemMap
     )
@@ -401,22 +348,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             filterItemMappings.Add(filterItemMapping.OriginalId, filterItemMapping);
         }
 
-        // if parent is unmapped, we don't know what the replacement items will be, so return empty unmapped list
-        // if parent is mapped, we can figure out which replacement items for this group are unmapped
-        var unmappedReplacementItems = new List<UnmappedFilterItem>();
-        if (replacementItemLabelToItemMap != null)
-        {
-            // parent is mapped
-            var mappedReplacementItemIds = filterItemMappings
-                .Values.Where(m => m.ReplacementId.HasValue)
-                .Select(m => m.ReplacementId!.Value);
-
-            unmappedReplacementItems = replacementItemLabelToItemMap
-                .Values.ExceptBy(mappedReplacementItemIds, item => item.Id)
-                .Select(item => new UnmappedFilterItem { Id = item.Id, Label = item.Label })
-                .ToList();
-        }
-
-        return (filterItemMappings, unmappedReplacementItems);
+        return filterItemMappings;
     }
 }


### PR DESCRIPTION
This PR simplifies the new filter mapping code by removing DataSetMapping.UnmappedReplacementFilters. This mean we don't have to manage a list of unmapped filters/groups/items anymore - if you need to know whether a filter is unmapped, we just calculate it in-place.

This work was born out of discussions with Jack on EES-7281. I had realised the possibilities for simplifying the work, but considered it too much work to be worth actually going through with, but Jack then used the AI to give us a good sense of what it could look like, at which we were both on board for doing this work.

There are a couple of fields without DataSetMapping.FilterMappings (UnmappedReplacementFilterGroups/Items) that have just been made nullable. This is because when this work is deployed, even though these will no longer be used, they might still exist in a DataSetMapping.FilterMappings JSON. So this is to ensure that JSON can still be parsed and those replacements aren't broken. Once no DataSetMappings use these columns, they can be remove outright - I'll create a separate ticket to do this.



