### PR TITLE
EES-7547 Remove DataSetMapping.UnmappedReplacementLocations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -114,6 +115,7 @@ public class DataSetMappingServicePermissionTests
         return new DataSetMappingService(
             contentDbContext,
             statisticsDbContext,
+            new LocationRepository(statisticsDbContext),
             userService ?? Mock.Of<IUserService>(MockBehavior.Strict)
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServicePermissionTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -935,32 +935,6 @@ public class DataSetMappingServiceTests
             var map3 = locationMappingList.Single(m => m.OriginalId == loc3Id);
             Assert.Equal(loc3ReplacementId, map3.ReplacementId);
             Assert.Equal(MapStatus.Unset, map3.Status);
-        }
-
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
-
-            // loc2 released displacedReplacementLocId above, so it should now be available to another mapping
-            var result = await service.UpdateLocationMappings(
-                releaseVersion.Id,
-                new LocationMappingUpdatesRequest
-                {
-                    OriginalDataFileId = originalDataFileId,
-                    ReplacementDataFileId = replacementDataFileId,
-                    Updates = [new() { OriginalId = loc4Id, NewReplacementId = displacedReplacementLocId }],
-                },
-                CancellationToken.None
-            );
-
-            var locationMappingList = result.AssertRight();
-
-            var map4 = locationMappingList.Single(m => m.OriginalId == loc4Id);
-            Assert.Equal(displacedReplacementLocId, map4.ReplacementId);
-            Assert.Equal("Old Country Name", map4.ReplacementName);
-            Assert.Equal("E9200002", map4.ReplacementCode);
-            Assert.Equal(MapStatus.ManuallySet, map4.Status);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
@@ -765,8 +766,9 @@ public class DataSetMappingServiceTests
         var loc1Id = Guid.NewGuid();
         var loc2Id = Guid.NewGuid();
         var loc3Id = Guid.NewGuid();
+        var loc4Id = Guid.NewGuid();
         var replacementLocId = Guid.NewGuid();
-        var newlyUnmappedLocId = Guid.NewGuid();
+        var displacedReplacementLocId = Guid.NewGuid();
         var loc3ReplacementId = Guid.NewGuid();
 
         var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
@@ -792,7 +794,7 @@ public class DataSetMappingServiceTests
                     {
                         OriginalId = loc2Id,
                         OriginalGeographicLevel = GeographicLevel.Country,
-                        ReplacementId = newlyUnmappedLocId,
+                        ReplacementId = displacedReplacementLocId,
                         ReplacementName = "Old Country Name",
                         ReplacementCode = "E9200002",
                         ReplacementGeographicLevel = GeographicLevel.Country,
@@ -809,17 +811,35 @@ public class DataSetMappingServiceTests
                         Status = MapStatus.Unset,
                     }
                 },
-            },
-            UnmappedReplacementLocations =
-            [
-                new UnmappedLocation
                 {
-                    Id = replacementLocId,
-                    GeographicLevel = GeographicLevel.LocalAuthority,
-                    Name = "New LA",
-                    Code = "301",
+                    loc4Id,
+                    new LocationMapping
+                    {
+                        OriginalId = loc4Id,
+                        OriginalGeographicLevel = GeographicLevel.Country,
+                        Status = MapStatus.Unset,
+                    }
                 },
-            ],
+            },
+        };
+
+        var replacementLocation = new Location
+        {
+            Id = replacementLocId,
+            GeographicLevel = GeographicLevel.LocalAuthority,
+            LocalAuthority = new LocalAuthority("301", null, "New LA"),
+        };
+        var displacedReplacementLocation = new Location
+        {
+            Id = displacedReplacementLocId,
+            GeographicLevel = GeographicLevel.Country,
+            Country = new Country("E9200002", "Old Country Name"),
+        };
+        var loc3ReplacementLocation = new Location
+        {
+            Id = loc3ReplacementId,
+            GeographicLevel = GeographicLevel.Region,
+            Region = new Region("E12000003", "Yorkshire and The Humber"),
         };
 
         var originalReleaseFile = new ReleaseFile
@@ -839,6 +859,8 @@ public class DataSetMappingServiceTests
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
             contentDbContext.ReleaseVersions.Add(releaseVersion);
@@ -847,9 +869,40 @@ public class DataSetMappingServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            statisticsDbContext.Location.AddRange(
+                replacementLocation,
+                displacedReplacementLocation,
+                loc3ReplacementLocation
+            );
+            statisticsDbContext.Observation.AddRange(
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementSubjectId,
+                    Location = replacementLocation,
+                },
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementSubjectId,
+                    Location = displacedReplacementLocation,
+                },
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementSubjectId,
+                    Location = loc3ReplacementLocation,
+                }
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
             var result = await service.UpdateLocationMappings(
                 releaseVersion.Id,
@@ -867,10 +920,12 @@ public class DataSetMappingServiceTests
             );
 
             var locationMappingList = result.AssertRight();
-            Assert.Equal(3, locationMappingList.Count);
+            Assert.Equal(4, locationMappingList.Count);
 
             var map1 = locationMappingList.Single(m => m.OriginalId == loc1Id);
             Assert.Equal(replacementLocId, map1.ReplacementId);
+            Assert.Equal("New LA", map1.ReplacementName);
+            Assert.Equal("301", map1.ReplacementCode);
             Assert.Equal(MapStatus.ManuallySet, map1.Status);
 
             var map2 = locationMappingList.Single(m => m.OriginalId == loc2Id);
@@ -883,15 +938,146 @@ public class DataSetMappingServiceTests
         }
 
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var dbMapping = contentDbContext.DataSetMappings.Single();
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
 
-            Assert.Single(dbMapping.UnmappedReplacementLocations);
+            // loc2 released displacedReplacementLocId above, so it should now be available to another mapping
+            var result = await service.UpdateLocationMappings(
+                releaseVersion.Id,
+                new LocationMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    Updates = [new() { OriginalId = loc4Id, NewReplacementId = displacedReplacementLocId }],
+                },
+                CancellationToken.None
+            );
 
-            // Check that the old replacement from loc2 was moved back to unmapped
-            Assert.Contains(dbMapping.UnmappedReplacementLocations, l => l.Id == newlyUnmappedLocId);
-            // Check that the new replacement was removed from unmapped
-            Assert.DoesNotContain(dbMapping.UnmappedReplacementLocations, l => l.Id == replacementLocId);
+            var locationMappingList = result.AssertRight();
+
+            var map4 = locationMappingList.Single(m => m.OriginalId == loc4Id);
+            Assert.Equal(displacedReplacementLocId, map4.ReplacementId);
+            Assert.Equal("Old Country Name", map4.ReplacementName);
+            Assert.Equal("E9200002", map4.ReplacementCode);
+            Assert.Equal(MapStatus.ManuallySet, map4.Status);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappings_ReplacementLocationClaimedByAnotherMapping_Fail()
+    {
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
+
+        var loc1Id = Guid.NewGuid();
+        var loc2Id = Guid.NewGuid();
+
+        var replacementLocId = Guid.NewGuid();
+
+        var releaseVersion = new ReleaseVersion { Id = Guid.NewGuid() };
+        var originalReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File { Id = originalDataFileId },
+        };
+        var replacementReleaseFile = new ReleaseFile
+        {
+            ReleaseVersionId = releaseVersion.Id,
+            File = new Content.Model.File
+            {
+                Id = replacementDataFileId,
+                Type = FileType.Data,
+                SubjectId = replacementSubjectId,
+            },
+        };
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
+            LocationMappings = new Dictionary<Guid, LocationMapping>
+            {
+                {
+                    loc1Id,
+                    new LocationMapping
+                    {
+                        OriginalId = loc1Id,
+                        OriginalGeographicLevel = GeographicLevel.LocalAuthority,
+                        ReplacementId = replacementLocId,
+                        ReplacementGeographicLevel = GeographicLevel.LocalAuthority,
+                        Status = MapStatus.AutoSet,
+                    }
+                },
+                {
+                    loc2Id,
+                    new LocationMapping
+                    {
+                        OriginalId = loc2Id,
+                        OriginalGeographicLevel = GeographicLevel.LocalAuthority,
+                        Status = MapStatus.Unset,
+                    }
+                },
+            },
+        };
+
+        var replacementLocation = new Location
+        {
+            Id = replacementLocId,
+            GeographicLevel = GeographicLevel.LocalAuthority,
+            LocalAuthority = new LocalAuthority("301", null, "New LA"),
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            contentDbContext.ReleaseFiles.AddRange(originalReleaseFile, replacementReleaseFile);
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            statisticsDbContext.Location.Add(replacementLocation);
+            statisticsDbContext.Observation.Add(
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementSubjectId,
+                    Location = replacementLocation,
+                }
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
+
+            var result = await service.UpdateLocationMappings(
+                releaseVersion.Id,
+                new LocationMappingUpdatesRequest
+                {
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
+                    Updates = [new() { OriginalId = loc2Id, NewReplacementId = replacementLocId }],
+                },
+                CancellationToken.None
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasError(
+                expectedPath: "Updates.NewReplacementId",
+                expectedCode: "UnmappedLocationMatchingReplacementLocationIdNotFound"
+            );
         }
     }
 
@@ -1130,7 +1316,6 @@ public class DataSetMappingServiceTests
                     new LocationMapping { OriginalId = locId }
                 },
             },
-            UnmappedReplacementLocations = [],
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1202,13 +1387,18 @@ public class DataSetMappingServiceTests
                     new LocationMapping { OriginalId = locId, OriginalGeographicLevel = GeographicLevel.Region }
                 },
             },
-            UnmappedReplacementLocations =
-            [
-                new UnmappedLocation { Id = replacementLocId, GeographicLevel = GeographicLevel.LocalAuthority },
-            ],
+        };
+
+        var replacementLocation = new Location
+        {
+            Id = replacementLocId,
+            GeographicLevel = GeographicLevel.LocalAuthority,
+            LocalAuthority = new LocalAuthority("301", null, "New LA"),
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
         await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
             contentDbContext.ReleaseVersions.Add(releaseVersion);
@@ -1217,9 +1407,24 @@ public class DataSetMappingServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var service = SetupDataSetMappingService(contentDbContext);
+            statisticsDbContext.Location.Add(replacementLocation);
+            statisticsDbContext.Observation.Add(
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementSubjectId,
+                    Location = replacementLocation,
+                }
+            );
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext, statisticsDbContext);
             var result = await service.UpdateLocationMappings(
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
@@ -3368,9 +3573,12 @@ public class DataSetMappingServiceTests
         IUserService? userService = null
     )
     {
+        statisticsDbContext ??= StatisticsDbUtils.InMemoryStatisticsDbContext();
+
         return new DataSetMappingService(
             contentDbContext,
-            statisticsDbContext ?? StatisticsDbUtils.InMemoryStatisticsDbContext(),
+            statisticsDbContext,
+            new LocationRepository(statisticsDbContext),
             userService ?? MockUtils.AlwaysTrueUserService().Object
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -427,8 +427,7 @@ public class ReplacementPlanServiceTests
                 {
                     { originalLocation.Id, CreateLocationMapping(originalLocation) },
                 }
-            )
-            .WithUnmappedReplacementLocations([]);
+            );
 
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
         timePeriodService
@@ -2703,8 +2702,7 @@ public class ReplacementPlanServiceTests
                 {
                     { location.Id, CreateLocationMapping(location, location, MapStatus.AutoSet) },
                 }
-            )
-            .WithUnmappedReplacementLocations([]);
+            );
 
         var contentDbContextId = Guid.NewGuid().ToString();
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -2987,8 +2985,7 @@ public class ReplacementPlanServiceTests
                 {
                     { location.Id, CreateLocationMapping(location, location, MapStatus.AutoSet) },
                 }
-            )
-            .WithUnmappedReplacementLocations([]);
+            );
 
         var contentDbContextId = Guid.NewGuid().ToString();
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -3284,16 +3281,7 @@ public class ReplacementPlanServiceTests
                     },
                     { originalLocationBirmingham.Id, CreateLocationMapping(originalLocationBirmingham) },
                 }
-            )
-            .WithUnmappedReplacementLocations([
-                new UnmappedLocation
-                {
-                    Id = replacementLocationNott.Id,
-                    GeographicLevel = replacementLocationNott.GeographicLevel,
-                    Name = replacementLocationNott.ToLocationAttribute().Name!,
-                    Code = replacementLocationNott.ToLocationAttribute().GetCodeOrFallback(),
-                },
-            ]);
+            );
 
         var contentDbContextId = Guid.NewGuid().ToString();
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -3312,6 +3300,38 @@ public class ReplacementPlanServiceTests
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
+            statisticsDbContext.Location.AddRange(
+                locationEng,
+                replacementLocationDerby,
+                locationLeicester,
+                replacementLocationNott
+            );
+            statisticsDbContext.Observation.AddRange(
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementReleaseSubject.SubjectId,
+                    Location = locationEng,
+                },
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementReleaseSubject.SubjectId,
+                    Location = replacementLocationDerby,
+                },
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementReleaseSubject.SubjectId,
+                    Location = locationLeicester,
+                },
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementReleaseSubject.SubjectId,
+                    Location = replacementLocationNott,
+                }
+            );
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -3624,16 +3644,7 @@ public class ReplacementPlanServiceTests
                 {
                     { originalLocationDerby.Id, CreateLocationMapping(originalLocationDerby) },
                 }
-            )
-            .WithUnmappedReplacementLocations([
-                new UnmappedLocation
-                {
-                    Id = replacementLocationDerby.Id,
-                    GeographicLevel = replacementLocationDerby.GeographicLevel,
-                    Name = replacementLocationDerby.ToLocationAttribute().Name!,
-                    Code = replacementLocationDerby.ToLocationAttribute().GetCodeOrFallback(),
-                },
-            ]);
+            );
 
         var contentDbContextId = Guid.NewGuid().ToString();
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -3652,6 +3663,15 @@ public class ReplacementPlanServiceTests
             statisticsDbContext.ReleaseVersion.AddRange(statsReleaseVersion);
             statisticsDbContext.ReleaseSubject.AddRange(originalReleaseSubject, replacementReleaseSubject);
             statisticsDbContext.IndicatorGroup.AddRange(originalIndicatorGroup, replacementIndicatorGroup);
+            statisticsDbContext.Location.AddRange(replacementLocationDerby);
+            statisticsDbContext.Observation.AddRange(
+                new Observation
+                {
+                    Id = Guid.NewGuid(),
+                    SubjectId = replacementReleaseSubject.SubjectId,
+                    Location = replacementLocationDerby,
+                }
+            );
             await statisticsDbContext.SaveChangesAsync();
         }
 
@@ -3763,6 +3783,7 @@ public class ReplacementPlanServiceTests
             contentDbContext,
             statisticsDbContext,
             new FootnoteRepository(statisticsDbContext),
+            new LocationRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),
             userService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -3204,6 +3204,7 @@ public class ReplacementServiceTests
             contentDbContext,
             statisticsDbContext,
             new FootnoteRepository(statisticsDbContext),
+            new LocationRepository(statisticsDbContext),
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict),
             userService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820105058_Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820105058_Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820105058_Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping")]
+    partial class Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820105058_Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260820105058_Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7547RemoveUnmappedReplacementLocationsFromDataSetMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "UnmappedReplacementLocations", table: "DataSetMappings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UnmappedReplacementLocations",
+                table: "DataSetMappings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: ""
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
@@ -20,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 public class DataSetMappingService(
     ContentDbContext contentDbContext,
     StatisticsDbContext statisticsDbContext,
+    ILocationRepository locationRepository,
     IUserService userService
 ) : IDataSetMappingService
 {
@@ -211,13 +213,22 @@ public class DataSetMappingService(
             )
             .OnSuccess(async validated =>
             {
-                var mapping = validated.Mapping;
+                var (mapping, replacementReleaseFile) = validated;
+
+                var replacementLocations = (
+                    await locationRepository.GetDistinctForSubject(replacementReleaseFile.File.SubjectId!.Value)
+                ).ToList();
 
                 var updatedMappings = request
                     .Updates.Select(update =>
-                        UpdateLocationMapping(mapping, update.OriginalId, update.NewReplacementId)
+                        mapping.UpdateLocationMapping(replacementLocations, update.OriginalId, update.NewReplacementId)
                     )
                     .ToList(); // cannot be async!
+
+                // The mutations above happen on the in-memory object graph beneath LocationMappings. EF can't see
+                // through the JSON column conversion on that property, so we must mark it dirty explicitly for the
+                // changes to be persisted.
+                contentDbContext.Entry(mapping).Property(x => x.LocationMappings).IsModified = true;
 
                 // we still save changes from the Updates that succeeded, even if some failed
                 await contentDbContext.SaveChangesAsync(cancellationToken);
@@ -226,100 +237,6 @@ public class DataSetMappingService(
                     .OnSuccessAll()
                     .OnSuccess(_ => mapping.LocationMappings.Values.Select(LocationMappingDto.FromModel).ToList());
             });
-    }
-
-    private Either<ActionResult, LocationMapping> UpdateLocationMapping(
-        DataSetMapping dataSetMapping,
-        Guid originalLocationId,
-        Guid? newReplacementLocationId = null
-    )
-    {
-        if (!dataSetMapping.LocationMappings.TryGetValue(originalLocationId, out var locationMapping))
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path = $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
-                    Code = "LocationMatchingOriginalIdNameNotFound",
-                    Message = $"Could not find location mapping matching original location id \"{originalLocationId}\"",
-                }
-            );
-        }
-
-        if (
-            locationMapping.ReplacementId == newReplacementLocationId
-            && locationMapping.Status == MapStatus.ManuallySet
-        )
-        {
-            return locationMapping; // it is already mapped, so can skip
-        }
-
-        var availableUnmappedLocation = dataSetMapping.UnmappedReplacementLocations.SingleOrDefault(unmappedLocation =>
-            unmappedLocation.Id == newReplacementLocationId
-        );
-
-        if (newReplacementLocationId != null && availableUnmappedLocation == null)
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedLocationMatchingReplacementLocationIdNotFound",
-                    Message = $"No available unmapped location matching replacement id \"{newReplacementLocationId}\"",
-                }
-            );
-        }
-
-        if (
-            newReplacementLocationId != null
-            && availableUnmappedLocation != null
-            && availableUnmappedLocation.GeographicLevel != locationMapping.OriginalGeographicLevel
-        )
-        {
-            return ValidationResult(
-                new ErrorViewModel
-                {
-                    Path =
-                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
-                    Code = "UnmappedLocationHasDifferentGeographicLevelAsOriginalLocation",
-                    Message =
-                        $"The replacement location has a different geographic level than the original location. Replacement id: \"{newReplacementLocationId}\"",
-                }
-            );
-        }
-
-        if (availableUnmappedLocation != null)
-        {
-            // remove availableUnmappedLocation from UnmappedReplacementLocations as it's about to become mapped
-            dataSetMapping.UnmappedReplacementLocations.Remove(availableUnmappedLocation);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementLocations).IsModified = true;
-        }
-
-        if (locationMapping.ReplacementId != null && locationMapping.ReplacementId != newReplacementLocationId)
-        {
-            // We need to move the preexisting mapped location into UnmappedReplacementLocations, as it will be overwritten
-            var newlyUnmappedLocation = new UnmappedLocation
-            {
-                Id = locationMapping.ReplacementId.Value,
-                GeographicLevel = locationMapping.ReplacementGeographicLevel!.Value,
-                Code = locationMapping.ReplacementCode!,
-                Name = locationMapping.ReplacementName!,
-            };
-            dataSetMapping.UnmappedReplacementLocations.Add(newlyUnmappedLocation);
-            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementLocations).IsModified = true;
-        }
-
-        // locationMapping.Original* properties should never change
-        locationMapping.ReplacementId = availableUnmappedLocation?.Id;
-        locationMapping.ReplacementGeographicLevel = availableUnmappedLocation?.GeographicLevel;
-        locationMapping.ReplacementCode = availableUnmappedLocation?.Code;
-        locationMapping.ReplacementName = availableUnmappedLocation?.Name;
-        locationMapping.Status = MapStatus.ManuallySet;
-
-        contentDbContext.Entry(dataSetMapping).Property(x => x.LocationMappings).IsModified = true;
-
-        return locationMapping;
     }
 
     private async Task<Either<ActionResult, (DataSetMapping Mapping, ReleaseFile ReplacementFile)>> ValidateMapping(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LocationMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LocationMappingExtensions.cs
@@ -1,0 +1,102 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+internal static class LocationMappingExtensions
+{
+    public static Either<ActionResult, LocationMapping> UpdateLocationMapping(
+        this DataSetMapping dataSetMapping,
+        List<Location> replacementLocations,
+        Guid originalId,
+        Guid? newReplacementId = null
+    )
+    {
+        if (!dataSetMapping.LocationMappings.TryGetValue(originalId, out var locationMapping))
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path = $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.OriginalId)}",
+                    Code = "LocationMatchingOriginalIdNameNotFound",
+                    Message = $"Could not find location mapping matching original location id \"{originalId}\"",
+                }
+            );
+        }
+
+        if (locationMapping.ReplacementId == newReplacementId && locationMapping.Status == MapStatus.ManuallySet)
+        {
+            return locationMapping; // it is already mapped, so can skip
+        }
+
+        if (
+            newReplacementId != null
+            && !IsLocationCandidateAvailable(
+                dataSetMapping,
+                locationMapping,
+                replacementLocations,
+                newReplacementId.Value
+            )
+        )
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedLocationMatchingReplacementLocationIdNotFound",
+                    Message =
+                        $"No available unmapped location matching replacement id \"{newReplacementId}\". DataSetMapping.Id: {dataSetMapping.Id}",
+                }
+            );
+        }
+
+        var replacement =
+            newReplacementId == null ? null : replacementLocations.Single(location => location.Id == newReplacementId);
+
+        if (replacement != null && replacement.GeographicLevel != locationMapping.OriginalGeographicLevel)
+        {
+            return ValidationResult(
+                new ErrorViewModel
+                {
+                    Path =
+                        $"{nameof(LocationMappingUpdatesRequest.Updates)}.{nameof(MappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedLocationHasDifferentGeographicLevelAsOriginalLocation",
+                    Message =
+                        $"The replacement location has a different geographic level than the original location. Replacement id: \"{newReplacementId}\"",
+                }
+            );
+        }
+
+        // mapping.Original* properties should never change
+        locationMapping.ReplacementId = replacement?.Id;
+        locationMapping.ReplacementGeographicLevel = replacement?.GeographicLevel;
+        locationMapping.ReplacementCode = replacement?.ToLocationAttribute().GetCodeOrFallback();
+        locationMapping.ReplacementName = replacement?.ToLocationAttribute().Name ?? "";
+        locationMapping.Status = MapStatus.ManuallySet;
+
+        return locationMapping;
+    }
+
+    private static bool IsLocationCandidateAvailable(
+        DataSetMapping dataSetMapping,
+        LocationMapping locationMapping,
+        List<Location> replacementLocations,
+        Guid candidateId
+    )
+    {
+        var candidateExists = replacementLocations.Any(candidate => candidate.Id == candidateId);
+
+        var alreadyClaimed = dataSetMapping.LocationMappings.Values.Any(other =>
+            other.OriginalId != locationMapping.OriginalId && other.ReplacementId == candidateId
+        );
+
+        return candidateExists && !alreadyClaimed;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LocationMappingExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LocationMappingExtensions.cs
@@ -13,7 +13,7 @@ internal static class LocationMappingExtensions
 {
     public static Either<ActionResult, LocationMapping> UpdateLocationMapping(
         this DataSetMapping dataSetMapping,
-        List<Location> replacementLocations,
+        IReadOnlyList<Location> replacementLocations,
         Guid originalId,
         Guid? newReplacementId = null
     )
@@ -87,7 +87,7 @@ internal static class LocationMappingExtensions
     private static bool IsLocationCandidateAvailable(
         DataSetMapping dataSetMapping,
         LocationMapping locationMapping,
-        List<Location> replacementLocations,
+        IReadOnlyList<Location> replacementLocations,
         Guid candidateId
     )
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
@@ -26,6 +26,7 @@ public class ReplacementPlanService(
     ContentDbContext contentDbContext,
     StatisticsDbContext statisticsDbContext,
     IFootnoteRepository footnoteRepository,
+    ILocationRepository locationRepository,
     IDataSetVersionService dataSetVersionService,
     ITimePeriodService timePeriodService,
     IUserService userService,
@@ -158,10 +159,15 @@ public class ReplacementPlanService(
                     .Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
                     .ToListAsync(cancellationToken);
 
+                var replacementLocations = (
+                    await locationRepository.GetDistinctForSubject(replacementSubjectId)
+                ).ToList();
+
                 var mappingPlan = ReplacementPlanMappingViewModel.FromModel(
                     mapping,
                     replacementFilters,
-                    replacementIndicators
+                    replacementIndicators,
+                    replacementLocations
                 );
 
                 return new DataReplacementPlanViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -309,11 +309,12 @@ public record ReplacementPlanMappingViewModel
     public static ReplacementPlanMappingViewModel FromModel(
         DataSetMapping mapping,
         List<Filter> replacementFilters,
-        List<Indicator> replacementIndicators
+        List<Indicator> replacementIndicators,
+        List<Location> replacementLocations
     )
     {
         var indicatorMappings = ReplacementPlanIndicatorMappingsViewModel.FromModel(mapping, replacementIndicators);
-        var locationMappings = ReplacementPlanLocationMappingsViewModel.FromModel(mapping);
+        var locationMappings = ReplacementPlanLocationMappingsViewModel.FromModel(mapping, replacementLocations);
         var filterMappings = ReplacementPlanFilterMappingsViewModel.FromModel(mapping, replacementFilters);
 
         return new ReplacementPlanMappingViewModel
@@ -395,7 +396,10 @@ public record ReplacementPlanLocationMappingsViewModel
     // Key is replacement location id
     public Dictionary<Guid, ReplacementPlanLocationViewModel> Candidates { get; init; } = new();
 
-    public static ReplacementPlanLocationMappingsViewModel FromModel(DataSetMapping mapping)
+    public static ReplacementPlanLocationMappingsViewModel FromModel(
+        DataSetMapping mapping,
+        List<Location> replacementLocations
+    )
     {
         var locationMappings = mapping.LocationMappings.Values.ToDictionary(
             locationMap => locationMap.OriginalId,
@@ -411,31 +415,15 @@ public record ReplacementPlanLocationMappingsViewModel
                 CandidateKey = locationMap.ReplacementId,
             }
         );
-        var locationCandidates = mapping // candidates are all possible replacement locations
-            .LocationMappings.Values.Where(locationMap => locationMap.ReplacementId != null)
-            .Select(locationMap => new
+        var locationCandidates = replacementLocations.ToDictionary(
+            replacementLocation => replacementLocation.Id,
+            replacementLocation => new ReplacementPlanLocationViewModel
             {
-                Id = locationMap.ReplacementId!.Value,
-                Code = locationMap.ReplacementCode!,
-                Name = locationMap.ReplacementName!,
-            })
-            .Concat(
-                mapping.UnmappedReplacementLocations.Select(unmappedLocation => new
-                {
-                    unmappedLocation.Id,
-                    unmappedLocation.Code,
-                    unmappedLocation.Name,
-                })
-            )
-            .ToDictionary(
-                x => x.Id,
-                x => new ReplacementPlanLocationViewModel
-                {
-                    Id = x.Id,
-                    Code = x.Code,
-                    Name = x.Name,
-                }
-            );
+                Id = replacementLocation.Id,
+                Code = replacementLocation.ToLocationAttribute().GetCodeOrFallback(),
+                Name = replacementLocation.ToLocationAttribute().Name ?? "",
+            }
+        );
 
         return new ReplacementPlanLocationMappingsViewModel
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
@@ -1,4 +1,4 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetMappingGeneratorExtensions.cs
@@ -1,4 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 
@@ -45,11 +45,6 @@ public static class DataSetMappingGeneratorExtensions
         Dictionary<Guid, LocationMapping> locationMappings
     ) => generator.ForInstance(m => m.SetLocationMappings(locationMappings));
 
-    public static Generator<DataSetMapping> WithUnmappedReplacementLocations(
-        this Generator<DataSetMapping> generator,
-        List<UnmappedLocation> unmappedLocations
-    ) => generator.ForInstance(m => m.SetUnmappedReplacementLocations(unmappedLocations));
-
     public static InstanceSetters<DataSetMapping> SetDefaults(this InstanceSetters<DataSetMapping> setters) =>
         setters
             .SetDefault(m => m.OriginalDataFileId)
@@ -92,9 +87,4 @@ public static class DataSetMappingGeneratorExtensions
         this InstanceSetters<DataSetMapping> setters,
         Dictionary<Guid, LocationMapping> locationMappings
     ) => setters.Set(m => m.LocationMappings, locationMappings);
-
-    public static InstanceSetters<DataSetMapping> SetUnmappedReplacementLocations(
-        this InstanceSetters<DataSetMapping> setters,
-        List<UnmappedLocation> unmappedLocations
-    ) => setters.Set(m => m.UnmappedReplacementLocations, unmappedLocations);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -20,7 +20,6 @@ public record DataSetMapping
     public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; init; } = null!;
 
     public Dictionary<Guid, LocationMapping> LocationMappings { get; init; } = null!;
-    public List<UnmappedLocation> UnmappedReplacementLocations { get; init; } = [];
 
     public Dictionary<Guid, FilterMapping> FilterMappings { get; set; } = null!; // EES-7370 Change set -> init
 
@@ -73,16 +72,6 @@ public record DataSetMapping
                 .HasColumnType("nvarchar(max)");
 
             builder
-                .Property(x => x.UnmappedReplacementLocations)
-                .HasConversion(
-                    unmappedLocations => JsonSerializer.Serialize(unmappedLocations, JsonOptions),
-                    unmappedLocationsString =>
-                        JsonSerializer.Deserialize<List<UnmappedLocation>>(unmappedLocationsString, JsonOptions)
-                        ?? new List<UnmappedLocation>(),
-                    ValueComparer.CreateDefault<List<UnmappedLocation>>(false)
-                );
-
-            builder
                 .Property(x => x.FilterMappings)
                 .HasConversion(
                     filterMappings => JsonSerializer.Serialize(filterMappings, JsonOptions),
@@ -119,14 +108,6 @@ public record IndicatorMapping
     public string? ReplacementGroupLabel { get; set; }
 
     public MapStatus Status { get; set; }
-}
-
-public record UnmappedLocation
-{
-    public Guid Id { get; set; }
-    public GeographicLevel GeographicLevel { get; set; }
-    public string Code { get; set; } = "";
-    public string Name { get; set; } = "";
 }
 
 public record LocationMapping

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataSetMappingServiceTests.cs
@@ -617,8 +617,6 @@ public class DataSetMappingServiceTests
                 },
                 dbDataSetMapping.LocationMappings
             );
-
-            Assert.Empty(dbDataSetMapping.UnmappedReplacementLocations);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using AngleSharp.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -35,7 +35,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             replacementFile.SubjectId!.Value
         );
 
-        var (locationMappings, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
+        var locationMappings = await GenerateInitialLocationMapping(
             statisticsDbContext,
             originalFile.SubjectId!.Value,
             replacementFile.SubjectId!.Value
@@ -53,7 +53,6 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = indicatorMappings,
             LocationMappings = locationMappings,
-            UnmappedReplacementLocations = unmappedReplacementLocations,
             FilterMappings = filterMappings,
         };
 
@@ -116,7 +115,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
         return indicatorMappings;
     }
 
-    private async Task<(Dictionary<Guid, LocationMapping>, List<UnmappedLocation>)> GenerateInitialLocationMapping(
+    private async Task<Dictionary<Guid, LocationMapping>> GenerateInitialLocationMapping(
         StatisticsDbContext statisticsDbContext,
         Guid originalSubjectId,
         Guid replacementSubjectId
@@ -171,22 +170,7 @@ public class DataSetMappingService(IDbContextSupplier dbContextSupplier) : IData
             }
         );
 
-        var mappedReplacementLocationIds = locationMappings
-            .Values.Where(map => map.ReplacementId.HasValue)
-            .Select(map => map.ReplacementId!.Value);
-
-        var unmappedReplacementLocations = replacementIdToLocationMap
-            .Values.ExceptBy(mappedReplacementLocationIds, location => location.Id)
-            .Select(location => new UnmappedLocation
-            {
-                Id = location.Id,
-                Code = location.ToLocationAttribute().GetCodeOrFallback(),
-                Name = location.ToLocationAttribute().Name ?? "",
-                GeographicLevel = location.GeographicLevel,
-            })
-            .ToList();
-
-        return (locationMappings, unmappedReplacementLocations);
+        return locationMappings;
     }
 
     private static async Task<Dictionary<Guid, FilterMapping>> GenerateInitialFilterMapping(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using AngleSharp.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;


### PR DESCRIPTION
This PR simplifies location mapping code by removing DataSetMapping.UnmappedReplacementLocations. This mean we don't have to manage a list of unmapped locations anymore - if we need to know whether an locations is unmapped, we just calculate it in-place.

This work was born out of discussions with Jack on EES-7281. I had realised the possibilities for simplifying the work, but considered it too much work to be worth actually going through with, but Jack then used the AI to give us a good sense of what it could look like, at which we were both on board for doing this work.

🚨 This should merged after https://github.com/dfe-analytical-services/explore-education-statistics/pull/7274 🚨

### Other changes

- Removed a BOMs from several files that had them - they've caused us issues in the past so decided to just remove them.