### PR TITLE
EES-7314 reinstate dependency-review action to fail instead of warn

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,5 +13,3 @@ jobs:
         uses: actions/checkout@v7
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v5.0.0
-        with:
-          warn-only: true


### PR DESCRIPTION
To be able to successfully update pnpm and merge into dev, we had to temporarily disable the dependency review action from failing the CI (it was treating **all** project dependencies as newly-added, and failing on pre-existing security advisories)

This PR sets it back to proper checking and handling of security vulnerabilities - now that dev has the updated pnpm lockfile as the baseline.

PR that added this warn only - https://github.com/dfe-analytical-services/explore-education-statistics/pull/7275