### PR TITLE
EES-7274 - Send UI test pipeline summary to Teams

### DIFF
--- a/azure-pipelines-ui-tests.yml
+++ b/azure-pipelines-ui-tests.yml
@@ -58,3 +58,66 @@ jobs:
     displayName: Seed data suite - Robot UI tests
     testFolder: tests/seed_data
     artifactName: test-results-seed-data
+
+- job: NotifyTeams
+  displayName: Send UI test pipeline summary to Teams
+  dependsOn:
+  - Public
+  - PublishAndAmend
+  - Admin
+  - AdminAndPublic
+  - PublicAPI
+  - SeedData
+  condition: always()
+  pool: ees-ubuntu2204-large
+  variables:
+    publicResult: $[ dependencies.Public.result ]
+    publishAndAmendResult: $[ dependencies.PublishAndAmend.result ]
+    adminResult: $[ dependencies.Admin.result ]
+    adminAndPublicResult: $[ dependencies.AdminAndPublic.result ]
+    publicApiResult: $[ dependencies.PublicAPI.result ]
+    seedDataResult: $[ dependencies.SeedData.result ]
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
+    fetchTags: false
+
+  - task: UsePythonVersion@0
+    displayName: Use Python 3.10
+    timeoutInMinutes: 5
+    inputs:
+      versionSpec: 3.10
+
+  - task: AzureKeyVault@2
+    displayName: Azure Key Vault - s101d01-kv-ees-01
+    continueOnError: true
+    inputs:
+      azureSubscription: $(SPN_NAME)
+      KeyVaultName: s101d01-kv-ees-01
+      SecretsFilter: ees-alerts-teams-uitests-webhookurl
+      RunAsPreJob: true
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download UI test artifacts
+    continueOnError: true
+    inputs:
+      buildType: current
+      targetPath: $(Pipeline.Workspace)/ui-test-results
+
+  - task: PythonScript@0
+    displayName: Send Teams summary
+    condition: always()
+    continueOnError: true
+    inputs:
+      scriptPath: tests/robot-tests/scripts/send_teams_pipeline_report.py
+      arguments: --artifacts-dir "$(Pipeline.Workspace)/ui-test-results" --environment dev
+      workingDirectory: tests/robot-tests
+    env:
+      TEAMS_UI_TESTS_WEBHOOK_URL: $(ees-alerts-teams-uitests-webhookurl)
+      UI_TEST_PUBLIC_RESULT: $(publicResult)
+      UI_TEST_PUBLISH_AND_AMEND_RESULT: $(publishAndAmendResult)
+      UI_TEST_ADMIN_RESULT: $(adminResult)
+      UI_TEST_ADMIN_AND_PUBLIC_RESULT: $(adminAndPublicResult)
+      UI_TEST_PUBLIC_API_RESULT: $(publicApiResult)
+      UI_TEST_SEED_DATA_RESULT: $(seedDataResult)

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -216,9 +216,13 @@ def run():
 
     except Exception as ex:
         if args.enable_slack_notifications:
-            slack_service = SlackService()
-            slack_service.send_exception_details(args.env, args.tests, number_of_test_runs, ex)
-        raise ex
+            try:
+                slack_service = SlackService()
+                slack_service.send_exception_details(args.env, args.tests, test_run_index, ex)
+            except Exception as notification_ex:
+                logger.error("Unable to send UI test exception details to Slack")
+                logger.error(notification_ex)
+        raise
 
 
 current_dir = Path(__file__).absolute().parent

--- a/tests/robot-tests/scripts/send_teams_pipeline_report.py
+++ b/tests/robot-tests/scripts/send_teams_pipeline_report.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import sys
+from pathlib import Path
+
+ROBOT_TESTS_DIRECTORY = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROBOT_TESTS_DIRECTORY))
+
+from tests.libs.logger import get_logger  # noqa: E402
+from tests.libs.teams import (  # noqa: E402
+    SuiteDefinition,
+    TeamsService,
+    build_pipeline_report_card,
+    collect_suite_results,
+    get_pipeline_artifacts_url,
+)
+
+logger = get_logger(__name__)
+
+SUITES = [
+    ("Public", "test-results-public", "UI_TEST_PUBLIC_RESULT"),
+    ("Publish and amend", "test-results-admin-and-public-2", "UI_TEST_PUBLISH_AND_AMEND_RESULT"),
+    ("Admin", "test-results-admin", "UI_TEST_ADMIN_RESULT"),
+    ("Admin and public", "test-results-admin-public", "UI_TEST_ADMIN_AND_PUBLIC_RESULT"),
+    ("Public API", "test-results-admin-public-api", "UI_TEST_PUBLIC_API_RESULT"),
+    ("Seed data", "test-results-seed-data", "UI_TEST_SEED_DATA_RESULT"),
+]
+
+
+def send_pipeline_report(artifacts_directory: Path, environment: str) -> bool:
+    suites = [
+        SuiteDefinition(
+            name=name,
+            artifact_name=artifact_name,
+            dependency_status=os.getenv(status_environment_variable, "unknown"),
+        )
+        for name, artifact_name, status_environment_variable in SUITES
+    ]
+    results = collect_suite_results(artifacts_directory, suites)
+    artifacts_url = get_pipeline_artifacts_url(
+        collection_uri=os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", ""),
+        project=os.getenv("SYSTEM_TEAMPROJECT", ""),
+        build_id=os.getenv("BUILD_BUILDID", ""),
+    )
+    card = build_pipeline_report_card(environment, results, artifacts_url)
+    return TeamsService().send_pipeline_report(card)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send the completed UI test pipeline report to Teams")
+    parser.add_argument("--artifacts-dir", type=Path, required=True, help="directory containing downloaded artifacts")
+    parser.add_argument("--environment", default="dev", help="environment tested by the UI test pipeline")
+    args = parser.parse_args()
+
+    try:
+        send_pipeline_report(args.artifacts_dir, args.environment)
+    except Exception as ex:
+        # Notification reporting must never change the result of the UI test pipeline.
+        logger.warning(f"Unable to create UI test report for Teams: {ex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/robot-tests/tests/libs/teams.py
+++ b/tests/robot-tests/tests/libs/teams.py
@@ -1,0 +1,257 @@
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+from xml.etree import ElementTree
+
+from tests.libs.logger import get_logger
+
+logger = get_logger(__name__)
+
+PASSED = "passed"
+FAILED = "failed"
+FLAKY = "flaky"
+UNAVAILABLE = "results unavailable"
+
+SUCCESSFUL_JOB_STATUSES = {"succeeded", "succeededwithissues"}
+
+
+@dataclass(frozen=True)
+class SuiteDefinition:
+    name: str
+    artifact_name: str
+    dependency_status: str
+
+
+@dataclass(frozen=True)
+class SuiteResult:
+    name: str
+    artifact_name: str
+    dependency_status: str
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    run_attempts: int = 0
+    final_failures: int = 0
+    classification: str = UNAVAILABLE
+
+    @property
+    def total(self) -> int:
+        return self.passed + self.failed + self.skipped
+
+
+def _read_totals(report_path: Path) -> tuple[int, int, int]:
+    report = ElementTree.parse(report_path)
+    total = report.find("./statistics/total/stat")
+
+    if total is None:
+        raise ValueError(f"Unable to find total statistics in {report_path}")
+
+    return int(total.attrib["pass"]), int(total.attrib["fail"]), int(total.attrib["skip"])
+
+
+def _get_run_number(run_directory: Path) -> Optional[int]:
+    match = re.fullmatch(r"run-(\d+)", run_directory.name)
+    return int(match.group(1)) if match else None
+
+
+def collect_suite_result(artifacts_directory: Path, suite: SuiteDefinition) -> SuiteResult:
+    artifact_directory = artifacts_directory / suite.artifact_name
+    merged_report_path = artifact_directory / "output.xml"
+
+    try:
+        passed, failed, skipped = _read_totals(merged_report_path)
+        run_directories = [
+            (run_number, run_directory)
+            for run_directory in artifact_directory.glob("run-*")
+            if (run_number := _get_run_number(run_directory)) is not None
+        ]
+
+        if not run_directories:
+            raise ValueError(f"Unable to find test run reports in {artifact_directory}")
+
+        _, final_run_directory = max(run_directories, key=lambda run: run[0])
+        _, final_failures, _ = _read_totals(final_run_directory / "output.xml")
+    except (ElementTree.ParseError, OSError, KeyError, TypeError, ValueError) as ex:
+        logger.warning(f'Unable to read results for "{suite.name}": {ex}')
+        return SuiteResult(
+            name=suite.name,
+            artifact_name=suite.artifact_name,
+            dependency_status=suite.dependency_status,
+        )
+
+    dependency_succeeded = suite.dependency_status.lower() in SUCCESSFUL_JOB_STATUSES
+
+    if final_failures > 0 or suite.dependency_status.lower() == "failed":
+        classification = FAILED
+    elif not dependency_succeeded:
+        classification = UNAVAILABLE
+    elif len(run_directories) > 1:
+        classification = FLAKY
+    else:
+        classification = PASSED
+
+    return SuiteResult(
+        name=suite.name,
+        artifact_name=suite.artifact_name,
+        dependency_status=suite.dependency_status,
+        passed=passed,
+        failed=failed,
+        skipped=skipped,
+        run_attempts=len(run_directories),
+        final_failures=final_failures,
+        classification=classification,
+    )
+
+
+def collect_suite_results(artifacts_directory: Path, suites: list[SuiteDefinition]) -> list[SuiteResult]:
+    return [collect_suite_result(artifacts_directory, suite) for suite in suites]
+
+
+def get_pipeline_artifacts_url(collection_uri: str, project: str, build_id: str) -> Optional[str]:
+    if not collection_uri or not project or not build_id:
+        return None
+
+    encoded_project = quote(project, safe="")
+    encoded_build_id = quote(build_id, safe="")
+    return (
+        f"{collection_uri.rstrip('/')}/{encoded_project}/_build/results"
+        f"?buildId={encoded_build_id}&view=artifacts&pathAsName=false&type=publishedArtifacts"
+    )
+
+
+def _get_pipeline_status(results: list[SuiteResult]) -> tuple[str, str, str]:
+    if any(result.classification in {FAILED, UNAVAILABLE} for result in results):
+        return "❌", "attention", "UI test pipeline completed with failures"
+    if any(result.classification == FLAKY for result in results):
+        return "⚠️", "warning", "UI test pipeline completed with flaky tests"
+    return "✅", "good", "UI test pipeline passed"
+
+
+def _format_attention_result(result: SuiteResult) -> str:
+    if result.classification == UNAVAILABLE:
+        detail = f"job status: {result.dependency_status or 'unknown'}"
+    elif result.classification == FLAKY:
+        detail = f"passed after {result.run_attempts} attempts"
+    elif result.final_failures == 0:
+        detail = f"job status: {result.dependency_status or 'unknown'}"
+    else:
+        detail = f"{result.final_failures} final failures after {result.run_attempts} attempts"
+
+    return f"- **{result.name}** — {result.classification}; `{result.artifact_name}`; {detail}"
+
+
+def build_pipeline_report_card(
+    environment: str,
+    results: list[SuiteResult],
+    artifacts_url: Optional[str],
+) -> dict:
+    status_emoji, status_color, title = _get_pipeline_status(results)
+    attention_results = [result for result in results if result.classification != PASSED]
+
+    facts = [
+        {"title": "Environment", "value": environment},
+        {"title": "Test suites", "value": str(len(results))},
+        {"title": "Total test cases", "value": str(sum(result.total for result in results))},
+        {"title": "Passed test cases", "value": str(sum(result.passed for result in results))},
+        {"title": "Failed test cases", "value": str(sum(result.failed for result in results))},
+        {"title": "Skipped test cases", "value": str(sum(result.skipped for result in results))},
+        {
+            "title": "Flaky suites",
+            "value": str(sum(result.classification == FLAKY for result in results)),
+        },
+        {
+            "title": "Unavailable results",
+            "value": str(sum(result.classification == UNAVAILABLE for result in results)),
+        },
+    ]
+
+    body = [
+        {
+            "type": "TextBlock",
+            "size": "Large",
+            "weight": "Bolder",
+            "text": f"{status_emoji} {title}",
+            "style": "heading",
+            "color": status_color,
+            "wrap": True,
+        },
+        {"type": "FactSet", "facts": facts},
+    ]
+
+    if attention_results:
+        body.extend(
+            [
+                {
+                    "type": "TextBlock",
+                    "weight": "Bolder",
+                    "text": "Failed, flaky or unavailable suites",
+                    "separator": True,
+                    "spacing": "Medium",
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "\n".join(_format_attention_result(result) for result in attention_results),
+                    "wrap": True,
+                },
+            ]
+        )
+
+    content = {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": body,
+    }
+
+    if artifacts_url:
+        content["actions"] = [
+            {
+                "type": "Action.OpenUrl",
+                "title": "View pipeline artifacts",
+                "url": artifacts_url,
+            }
+        ]
+
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": content,
+            }
+        ],
+    }
+
+
+class TeamsService:
+    def __init__(self, webhook_url: Optional[str] = None):
+        self.webhook_url = webhook_url or os.getenv("TEAMS_UI_TESTS_WEBHOOK_URL")
+
+    def send_pipeline_report(self, card: dict) -> bool:
+        if not self.webhook_url:
+            logger.warning("TEAMS_UI_TESTS_WEBHOOK_URL is not set; skipping Teams notification")
+            return False
+
+        try:
+            request = Request(
+                self.webhook_url,
+                data=json.dumps(card).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urlopen(request, timeout=30) as response:
+                if not 200 <= response.status < 300:
+                    logger.warning(f"Teams webhook returned HTTP {response.status}")
+                    return False
+        except (HTTPError, URLError, TimeoutError, ValueError) as ex:
+            logger.warning(f"Unable to send UI test report to Teams: {ex}")
+            return False
+
+        logger.info("Sent UI test pipeline report to Teams")
+        return True

--- a/tests/robot-tests/tests/libs/teams_test.py
+++ b/tests/robot-tests/tests/libs/teams_test.py
@@ -1,0 +1,247 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+from scripts.send_teams_pipeline_report import SUITES, send_pipeline_report
+from tests.libs.teams import (
+    FAILED,
+    FLAKY,
+    PASSED,
+    UNAVAILABLE,
+    SuiteDefinition,
+    SuiteResult,
+    TeamsService,
+    build_pipeline_report_card,
+    collect_suite_result,
+    get_pipeline_artifacts_url,
+)
+
+
+def _write_report(path: Path, passed: int, failed: int, skipped: int):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "<robot><statistics><total>"
+        f'<stat pass="{passed}" fail="{failed}" skip="{skipped}" />'
+        "</total></statistics></robot>",
+        encoding="utf-8",
+    )
+
+
+class CollectSuiteResultTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.artifacts_directory = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def create_suite(self, dependency_status: str = "Succeeded") -> SuiteDefinition:
+        return SuiteDefinition(
+            name="Public & API",
+            artifact_name="test-results-public-api",
+            dependency_status=dependency_status,
+        )
+
+    def write_suite_reports(
+        self,
+        merged: tuple[int, int, int],
+        final: tuple[int, int, int],
+        run_attempts: int = 1,
+    ):
+        artifact_directory = self.artifacts_directory / "test-results-public-api"
+        _write_report(artifact_directory / "output.xml", *merged)
+
+        for run_attempt in range(1, run_attempts + 1):
+            run_totals = final if run_attempt == run_attempts else merged
+            _write_report(artifact_directory / f"run-{run_attempt}" / "output.xml", *run_totals)
+
+    def test_classifies_passing_suite(self):
+        self.write_suite_reports(merged=(8, 0, 1), final=(8, 0, 1))
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite())
+
+        self.assertEqual(PASSED, result.classification)
+        self.assertEqual((8, 0, 1, 1), (result.passed, result.failed, result.skipped, result.run_attempts))
+
+    def test_classifies_final_failures(self):
+        self.write_suite_reports(merged=(6, 2, 1), final=(0, 2, 0), run_attempts=3)
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite("Failed"))
+
+        self.assertEqual(FAILED, result.classification)
+        self.assertEqual(2, result.final_failures)
+        self.assertEqual(3, result.run_attempts)
+
+    def test_classifies_suite_that_passes_on_rerun_as_flaky(self):
+        self.write_suite_reports(merged=(8, 0, 1), final=(2, 0, 0), run_attempts=2)
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite())
+
+        self.assertEqual(FLAKY, result.classification)
+        self.assertEqual(2, result.run_attempts)
+
+    def test_classifies_failed_job_even_when_report_has_no_final_failures(self):
+        self.write_suite_reports(merged=(8, 0, 1), final=(8, 0, 1))
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite("Failed"))
+
+        self.assertEqual(FAILED, result.classification)
+
+        card = build_pipeline_report_card("dev", [result], None)
+        self.assertIn("job status: Failed", card["attachments"][0]["content"]["body"][3]["text"])
+
+    def test_classifies_canceled_job_with_a_report_as_unavailable(self):
+        self.write_suite_reports(merged=(8, 0, 1), final=(8, 0, 1))
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite("Canceled"))
+
+        self.assertEqual(UNAVAILABLE, result.classification)
+
+    def test_classifies_missing_report_as_unavailable(self):
+        result = collect_suite_result(self.artifacts_directory, self.create_suite("Canceled"))
+
+        self.assertEqual(UNAVAILABLE, result.classification)
+        self.assertEqual("test-results-public-api", result.artifact_name)
+
+    def test_classifies_malformed_report_as_unavailable(self):
+        report_path = self.artifacts_directory / "test-results-public-api" / "output.xml"
+        report_path.parent.mkdir(parents=True)
+        report_path.write_text("not xml", encoding="utf-8")
+
+        result = collect_suite_result(self.artifacts_directory, self.create_suite())
+
+        self.assertEqual(UNAVAILABLE, result.classification)
+
+
+class BuildPipelineReportCardTests(unittest.TestCase):
+    def test_builds_aggregate_card_with_only_attention_suites(self):
+        results = [
+            SuiteResult("Public", "public-artifact", "Succeeded", 10, 0, 1, 1, 0, PASSED),
+            SuiteResult("Admin & public", "admin & artifact", "Failed", 8, 2, 3, 3, 2, FAILED),
+            SuiteResult("Public API", "api-artifact", "Succeeded", 7, 0, 0, 2, 0, FLAKY),
+            SuiteResult("Seed data", "seed-artifact", "Canceled"),
+        ]
+        artifacts_url = "https://dev.azure.com/example/project/_build/results?buildId=123&view=artifacts"
+
+        card = build_pipeline_report_card("dev", results, artifacts_url)
+
+        content = card["attachments"][0]["content"]
+        facts = content["body"][1]["facts"]
+        details = content["body"][3]["text"]
+        self.assertEqual("31", next(fact["value"] for fact in facts if fact["title"] == "Total test cases"))
+        self.assertNotIn("**Public**", details)
+        self.assertIn("**Admin & public**", details)
+        self.assertIn("`admin & artifact`", details)
+        self.assertIn("**Public API**", details)
+        self.assertIn("**Seed data**", details)
+        self.assertEqual(artifacts_url, content["actions"][0]["url"])
+        self.assertEqual(1, len(content["actions"]))
+
+    def test_builds_success_card_without_attention_section(self):
+        results = [
+            SuiteResult(f"Suite {index}", f"artifact-{index}", "Succeeded", 10, 0, 0, 1, 0, PASSED)
+            for index in range(1, 7)
+        ]
+
+        card = build_pipeline_report_card("dev", results, None)
+
+        content = card["attachments"][0]["content"]
+        self.assertEqual(2, len(content["body"]))
+        self.assertNotIn("actions", content)
+        self.assertIn("pipeline passed", content["body"][0]["text"])
+        self.assertEqual("6", content["body"][1]["facts"][1]["value"])
+
+    def test_encodes_project_and_build_id_in_artifacts_url(self):
+        url = get_pipeline_artifacts_url(
+            "https://dev.azure.com/example/",
+            "Education & Statistics",
+            "build/123",
+        )
+
+        self.assertEqual(
+            "https://dev.azure.com/example/Education%20%26%20Statistics/_build/results"
+            "?buildId=build%2F123&view=artifacts&pathAsName=false&type=publishedArtifacts",
+            url,
+        )
+
+    def test_returns_no_artifacts_url_when_build_context_is_missing(self):
+        self.assertIsNone(get_pipeline_artifacts_url("", "project", "123"))
+        self.assertIsNone(get_pipeline_artifacts_url("https://dev.azure.com/example", "", "123"))
+        self.assertIsNone(get_pipeline_artifacts_url("https://dev.azure.com/example", "project", ""))
+
+
+class TeamsServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.card = {"type": "message"}
+
+    @patch("tests.libs.teams.urlopen")
+    def test_returns_true_for_successful_webhook_response(self, urlopen_mock):
+        response = MagicMock()
+        response.status = 200
+        urlopen_mock.return_value.__enter__.return_value = response
+
+        result = TeamsService("https://example.com/webhook").send_pipeline_report(self.card)
+
+        self.assertTrue(result)
+        request = urlopen_mock.call_args.args[0]
+        self.assertEqual("POST", request.method)
+        self.assertEqual("application/json", request.headers["Content-type"])
+
+    @patch("tests.libs.teams.urlopen", side_effect=TimeoutError("timed out"))
+    def test_returns_false_for_webhook_timeout(self, _):
+        self.assertFalse(TeamsService("https://example.com/webhook").send_pipeline_report(self.card))
+
+    @patch("tests.libs.teams.urlopen", side_effect=URLError("unavailable"))
+    def test_returns_false_for_webhook_connection_error(self, _):
+        self.assertFalse(TeamsService("https://example.com/webhook").send_pipeline_report(self.card))
+
+    @patch("tests.libs.teams.urlopen")
+    def test_returns_false_for_webhook_http_error(self, urlopen_mock):
+        urlopen_mock.side_effect = HTTPError("https://example.com", 500, "failure", {}, None)
+
+        self.assertFalse(TeamsService("https://example.com/webhook").send_pipeline_report(self.card))
+
+    def test_returns_false_for_malformed_webhook_url(self):
+        self.assertFalse(TeamsService("://bad-url").send_pipeline_report(self.card))
+
+    def test_returns_false_when_webhook_is_missing(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(TeamsService().send_pipeline_report(self.card))
+
+
+class SendPipelineReportTests(unittest.TestCase):
+    @patch("scripts.send_teams_pipeline_report.TeamsService")
+    def test_sends_one_card_containing_all_six_suites(self, teams_service_mock):
+        teams_service_mock.return_value.send_pipeline_report.return_value = True
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            artifacts_directory = Path(temporary_directory)
+            for _, artifact_name, _ in SUITES:
+                _write_report(artifacts_directory / artifact_name / "output.xml", 10, 0, 0)
+                _write_report(artifacts_directory / artifact_name / "run-1" / "output.xml", 10, 0, 0)
+
+            environment = {status_environment_variable: "Succeeded" for _, _, status_environment_variable in SUITES}
+            environment.update(
+                {
+                    "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI": "https://dev.azure.com/example/",
+                    "SYSTEM_TEAMPROJECT": "Education Statistics",
+                    "BUILD_BUILDID": "123",
+                    "TEAMS_UI_TESTS_WEBHOOK_URL": "https://example.com/webhook",
+                }
+            )
+
+            with patch.dict("os.environ", environment, clear=True):
+                result = send_pipeline_report(artifacts_directory, "dev")
+
+        self.assertTrue(result)
+        teams_service_mock.return_value.send_pipeline_report.assert_called_once()
+        card = teams_service_mock.return_value.send_pipeline_report.call_args.args[0]
+        facts = card["attachments"][0]["content"]["body"][1]["facts"]
+        self.assertEqual("6", next(fact["value"] for fact in facts if fact["title"] == "Test suites"))
+        self.assertEqual("60", next(fact["value"] for fact in facts if fact["title"] == "Total test cases"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a single Microsoft Teams notification when the UI-test pipeline completes.

The notification:

- Aggregates results from all six UI-test suites.
- Highlights failed, flaky, or unavailable suites.
- Links to the pipeline artifacts.
- Does not affect test results if Teams notification delivery fails.

The existing Slack integration posts an individual message for each test suite and attaches its full test report as a ZIP file in the message thread. The Teams integration uses an incoming webhook, which does not support uploading file attachments or adding threaded file replies in the same way. Teams therefore receives one consolidated summary message with a link to the Azure pipeline artifacts instead.

Existing Slack notifications remain unchanged.