### PR TITLE
EES-7560 Fix frontend/backend name mismatch bug

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
@@ -199,8 +199,8 @@ export default function DataFileReplacementDifferences({
         replacementFileId,
         [
           {
-            originalLocationId: sourceKey,
-            newReplacementLocationId: candidateKey,
+            originalId: sourceKey,
+            newReplacementId: candidateKey,
           },
         ],
       );

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -278,8 +278,8 @@ const dataReplacementService = {
     originalDataFileId: string,
     replacementDataFileId: string,
     updates: {
-      originalLocationId: string;
-      newReplacementLocationId?: string;
+      originalId: string;
+      newReplacementId?: string;
     }[],
   ): Promise<DataReplacementPlan['mapping']['locations']['mappings']> {
     const locationMappings: PlanMappingLocationUpdateResponse =


### PR DESCRIPTION
This PR fixes a bug I introduced by renaming the backend request to update a location mapping from the name originalLocationId -> originalId and newReplacementLocationId -> newReplacementId.

Not a lot else to say about it!