### PR TITLE
EES-7546 Remove UnmappedReplacementIndicators

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -30,8 +30,12 @@ public class DataSetMappingServiceTests
         var originalIndicator3Id = Guid.NewGuid();
         var originalIndicator4Id = Guid.NewGuid();
 
+        var replacementIndicator1Id = Guid.NewGuid();
+        var replacementIndicator2Id = Guid.NewGuid();
+        var replacementIndicator3Id = Guid.NewGuid();
         var replacementIndicator4Id = Guid.NewGuid();
         var replacementIndicator5Id = Guid.NewGuid();
+        var replacementIndicator6Id = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -77,7 +81,7 @@ public class DataSetMappingServiceTests
                         OriginalColumnName = "original_indicator_2",
                         OriginalGroupId = Guid.NewGuid(),
                         OriginalGroupLabel = "Original indicator 2 group label",
-                        ReplacementId = Guid.NewGuid(),
+                        ReplacementId = replacementIndicator1Id,
                         ReplacementLabel = "Replacement indicator 1 - that will be unset",
                         ReplacementColumnName = "replacement_indicator_1",
                         ReplacementGroupId = Guid.NewGuid(),
@@ -94,7 +98,7 @@ public class DataSetMappingServiceTests
                         OriginalColumnName = "original_indicator_3",
                         OriginalGroupId = Guid.NewGuid(),
                         OriginalGroupLabel = "Original indicator 3 group label",
-                        ReplacementId = Guid.NewGuid(),
+                        ReplacementId = replacementIndicator2Id,
                         ReplacementLabel = "Replacement indicator 2 - that will be unset",
                         ReplacementColumnName = "replacement_indicator_2",
                         ReplacementGroupId = Guid.NewGuid(),
@@ -111,7 +115,7 @@ public class DataSetMappingServiceTests
                         OriginalColumnName = "original_indicator_4",
                         OriginalGroupId = Guid.NewGuid(),
                         OriginalGroupLabel = "Original indicator 4 group label",
-                        ReplacementId = Guid.NewGuid(),
+                        ReplacementId = replacementIndicator3Id,
                         ReplacementLabel = "Replacement indicator 3 - that will remain",
                         ReplacementColumnName = "replacement_indicator_3",
                         ReplacementGroupId = Guid.NewGuid(),
@@ -120,36 +124,57 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementIndicators =
+        };
+
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Replacement indicator group label",
+            SubjectId = replacementSubjectId,
+            Indicators =
             [
-                new UnmappedIndicator
+                new Indicator
+                {
+                    Id = replacementIndicator1Id,
+                    Label = "Replacement indicator 1 - that will be unset",
+                    Name = "replacement_indicator_1",
+                },
+                new Indicator
+                {
+                    Id = replacementIndicator2Id,
+                    Label = "Replacement indicator 2 - that will be unset",
+                    Name = "replacement_indicator_2",
+                },
+                new Indicator
+                {
+                    Id = replacementIndicator3Id,
+                    Label = "Replacement indicator 3 - that will remain",
+                    Name = "replacement_indicator_3",
+                },
+                new Indicator
                 {
                     Id = replacementIndicator4Id,
                     Label = "Replacement indicator 4 - that will be mapped to Original indicator 1",
-                    ColumnName = "replacement_indicator_4",
-                    GroupId = Guid.NewGuid(),
-                    GroupLabel = "Replacement indicator 4 group label",
+                    Name = "replacement_indicator_4",
                 },
-                new UnmappedIndicator
+                new Indicator
                 {
                     Id = replacementIndicator5Id,
                     Label = "Replacement indicator 5 - that will be mapped to Original indicator 2",
-                    ColumnName = "replacement_indicator_5",
-                    GroupId = Guid.NewGuid(),
-                    GroupLabel = "Replacement indicator 5 group label",
+                    Name = "replacement_indicator_5",
                 },
-                new UnmappedIndicator
+                new Indicator
                 {
-                    Id = Guid.NewGuid(),
-                    Label = "Replacement indicator 6 - that will be remain unmapped",
-                    ColumnName = "replacement_indicator_6",
-                    GroupId = Guid.NewGuid(),
-                    GroupLabel = "Replacement indicator 6 group label",
+                    Id = replacementIndicator6Id,
+                    Label = "Replacement indicator 6 - that will remain unmapped",
+                    Name = "replacement_indicator_6",
                 },
             ],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
             contentDbContext.ReleaseVersions.Add(releaseVersion);
@@ -158,9 +183,16 @@ public class DataSetMappingServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            statisticsDbContext.IndicatorGroup.Add(replacementIndicatorGroup);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateIndicatorMappings(
                 releaseVersion.Id,
@@ -235,22 +267,34 @@ public class DataSetMappingServiceTests
                 () => Assert.Equal("replacement_indicator_3", originalIndicator4Mapping.ReplacementColumnName),
                 () => Assert.Equal(MapStatus.AutoSet, originalIndicator4Mapping.Status)
             );
+        }
 
-            var unmappedReplacementIndicators = dbMapping.UnmappedReplacementIndicators.ToList();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                releaseVersion.Id,
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    Updates = [new() { OriginalId = originalIndicator3Id, NewReplacementId = replacementIndicator1Id }],
+                },
+                CancellationToken.None
+            );
+
+            var indicatorMappingList = result.AssertRight();
+
+            var originalIndicator3Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_3"
+            );
+
             Assert.Multiple(
-                () => Assert.Equal(3, unmappedReplacementIndicators.Count),
-                () =>
-                    Assert.NotNull(
-                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_1")
-                    ),
-                () =>
-                    Assert.NotNull(
-                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_2")
-                    ),
-                () =>
-                    Assert.NotNull(
-                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_6")
-                    )
+                () => Assert.Equal(replacementIndicator1Id, originalIndicator3Mapping.ReplacementId),
+                () => Assert.Equal("replacement_indicator_1", originalIndicator3Mapping.ReplacementColumnName),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator3Mapping.Status)
             );
         }
     }
@@ -300,7 +344,6 @@ public class DataSetMappingServiceTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>(),
-            UnmappedReplacementIndicators = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -467,7 +510,6 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementIndicators = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -551,7 +593,6 @@ public class DataSetMappingServiceTests
                     }
                 },
             },
-            UnmappedReplacementIndicators = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -581,6 +622,124 @@ public class DataSetMappingServiceTests
                             NewReplacementId = replacementIndicatorAlreadyMappedId,
                         },
                     ],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasError(
+                expectedPath: "Updates.NewReplacementId",
+                expectedCode: "UnmappedIndicatorMatchingReplacementIdNotFound"
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateIndicatorMapping_ReplacementIndicatorClaimedByAnotherMapping_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
+
+        var originalIndicator1Id = Guid.NewGuid();
+        var originalIndicator2Id = Guid.NewGuid();
+
+        var replacementIndicatorId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
+            {
+                {
+                    originalIndicator1Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator1Id,
+                        OriginalColumnName = "original_indicator_1",
+                        ReplacementId = replacementIndicatorId,
+                        ReplacementColumnName = "replacement_indicator",
+                        Status = MapStatus.AutoSet,
+                    }
+                },
+                {
+                    originalIndicator2Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator2Id,
+                        OriginalColumnName = "original_indicator_2",
+                        Status = MapStatus.Unset,
+                    }
+                },
+            },
+        };
+
+        var replacementIndicatorGroup = new IndicatorGroup
+        {
+            Id = Guid.NewGuid(),
+            Label = "Replacement indicator group label",
+            SubjectId = replacementSubjectId,
+            Indicators =
+            [
+                new Indicator
+                {
+                    Id = replacementIndicatorId,
+                    Label = "Replacement indicator",
+                    Name = "replacement_indicator",
+                },
+            ],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.IndicatorGroup.Add(replacementIndicatorGroup);
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                releaseVersion.Id,
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    Updates = [new() { OriginalId = originalIndicator2Id, NewReplacementId = replacementIndicatorId }],
                 },
                 CancellationToken.None
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -422,16 +422,6 @@ public class ReplacementPlanServiceTests
                     { originalIndicator.Id, CreateIndicatorMapping(originalIndicator, originalIndicatorGroup) },
                 }
             )
-            .WithUnmappedReplacementIndicators([
-                new UnmappedIndicator
-                {
-                    Id = replacementIndicator.Id,
-                    ColumnName = replacementIndicator.Name,
-                    Label = replacementIndicator.Label,
-                    GroupId = replacementIndicatorGroup.Id,
-                    GroupLabel = replacementIndicatorGroup.Label,
-                },
-            ])
             .WithLocationMappings(
                 new Dictionary<Guid, LocationMapping>
                 {
@@ -2708,16 +2698,6 @@ public class ReplacementPlanServiceTests
                     },
                 }
             )
-            .WithUnmappedReplacementIndicators([
-                new UnmappedIndicator
-                {
-                    Id = replacementNewIndicator.Id,
-                    Label = replacementNewIndicator.Label,
-                    ColumnName = replacementNewIndicator.Name,
-                    GroupId = replacementIndicatorGroup.Id,
-                    GroupLabel = replacementIndicatorGroup.Label,
-                },
-            ])
             .WithLocationMappings(
                 new Dictionary<Guid, LocationMapping>
                 {
@@ -3002,16 +2982,6 @@ public class ReplacementPlanServiceTests
                     },
                 }
             )
-            .WithUnmappedReplacementIndicators([
-                new UnmappedIndicator
-                {
-                    Id = replacementIndicatorAUpdated.Id,
-                    Label = replacementIndicatorAUpdated.Label,
-                    ColumnName = replacementIndicatorAUpdated.Name,
-                    GroupId = replacementIndicatorGroup.Id,
-                    GroupLabel = replacementIndicatorGroup.Label,
-                },
-            ])
             .WithLocationMappings(
                 new Dictionary<Guid, LocationMapping>
                 {
@@ -3300,7 +3270,6 @@ public class ReplacementPlanServiceTests
                     },
                 }
             )
-            .WithUnmappedReplacementIndicators([])
             .WithLocationMappings(
                 new Dictionary<Guid, LocationMapping>
                 {
@@ -3650,7 +3619,6 @@ public class ReplacementPlanServiceTests
                     },
                 }
             )
-            .WithUnmappedReplacementIndicators([])
             .WithLocationMappings(
                 new Dictionary<Guid, LocationMapping>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -532,7 +532,8 @@ public class ReplacementServiceHelperTests
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
             replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
-            originalReleaseFile.IndicatorSequence
+            originalReleaseFile.IndicatorSequence,
+            replacementGroups
         );
 
         // Verify the updated sequence of indicators
@@ -744,7 +745,8 @@ public class ReplacementServiceHelperTests
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
             replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
-            originalReleaseFile.IndicatorSequence
+            originalReleaseFile.IndicatorSequence,
+            replacementGroups
         );
 
         // Verify the updated sequence of indicators
@@ -908,7 +910,8 @@ public class ReplacementServiceHelperTests
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
             replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
-            originalReleaseFile.IndicatorSequence
+            originalReleaseFile.IndicatorSequence,
+            replacementGroups
         );
 
         // Verify the updated sequence of indicators
@@ -1014,7 +1017,8 @@ public class ReplacementServiceHelperTests
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
             replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
-            originalReleaseFile.IndicatorSequence
+            originalReleaseFile.IndicatorSequence,
+            replacementGroups
         );
 
         Assert.NotNull(updatedSequence);
@@ -1148,14 +1152,14 @@ public class ReplacementServiceHelperTests
                     }
                 },
             },
-            UnmappedReplacementIndicators = [],
         };
 
         var updatedSequence = ReplacementServiceHelper.ReplaceIndicatorSequence(
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroups.ToDictionary(g => g.Id, g => g.Label),
             replacementGroupLabelToIdMap: replacementGroups.ToDictionary(g => g.Label, g => g.Id),
-            originalReleaseFile.IndicatorSequence
+            originalReleaseFile.IndicatorSequence,
+            replacementGroups
         );
 
         Assert.NotNull(updatedSequence);
@@ -1181,7 +1185,6 @@ public class ReplacementServiceHelperTests
     )
     {
         Dictionary<Guid, IndicatorMapping> indicatorsMappings = new();
-        List<UnmappedIndicator> unmappedReplacementIndicators = [];
         if (originalIndicatorGroups != null && replacementIndicatorGroups != null)
         {
             // emulates automapping that occurs from indicator groups when a mapping is initially generated
@@ -1211,21 +1214,6 @@ public class ReplacementServiceHelperTests
                         };
                     }
                 );
-            unmappedReplacementIndicators = replacementIndicatorGroups
-                .SelectMany(group => group.Indicators, (group, indicator) => new { group, indicator })
-                .ExceptBy(
-                    indicatorsMappings.Values.Select(mapping => mapping.ReplacementId),
-                    unmappedPair => unmappedPair.indicator.Id
-                )
-                .Select(pair => new UnmappedIndicator
-                {
-                    Id = pair.indicator.Id,
-                    Label = pair.indicator.Label,
-                    ColumnName = pair.indicator.Name,
-                    GroupId = pair.group.Id,
-                    GroupLabel = pair.group.Label,
-                })
-                .ToList();
         }
 
         return new DataSetMapping
@@ -1233,7 +1221,6 @@ public class ReplacementServiceHelperTests
             OriginalDataFileId = originalDataFileId,
             ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = indicatorsMappings,
-            UnmappedReplacementIndicators = unmappedReplacementIndicators,
         };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820095538_Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820095538_Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820095538_Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping")]
+    partial class Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820095538_Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820095538_Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7546RemoveUnmappedReplacementIndicatorsFromDataSetMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "UnmappedReplacementIndicators", table: "DataSetMappings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UnmappedReplacementIndicators",
+                table: "DataSetMappings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: ""
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -160,13 +160,28 @@ public class DataSetMappingService(
             )
             .OnSuccess(async validated =>
             {
-                var mapping = validated.Mapping;
+                var (mapping, replacementReleaseFile) = validated;
+
+                var replacementIndicators = await statisticsDbContext
+                    .Indicator.AsNoTracking()
+                    .Include(i => i.IndicatorGroup)
+                    .Where(i => i.IndicatorGroup.SubjectId == replacementReleaseFile.File.SubjectId!.Value)
+                    .ToListAsync(cancellationToken);
 
                 var updatedMappings = request
                     .Updates.Select(update =>
-                        UpdateIndicatorMapping(mapping, update.OriginalId, update.NewReplacementId)
+                        mapping.UpdateIndicatorMapping(
+                            replacementIndicators,
+                            update.OriginalId,
+                            update.NewReplacementId
+                        )
                     )
                     .ToList(); // cannot be async!
+
+                // The mutations above happen on the in-memory object graph beneath IndicatorMappings. EF can't see
+                // through the JSON column conversion on that property, so we must mark it dirty explicitly for the
+                // changes to be persisted.
+                contentDbContext.Entry(mapping).Property(x => x.IndicatorMappings).IsModified = true;
 
                 // we still save changes from the Updates that succeeded, even if some failed
                 await contentDbContext.SaveChangesAsync(cancellationToken);
@@ -175,83 +190,6 @@ public class DataSetMappingService(
                     .OnSuccessAll()
                     .OnSuccess(_ => mapping.IndicatorMappings.Values.Select(IndicatorMappingDto.FromModel).ToList());
             });
-    }
-
-    private Either<ActionResult, IndicatorMapping> UpdateIndicatorMapping(
-        DataSetMapping dataSetMapping,
-        Guid originalId,
-        Guid? newReplacementId = null
-    )
-    {
-        if (!dataSetMapping.IndicatorMappings.TryGetValue(originalId, out var indicatorMapping))
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "IndicatorMatchingOriginalIdNotFound",
-                    Message = $"Could not find indicator mapping matching original id \"{originalId}\"",
-                }
-            );
-        }
-
-        if (indicatorMapping.ReplacementId == newReplacementId && indicatorMapping.Status == MapStatus.ManuallySet)
-        {
-            return indicatorMapping; // it is already mapped, so can skip
-        }
-
-        var availableUnmappedIndicator = dataSetMapping.UnmappedReplacementIndicators.SingleOrDefault(
-            unmappedIndicator => unmappedIndicator.Id == newReplacementId
-        );
-
-        if (newReplacementId != null && availableUnmappedIndicator == null)
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedIndicatorMatchingReplacementIdNotFound",
-                    Message =
-                        $"No available unmapped indicator matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
-                }
-            );
-        }
-
-        if (availableUnmappedIndicator != null)
-        {
-            // remove availableUnmappedIndicator from UnmappedReplacementIndicators as it's about to become mapped
-            dataSetMapping.UnmappedReplacementIndicators.Remove(availableUnmappedIndicator);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementIndicators).IsModified = true;
-        }
-
-        if (indicatorMapping.ReplacementId != null && indicatorMapping.ReplacementId != newReplacementId)
-        {
-            // We need to move the preexisting mapped indicator into UnmappedReplacementIndicators, as it will be overwritten
-            var newlyUnmappedIndicator = new UnmappedIndicator
-            {
-                Id = indicatorMapping.ReplacementId.Value,
-                ColumnName = indicatorMapping.ReplacementColumnName!,
-                Label = indicatorMapping.ReplacementLabel!,
-                GroupId = indicatorMapping.ReplacementGroupId!.Value,
-                GroupLabel = indicatorMapping.ReplacementGroupLabel!,
-            };
-            dataSetMapping.UnmappedReplacementIndicators.Add(newlyUnmappedIndicator);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementIndicators).IsModified = true;
-        }
-
-        // mapping.Original* properties should never change
-        indicatorMapping.ReplacementId = availableUnmappedIndicator?.Id;
-        indicatorMapping.ReplacementColumnName = availableUnmappedIndicator?.ColumnName;
-        indicatorMapping.ReplacementLabel = availableUnmappedIndicator?.Label;
-        indicatorMapping.ReplacementGroupId = availableUnmappedIndicator?.GroupId;
-        indicatorMapping.ReplacementGroupLabel = availableUnmappedIndicator?.GroupLabel;
-        indicatorMapping.Status = MapStatus.ManuallySet;
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.IndicatorMappings).IsModified = true;
-
-        return indicatorMapping;
     }
 
     public async Task<Either<ActionResult, List<LocationMappingDto>>> UpdateLocationMappings(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IndicatorMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IndicatorMappingExtensions.cs
@@ -13,7 +13,7 @@ internal static class IndicatorMappingExtensions
 {
     public static Either<ActionResult, IndicatorMapping> UpdateIndicatorMapping(
         this DataSetMapping dataSetMapping,
-        List<Indicator> replacementIndicators,
+        IReadOnlyList<Indicator> replacementIndicators,
         Guid originalId,
         Guid? newReplacementId = null
     )
@@ -77,7 +77,7 @@ internal static class IndicatorMappingExtensions
     private static bool IsIndicatorCandidateAvailable(
         DataSetMapping dataSetMapping,
         IndicatorMapping indicatorMapping,
-        List<Indicator> replacementIndicators,
+        IReadOnlyList<Indicator> replacementIndicators,
         Guid candidateId
     )
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IndicatorMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IndicatorMappingExtensions.cs
@@ -1,0 +1,92 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+internal static class IndicatorMappingExtensions
+{
+    public static Either<ActionResult, IndicatorMapping> UpdateIndicatorMapping(
+        this DataSetMapping dataSetMapping,
+        List<Indicator> replacementIndicators,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        if (!dataSetMapping.IndicatorMappings.TryGetValue(originalId, out var indicatorMapping))
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "IndicatorMatchingOriginalIdNotFound",
+                    Message = $"Could not find indicator mapping matching original id \"{originalId}\"",
+                }
+            );
+        }
+
+        if (indicatorMapping.ReplacementId == newReplacementId && indicatorMapping.Status == MapStatus.ManuallySet)
+        {
+            return indicatorMapping; // it is already mapped, so can skip
+        }
+
+        if (
+            newReplacementId != null
+            && !IsIndicatorCandidateAvailable(
+                dataSetMapping,
+                indicatorMapping,
+                replacementIndicators,
+                newReplacementId.Value
+            )
+        )
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedIndicatorMatchingReplacementIdNotFound",
+                    Message =
+                        $"No available unmapped indicator matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        var replacement =
+            newReplacementId == null
+                ? null
+                : replacementIndicators.Single(indicator => indicator.Id == newReplacementId);
+
+        // mapping.Original* properties should never change
+        indicatorMapping.ReplacementId = replacement?.Id;
+        indicatorMapping.ReplacementColumnName = replacement?.Name;
+        indicatorMapping.ReplacementLabel = replacement?.Label;
+        indicatorMapping.ReplacementGroupId = replacement?.IndicatorGroupId;
+        indicatorMapping.ReplacementGroupLabel = replacement?.IndicatorGroup.Label;
+        indicatorMapping.Status = MapStatus.ManuallySet;
+
+        return indicatorMapping;
+    }
+
+    private static bool IsIndicatorCandidateAvailable(
+        DataSetMapping dataSetMapping,
+        IndicatorMapping indicatorMapping,
+        List<Indicator> replacementIndicators,
+        Guid candidateId
+    )
+    {
+        var candidateExists = replacementIndicators.Any(candidate => candidate.Id == candidateId);
+
+        var alreadyClaimed = dataSetMapping.IndicatorMappings.Values.Any(other =>
+            other.OriginalId != indicatorMapping.OriginalId && other.ReplacementId == candidateId
+        );
+
+        return candidateExists && !alreadyClaimed;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -152,7 +152,17 @@ public class ReplacementPlanService(
                     .Where(f => f.SubjectId == replacementSubjectId)
                     .ToListAsync(cancellationToken);
 
-                var mappingPlan = ReplacementPlanMappingViewModel.FromModel(mapping, replacementFilters);
+                var replacementIndicators = await statisticsDbContext
+                    .Indicator.AsNoTracking()
+                    .Include(i => i.IndicatorGroup)
+                    .Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
+                    .ToListAsync(cancellationToken);
+
+                var mappingPlan = ReplacementPlanMappingViewModel.FromModel(
+                    mapping,
+                    replacementFilters,
+                    replacementIndicators
+                );
 
                 return new DataReplacementPlanViewModel
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -124,7 +124,12 @@ public class ReplacementService(
                     mapping,
                     cancellationToken
                 );
-                replacementReleaseFile.IndicatorSequence = ReplaceIndicatorSequence(originalReleaseFile, mapping);
+                replacementReleaseFile.IndicatorSequence = await ReplaceIndicatorSequence(
+                    originalReleaseFile,
+                    replacementSubjectId,
+                    mapping,
+                    cancellationToken
+                );
                 replacementReleaseFile.Summary = originalReleaseFile.Summary; // Set Data guidance
 
                 // To remove original, we first unlink the files. If we don't do this,
@@ -669,9 +674,11 @@ public class ReplacementService(
         );
     }
 
-    private static List<IndicatorGroupSequenceEntry>? ReplaceIndicatorSequence(
+    private async Task<List<IndicatorGroupSequenceEntry>?> ReplaceIndicatorSequence(
         ReleaseFile originalReleaseFile,
-        DataSetMapping mapping
+        Guid replacementSubjectId,
+        DataSetMapping mapping,
+        CancellationToken cancellationToken
     )
     {
         // If the sequence is null then leave it so we continue to fallback to ordering by label alphabetically
@@ -680,23 +687,25 @@ public class ReplacementService(
             return null;
         }
 
+        var replacementIndicatorGroups = await statisticsDbContext
+            .IndicatorGroup.AsNoTracking()
+            .Include(ig => ig.Indicators)
+            .Where(ig => ig.SubjectId == replacementSubjectId)
+            .ToListAsync(cancellationToken);
+
         var originalGroupIdToLabelMap = mapping
             .IndicatorMappings.Values.Select(i => new { Id = i.OriginalGroupId, Label = i.OriginalGroupLabel })
             .Distinct()
             .ToDictionary(ig => ig.Id, ig => ig.Label);
 
-        var replacementGroupLabelToIdMap = mapping
-            .IndicatorMappings.Values.Where(indMap => indMap.ReplacementId != null)
-            .Select(indMap => new { Id = indMap.ReplacementGroupId!.Value, Label = indMap.ReplacementGroupLabel! })
-            .Concat(mapping.UnmappedReplacementIndicators.Select(i => new { Id = i.GroupId, Label = i.GroupLabel }))
-            .Distinct()
-            .ToDictionary(ig => ig.Label, ig => ig.Id);
+        var replacementGroupLabelToIdMap = replacementIndicatorGroups.ToDictionary(ig => ig.Label, ig => ig.Id);
 
         return ReplacementServiceHelper.ReplaceIndicatorSequence(
             mapping: mapping,
             originalGroupIdToLabelMap: originalGroupIdToLabelMap,
             replacementGroupLabelToIdMap: replacementGroupLabelToIdMap,
-            originalSequence: originalSequence
+            originalSequence: originalSequence,
+            replacementIndicatorGroups
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementServiceHelper.cs
@@ -168,7 +168,8 @@ public abstract class ReplacementServiceHelper
         DataSetMapping mapping,
         Dictionary<Guid, string> originalGroupIdToLabelMap,
         Dictionary<string, Guid> replacementGroupLabelToIdMap,
-        List<IndicatorGroupSequenceEntry> originalSequence
+        List<IndicatorGroupSequenceEntry> originalSequence,
+        List<IndicatorGroup> replacementIndicatorGroups
     )
     {
         // The below code to create replacementSequence can be summarised as "Create all replacement groups, and as
@@ -179,21 +180,27 @@ public abstract class ReplacementServiceHelper
         // - STEP 1: Add replacement groups that can be mapped from originalSequence (by group label)
         // - STEP 2: Then add new replacement groups from mapping.IndicatorMappings that haven't been mapped from
         //   originalSequence
-        // - STEP 3: Finally, add any new replacement groups from mapping.UnmappedReplacementIndicators that haven't yet been
-        //   added to replacementSequence.
+        // - STEP 3: Finally, add any new replacement groups from the unmapped replacement indicators that haven't yet
+        //   been added to replacementSequence.
         //
         // As we add replacement groups to replacementSequence, we must ensure that all replacement indicators belonging
         // to each group are added. This is because it's possible that are new indicators in the replacement and/or an
         // indicator was moved to a different group in the replacement. For example, after creating a group mapped from
         // originalSequence, we add replacement indicators that can be mapped from entries in that originalSequenceGroup
         // first (preserving the ordering as possible) but then also need to add other indicators belonging to that
-        // replacement group from IndicationMappings (i.e. those that have moved group) and UnmappedReplacementIndicators.
+        // replacement group from IndicationMappings (i.e. those that have moved group) and the unmapped replacement
+        // indicators.
         //
         // Follow comments PART 1-6 in the code below to track the creation of all replacement sequence groups and indicators:
         // - Create all replacement groups with a label matching an originalSequence group (1,2,3)
         // - Create new groups for mapped indicators that previously belonged to an original group, but moved to a new
         //   group (4,5)
-        // - Create new groups for UnmappedReplacementIndicators (6)
+        // - Create new groups for unmapped replacement indicators (6)
+
+        var claimedIndicatorIds = mapping
+            .IndicatorMappings.Values.Where(map => map.ReplacementId != null)
+            .Select(map => map.ReplacementId!.Value)
+            .ToHashSet();
 
         var replacementSequence = originalSequence
             .Select(originalGroupSequence =>
@@ -209,10 +216,10 @@ public abstract class ReplacementServiceHelper
                     .IndicatorMappings.Values.Where(map => map.ReplacementGroupId == replacementGroupId)
                     .ToList();
 
-                var unmappedIndicatorsForGroup = mapping
-                    .UnmappedReplacementIndicators.Where(unmappedIndicator =>
-                        unmappedIndicator.GroupId == replacementGroupId
-                    )
+                var unmappedIndicatorsForGroup = replacementIndicatorGroups
+                    .Where(indicatorGroup => indicatorGroup.Id == replacementGroupId)
+                    .SelectMany(indicatorGroup => indicatorGroup.Indicators)
+                    .Where(indicator => !claimedIndicatorIds.Contains(indicator.Id))
                     .ToList();
 
                 if (!mappingsForGroupWithReplacementSet.Any() && !unmappedIndicatorsForGroup.Any())
@@ -285,15 +292,11 @@ public abstract class ReplacementServiceHelper
 
             // PART 5. Unmapped replacement indicators that belong to this group
             childSequence.AddRange(
-                mapping
-                    .UnmappedReplacementIndicators.Where(unmappedIndicator =>
-                        unmappedIndicator.GroupId == group.Key.GroupId
-                    )
-                    .Select(unmappedIndicator => new
-                    {
-                        ReplacementId = unmappedIndicator.Id,
-                        ReplacementLabel = unmappedIndicator.Label,
-                    })
+                replacementIndicatorGroups
+                    .Where(indicatorGroup => indicatorGroup.Id == group.Key.GroupId)
+                    .SelectMany(indicatorGroup => indicatorGroup.Indicators)
+                    .Where(indicator => !claimedIndicatorIds.Contains(indicator.Id))
+                    .Select(indicator => new { ReplacementId = indicator.Id, ReplacementLabel = indicator.Label })
             );
 
             replacementSequence.Add(
@@ -306,19 +309,27 @@ public abstract class ReplacementServiceHelper
 
         // STEP 3
         // PART 6. Finally, add any unmapped replacement indicators that belong to a new group
-        var unmappedReplacementIndicatorsWithNewGroups = mapping
-            .UnmappedReplacementIndicators.Where(unmappedIndicator =>
-                !replacementSequence.Select(groupSeq => groupSeq.Id).ToList().Contains(unmappedIndicator.GroupId)
-            )
-            .GroupBy(unmappedIndicator => new { unmappedIndicator.GroupId, unmappedIndicator.GroupLabel })
-            .OrderBy(grouping => grouping.Key.GroupLabel)
-            .Select(grouping => new IndicatorGroupSequenceEntry(
-                Id: grouping.Key.GroupId,
-                ChildSequence: grouping
-                    .OrderBy(unmappedIndicator => unmappedIndicator.Label)
-                    .Select(unmappedIndicator => unmappedIndicator.Id)
+        groupIdsInReplacementSequence = replacementSequence.Select(groupSeq => groupSeq.Id).ToList();
+        var unmappedReplacementIndicatorsWithNewGroups = replacementIndicatorGroups
+            .Where(indicatorGroup => !groupIdsInReplacementSequence.Contains(indicatorGroup.Id))
+            .Select(indicatorGroup => new
+            {
+                indicatorGroup.Id,
+                indicatorGroup.Label,
+                UnmappedIndicators = indicatorGroup
+                    .Indicators.Where(indicator => !claimedIndicatorIds.Contains(indicator.Id))
+                    .ToList(),
+            })
+            .Where(indicatorGroup => indicatorGroup.UnmappedIndicators.Count > 0)
+            .OrderBy(indicatorGroup => indicatorGroup.Label)
+            .Select(indicatorGroup => new IndicatorGroupSequenceEntry(
+                Id: indicatorGroup.Id,
+                ChildSequence: indicatorGroup
+                    .UnmappedIndicators.OrderBy(indicator => indicator.Label)
+                    .Select(indicator => indicator.Id)
                     .ToList()
-            ));
+            ))
+            .ToList();
         replacementSequence.AddRange(unmappedReplacementIndicatorsWithNewGroups);
 
         return replacementSequence;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -306,9 +306,13 @@ public record ReplacementPlanMappingViewModel
 
     public ReplacementPlanFilterMappingsViewModel Filters { get; init; } = null!;
 
-    public static ReplacementPlanMappingViewModel FromModel(DataSetMapping mapping, List<Filter> replacementFilters)
+    public static ReplacementPlanMappingViewModel FromModel(
+        DataSetMapping mapping,
+        List<Filter> replacementFilters,
+        List<Indicator> replacementIndicators
+    )
     {
-        var indicatorMappings = ReplacementPlanIndicatorMappingsViewModel.FromModel(mapping);
+        var indicatorMappings = ReplacementPlanIndicatorMappingsViewModel.FromModel(mapping, replacementIndicators);
         var locationMappings = ReplacementPlanLocationMappingsViewModel.FromModel(mapping);
         var filterMappings = ReplacementPlanFilterMappingsViewModel.FromModel(mapping, replacementFilters);
 
@@ -329,7 +333,10 @@ public record ReplacementPlanIndicatorMappingsViewModel
     // Key is replacement indicator id
     public Dictionary<Guid, ReplacementPlanIndicatorViewModel> Candidates { get; init; } = null!;
 
-    public static ReplacementPlanIndicatorMappingsViewModel FromModel(DataSetMapping mapping)
+    public static ReplacementPlanIndicatorMappingsViewModel FromModel(
+        DataSetMapping mapping,
+        List<Indicator> replacementIndicators
+    )
     {
         var indicatorMappings = mapping.IndicatorMappings.Values.ToDictionary(
             indicatorMap => indicatorMap.OriginalId,
@@ -345,31 +352,17 @@ public record ReplacementPlanIndicatorMappingsViewModel
                 CandidateKey = indicatorMap.ReplacementId,
             }
         );
-        var indicatorCandidates = mapping // candidates are all possible replacement indicators
-            .IndicatorMappings.Values.Where(indicatorMap => indicatorMap.ReplacementId != null)
-            .Select(indicatorMap => new
+
+        var indicatorCandidates = replacementIndicators.ToDictionary(
+            replacementIndicator => replacementIndicator.Id,
+            replacementIndicator => new ReplacementPlanIndicatorViewModel
             {
-                Id = indicatorMap.ReplacementId!.Value,
-                ColumnName = indicatorMap.ReplacementColumnName!,
-                Label = indicatorMap.ReplacementLabel!,
-            })
-            .Concat(
-                mapping.UnmappedReplacementIndicators.Select(unmappedIndicator => new
-                {
-                    unmappedIndicator.Id,
-                    unmappedIndicator.ColumnName,
-                    unmappedIndicator.Label,
-                })
-            )
-            .ToDictionary(
-                x => x.Id,
-                x => new ReplacementPlanIndicatorViewModel
-                {
-                    Id = x.Id,
-                    Name = x.ColumnName,
-                    Label = x.Label,
-                }
-            );
+                Id = replacementIndicator.Id,
+                Name = replacementIndicator.Name,
+                Label = replacementIndicator.Label,
+            }
+        );
+
         return new ReplacementPlanIndicatorMappingsViewModel
         {
             Mappings = indicatorMappings,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
@@ -40,11 +40,6 @@ public static class DataSetMappingGeneratorExtensions
         Dictionary<Guid, IndicatorMapping> indicatorMappings
     ) => generator.ForInstance(m => m.SetIndicatorMappings(indicatorMappings));
 
-    public static Generator<DataSetMapping> WithUnmappedReplacementIndicators(
-        this Generator<DataSetMapping> generator,
-        List<UnmappedIndicator> unmappedIndicators
-    ) => generator.ForInstance(m => m.SetUnmappedReplacementIndicators(unmappedIndicators));
-
     public static Generator<DataSetMapping> WithLocationMappings(
         this Generator<DataSetMapping> generator,
         Dictionary<Guid, LocationMapping> locationMappings
@@ -92,11 +87,6 @@ public static class DataSetMappingGeneratorExtensions
         this InstanceSetters<DataSetMapping> setters,
         Dictionary<Guid, IndicatorMapping> indicatorMappings
     ) => setters.Set(m => m.IndicatorMappings, indicatorMappings);
-
-    public static InstanceSetters<DataSetMapping> SetUnmappedReplacementIndicators(
-        this InstanceSetters<DataSetMapping> setters,
-        List<UnmappedIndicator> unmappedIndicators
-    ) => setters.Set(m => m.UnmappedReplacementIndicators, unmappedIndicators);
 
     public static InstanceSetters<DataSetMapping> SetLocationMappings(
         this InstanceSetters<DataSetMapping> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -18,7 +18,6 @@ public record DataSetMapping
     public File ReplacementDataFile { get; init; } = null!;
 
     public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; init; } = null!;
-    public List<UnmappedIndicator> UnmappedReplacementIndicators { get; init; } = [];
 
     public Dictionary<Guid, LocationMapping> LocationMappings { get; init; } = null!;
     public List<UnmappedLocation> UnmappedReplacementLocations { get; init; } = [];
@@ -63,16 +62,6 @@ public record DataSetMapping
                 .HasColumnType("nvarchar(max)");
 
             builder
-                .Property(x => x.UnmappedReplacementIndicators)
-                .HasConversion(
-                    unmappedIndicators => JsonSerializer.Serialize(unmappedIndicators, JsonOptions),
-                    unmappedIndicatorsString =>
-                        JsonSerializer.Deserialize<List<UnmappedIndicator>>(unmappedIndicatorsString, JsonOptions)
-                        ?? new List<UnmappedIndicator>(),
-                    ValueComparer.CreateDefault<List<UnmappedIndicator>>(false)
-                );
-
-            builder
                 .Property(x => x.LocationMappings)
                 .HasConversion(
                     locationMappings => JsonSerializer.Serialize(locationMappings, JsonOptions),
@@ -113,15 +102,6 @@ public enum MapStatus
     ManuallySet, // user manually mapped this (whether to another Id or nothing)
     AutoSet, // automatically mapped when the initial mapping was created
     ParentNotMapped,
-}
-
-public record UnmappedIndicator
-{
-    public Guid Id { get; set; }
-    public string Label { get; set; } = "";
-    public string ColumnName { get; set; } = "";
-    public Guid GroupId { get; set; }
-    public string GroupLabel { get; set; } = "";
 }
 
 public record IndicatorMapping

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
@@ -413,25 +413,6 @@ public class DataSetMappingServiceTests
                         CreateIndicatorMapping(originalIndicatorA4, originalIndicatorGroupA, mapStatus: MapStatus.Unset)
                     },
                 },
-                UnmappedReplacementIndicators =
-                [
-                    new UnmappedIndicator
-                    {
-                        Id = replacementIndicatorA3.Id,
-                        Label = replacementIndicatorA3.Label,
-                        ColumnName = replacementIndicatorA3.Name,
-                        GroupId = replacementIndicatorGroupA.Id,
-                        GroupLabel = replacementIndicatorGroupA.Label,
-                    },
-                    new UnmappedIndicator
-                    {
-                        Id = replacementIndicatorA4.Id,
-                        Label = replacementIndicatorA4.Label,
-                        ColumnName = replacementIndicatorA4.Name,
-                        GroupId = replacementIndicatorGroupB.Id,
-                        GroupLabel = replacementIndicatorGroupB.Label,
-                    },
-                ],
             };
 
             result.AssertDeepEqualTo(expectedMapping, ignoreProperties: [mapping => mapping.Id]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -29,7 +29,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
 
         var originalFile = replacementFile.Replacing!;
 
-        var (indicatorMappings, unmappedReplacementIndicators) = await GenerateInitialIndicatorMapping(
+        var indicatorMappings = await GenerateInitialIndicatorMapping(
             statisticsDbContext,
             originalFile.SubjectId!.Value,
             replacementFile.SubjectId!.Value
@@ -52,7 +52,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             OriginalDataFileId = originalFile.Id,
             ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = indicatorMappings,
-            UnmappedReplacementIndicators = unmappedReplacementIndicators,
             LocationMappings = locationMappings,
             UnmappedReplacementLocations = unmappedReplacementLocations,
             FilterMappings = filterMappings,
@@ -62,7 +61,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         await contentDbContext.SaveChangesAsync();
     }
 
-    private async Task<(Dictionary<Guid, IndicatorMapping>, List<UnmappedIndicator>)> GenerateInitialIndicatorMapping(
+    private async Task<Dictionary<Guid, IndicatorMapping>> GenerateInitialIndicatorMapping(
         StatisticsDbContext statisticsDbContext,
         Guid originalSubjectId,
         Guid replacementSubjectId
@@ -114,23 +113,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             }
         );
 
-        var mappedReplacementIndicatorIds = indicatorMappings
-            .Values.Where(m => m.ReplacementId.HasValue)
-            .Select(m => m.ReplacementId!.Value);
-
-        var unmappedReplacementIndicators = replacementIndicatorNameToIndicatorMap
-            .Values.ExceptBy(mappedReplacementIndicatorIds, indicator => indicator.Id)
-            .Select(i => new UnmappedIndicator
-            {
-                Id = i.Id,
-                Label = i.Label,
-                ColumnName = i.Name,
-                GroupId = i.IndicatorGroupId,
-                GroupLabel = i.IndicatorGroup.Label,
-            })
-            .ToList();
-
-        return (indicatorMappings, unmappedReplacementIndicators);
+        return indicatorMappings;
     }
 
     private async Task<(Dictionary<Guid, LocationMapping>, List<UnmappedLocation>)> GenerateInitialLocationMapping(


### PR DESCRIPTION
This PR simplifies indicator mapping code by removing DataSetMapping.UnmappedReplacementIndicators. This mean we don't have to manage a list of unmapped indicators anymore - if you need to know whether an indicator is unmapped, we just calculate it in-place.

This work was born out of discussions with Jack on EES-7281. I had realised the possibilities for simplifying the work, but considered it too much work to be worth actually going through with, but Jack then used the AI to give us a good sense of what it could look like, at which we were both on board for doing this work.

:rotating_light: This should merged after https://github.com/dfe-analytical-services/explore-education-statistics/pull/7272 :rotating_light: 