### PR TITLE
EES-7545 datablock origin display

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -385,6 +385,21 @@ public class DataBlockServiceTests
     {
         ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());
 
+        var subjectId1 = Guid.NewGuid();
+        var subjectId2 = Guid.NewGuid();
+
+        ReleaseFile dataReleaseFile1 = _fixture
+            .DefaultReleaseFile()
+            .WithReleaseVersion(releaseVersion)
+            .WithName("Test data set name 1")
+            .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId1));
+
+        ReleaseFile dataReleaseFile2 = _fixture
+            .DefaultReleaseFile()
+            .WithReleaseVersion(releaseVersion)
+            .WithName("Test data set name 2")
+            .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId2));
+
         var dataBlock1 = new DataBlock
         {
             Heading = "Test heading 1",
@@ -395,6 +410,7 @@ public class DataBlockServiceTests
             ContentSectionId = Guid.NewGuid(),
             Query = new FullTableQuery
             {
+                SubjectId = subjectId1,
                 Filters = new List<Guid> { Guid.NewGuid() },
                 Indicators = new List<Guid> { Guid.NewGuid() },
             },
@@ -440,6 +456,7 @@ public class DataBlockServiceTests
             Created = new DateTime(2001, 2, 2),
             Query = new FullTableQuery
             {
+                SubjectId = subjectId2,
                 Filters = new List<Guid> { Guid.NewGuid() },
                 Indicators = new List<Guid> { Guid.NewGuid() },
             },
@@ -474,6 +491,7 @@ public class DataBlockServiceTests
         {
             await context.AddRangeAsync(dataBlock1, dataBlock2);
             await context.FeaturedTables.AddRangeAsync(featuredTable1, featuredTable2);
+            await context.ReleaseFiles.AddRangeAsync(dataReleaseFile1, dataReleaseFile2);
             await context.SaveChangesAsync();
         }
 
@@ -492,6 +510,7 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable1.Name, listResult[0].HighlightName);
             Assert.Equal(featuredTable1.Description, listResult[0].HighlightDescription);
             Assert.Equal(dataBlock1.Source, listResult[0].Source);
+            Assert.Equal("Test data set name 1", listResult[0].DataSetName);
             Assert.Equal(1, listResult[0].ChartsCount);
             Assert.True(listResult[0].InContent);
 
@@ -501,13 +520,14 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable2.Name, listResult[1].HighlightName);
             Assert.Equal(featuredTable2.Description, listResult[1].HighlightDescription);
             Assert.Equal(dataBlock2.Source, listResult[1].Source);
+            Assert.Equal("Test data set name 2", listResult[1].DataSetName);
             Assert.Equal(0, listResult[1].ChartsCount);
             Assert.False(listResult[1].InContent);
         }
     }
 
     [Fact]
-    public async Task List_SetsDataSetNameFromDataBlockSubject()
+    public async Task List_KeyStatisticInContent()
     {
         ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());
 
@@ -519,48 +539,12 @@ public class DataBlockServiceTests
             .WithName("Test data set name")
             .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId));
 
-        var dataBlockWithDataSet = new DataBlock
+        var dataBlock = new DataBlock
         {
-            Name = "Test name 1",
+            ContentSectionId = null,
             Query = new FullTableQuery { SubjectId = subjectId },
             ReleaseVersion = releaseVersion,
         };
-
-        var dataBlockWithoutDataSet = new DataBlock
-        {
-            Name = "Test name 2",
-            Query = new FullTableQuery { SubjectId = Guid.NewGuid() },
-            ReleaseVersion = releaseVersion,
-        };
-
-        var contextId = Guid.NewGuid().ToString();
-
-        await using (var context = InMemoryContentDbContext(contextId))
-        {
-            await context.AddRangeAsync(dataBlockWithDataSet, dataBlockWithoutDataSet);
-            await context.ReleaseFiles.AddAsync(dataReleaseFile);
-            await context.SaveChangesAsync();
-        }
-
-        await using (var context = InMemoryContentDbContext(contextId))
-        {
-            var service = BuildDataBlockService(context);
-            var result = await service.List(releaseVersion.Id);
-
-            var listResult = result.AssertRight();
-
-            Assert.Equal(2, listResult.Count);
-            Assert.Equal("Test data set name", listResult[0].DataSetName);
-            Assert.Null(listResult[1].DataSetName);
-        }
-    }
-
-    [Fact]
-    public async Task List_KeyStatisticInContent()
-    {
-        ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());
-
-        var dataBlock = new DataBlock { ContentSectionId = null, ReleaseVersion = releaseVersion };
 
         var keyStatistic = new KeyStatisticDataBlock { ReleaseVersion = releaseVersion, DataBlock = dataBlock };
 
@@ -570,6 +554,7 @@ public class DataBlockServiceTests
         {
             await context.AddRangeAsync(dataBlock);
             await context.KeyStatisticsDataBlock.AddAsync(keyStatistic);
+            await context.ReleaseFiles.AddAsync(dataReleaseFile);
             await context.SaveChangesAsync();
         }
 
@@ -592,6 +577,14 @@ public class DataBlockServiceTests
     {
         ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());
 
+        var subjectId = Guid.NewGuid();
+
+        ReleaseFile dataReleaseFile = _fixture
+            .DefaultReleaseFile()
+            .WithReleaseVersion(releaseVersion)
+            .WithName("Test data set name")
+            .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId));
+
         var relatedDataBlock = new DataBlock
         {
             Heading = "Test heading 1",
@@ -602,6 +595,7 @@ public class DataBlockServiceTests
             ContentSectionId = Guid.NewGuid(),
             Query = new FullTableQuery
             {
+                SubjectId = subjectId,
                 Filters = new List<Guid> { Guid.NewGuid() },
                 Indicators = new List<Guid> { Guid.NewGuid() },
             },
@@ -650,6 +644,7 @@ public class DataBlockServiceTests
         {
             await context.AddRangeAsync(relatedDataBlock, unrelatedDataBlock);
             await context.FeaturedTables.AddAsync(featuredTable1);
+            await context.ReleaseFiles.AddAsync(dataReleaseFile);
             await context.SaveChangesAsync();
         }
 
@@ -666,6 +661,7 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable1.Name, viewModel.HighlightName);
             Assert.Equal(featuredTable1.Description, viewModel.HighlightDescription);
             Assert.Equal(relatedDataBlock.Source, viewModel.Source);
+            Assert.Equal("Test data set name", viewModel.DataSetName);
             Assert.Equal(1, viewModel.ChartsCount);
             Assert.True(viewModel.InContent);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -507,6 +507,55 @@ public class DataBlockServiceTests
     }
 
     [Fact]
+    public async Task List_SetsDataSetNameFromDataBlockSubject()
+    {
+        ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());
+
+        var subjectId = Guid.NewGuid();
+
+        ReleaseFile dataReleaseFile = _fixture
+            .DefaultReleaseFile()
+            .WithReleaseVersion(releaseVersion)
+            .WithName("Test data set name")
+            .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId));
+
+        var dataBlockWithDataSet = new DataBlock
+        {
+            Name = "Test name 1",
+            Query = new FullTableQuery { SubjectId = subjectId },
+            ReleaseVersion = releaseVersion,
+        };
+
+        var dataBlockWithoutDataSet = new DataBlock
+        {
+            Name = "Test name 2",
+            Query = new FullTableQuery { SubjectId = Guid.NewGuid() },
+            ReleaseVersion = releaseVersion,
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            await context.AddRangeAsync(dataBlockWithDataSet, dataBlockWithoutDataSet);
+            await context.ReleaseFiles.AddAsync(dataReleaseFile);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryContentDbContext(contextId))
+        {
+            var service = BuildDataBlockService(context);
+            var result = await service.List(releaseVersion.Id);
+
+            var listResult = result.AssertRight();
+
+            Assert.Equal(2, listResult.Count);
+            Assert.Equal("Test data set name", listResult[0].DataSetName);
+            Assert.Null(listResult[1].DataSetName);
+        }
+    }
+
+    [Fact]
     public async Task List_KeyStatisticInContent()
     {
         ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion().WithRelease(_fixture.DefaultRelease());

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -391,13 +391,13 @@ public class DataBlockServiceTests
         ReleaseFile dataReleaseFile1 = _fixture
             .DefaultReleaseFile()
             .WithReleaseVersion(releaseVersion)
-            .WithName("Test data set name 1")
+            .WithName("Test data set title 1")
             .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId1));
 
         ReleaseFile dataReleaseFile2 = _fixture
             .DefaultReleaseFile()
             .WithReleaseVersion(releaseVersion)
-            .WithName("Test data set name 2")
+            .WithName("Test data set title 2")
             .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId2));
 
         var dataBlock1 = new DataBlock
@@ -510,7 +510,7 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable1.Name, listResult[0].HighlightName);
             Assert.Equal(featuredTable1.Description, listResult[0].HighlightDescription);
             Assert.Equal(dataBlock1.Source, listResult[0].Source);
-            Assert.Equal("Test data set name 1", listResult[0].DataSetName);
+            Assert.Equal("Test data set title 1", listResult[0].DataSetTitle);
             Assert.Equal(1, listResult[0].ChartsCount);
             Assert.True(listResult[0].InContent);
 
@@ -520,7 +520,7 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable2.Name, listResult[1].HighlightName);
             Assert.Equal(featuredTable2.Description, listResult[1].HighlightDescription);
             Assert.Equal(dataBlock2.Source, listResult[1].Source);
-            Assert.Equal("Test data set name 2", listResult[1].DataSetName);
+            Assert.Equal("Test data set title 2", listResult[1].DataSetTitle);
             Assert.Equal(0, listResult[1].ChartsCount);
             Assert.False(listResult[1].InContent);
         }
@@ -582,7 +582,7 @@ public class DataBlockServiceTests
         ReleaseFile dataReleaseFile = _fixture
             .DefaultReleaseFile()
             .WithReleaseVersion(releaseVersion)
-            .WithName("Test data set name")
+            .WithName("Test data set title")
             .WithFile(_fixture.DefaultFile().WithType(FileType.Data).WithSubjectId(subjectId));
 
         var relatedDataBlock = new DataBlock
@@ -661,7 +661,7 @@ public class DataBlockServiceTests
             Assert.Equal(featuredTable1.Name, viewModel.HighlightName);
             Assert.Equal(featuredTable1.Description, viewModel.HighlightDescription);
             Assert.Equal(relatedDataBlock.Source, viewModel.Source);
-            Assert.Equal("Test data set name", viewModel.DataSetName);
+            Assert.Equal("Test data set title", viewModel.DataSetTitle);
             Assert.Equal(1, viewModel.ChartsCount);
             Assert.True(viewModel.InContent);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -186,6 +186,8 @@ public class DataBlockService : IDataBlockService
                     .FeaturedTables.Where(ks => ks.ReleaseVersionId == releaseVersion.Id)
                     .ToListAsync();
 
+                var dataSetNamesBySubjectId = await GetDataSetNamesBySubjectId(releaseVersion.Id);
+
                 return dataBlocks
                     .Select(block =>
                     {
@@ -202,6 +204,9 @@ public class DataBlockService : IDataBlockService
                             HighlightName = featuredTable?.Name,
                             HighlightDescription = featuredTable?.Description,
                             Source = block.Source,
+                            DataSetName = block.Query is null
+                                ? null
+                                : dataSetNamesBySubjectId.GetValueOrDefault(block.Query.SubjectId),
                             ChartsCount = block.Charts.Count,
                             InContent = inContent,
                         };
@@ -491,6 +496,22 @@ public class DataBlockService : IDataBlockService
             && await _context
                 .KeyStatisticsDataBlock.Where(ks => ks.ReleaseVersionId == releaseVersionId)
                 .AllAsync(ks => ks.DataBlockId != dataBlockVersion.Id);
+    }
+
+    private async Task<Dictionary<Guid, string?>> GetDataSetNamesBySubjectId(Guid releaseVersionId)
+    {
+        var dataReleaseFiles = await _context
+            .ReleaseFiles.Where(rf =>
+                rf.ReleaseVersionId == releaseVersionId && rf.File.Type == FileType.Data && rf.File.SubjectId != null
+            )
+            .Select(rf => new { SubjectId = rf.File.SubjectId!.Value, rf.Name })
+            .ToListAsync();
+
+        // Group defensively - a release version should only have one data file per subject, but we
+        // don't want to throw here if that ever isn't the case.
+        return dataReleaseFiles
+            .GroupBy(rf => rf.SubjectId)
+            .ToDictionary(group => group.Key, group => group.First().Name);
     }
 
     public async Task<List<DataBlock>> ListDataBlocks(Guid releaseVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -204,9 +204,7 @@ public class DataBlockService : IDataBlockService
                             HighlightName = featuredTable?.Name,
                             HighlightDescription = featuredTable?.Description,
                             Source = block.Source,
-                            DataSetName = block.Query is null
-                                ? null
-                                : dataSetNamesBySubjectId.GetValueOrDefault(block.Query.SubjectId),
+                            DataSetName = dataSetNamesBySubjectId[block.Query.SubjectId],
                             ChartsCount = block.Charts.Count,
                             InContent = inContent,
                         };
@@ -498,20 +496,17 @@ public class DataBlockService : IDataBlockService
                 .AllAsync(ks => ks.DataBlockId != dataBlockVersion.Id);
     }
 
-    private async Task<Dictionary<Guid, string?>> GetDataSetNamesBySubjectId(Guid releaseVersionId)
+    private async Task<Dictionary<Guid, string>> GetDataSetNamesBySubjectId(Guid releaseVersionId)
     {
-        var dataReleaseFiles = await _context
+        return await _context
             .ReleaseFiles.Where(rf =>
-                rf.ReleaseVersionId == releaseVersionId && rf.File.Type == FileType.Data && rf.File.SubjectId != null
+                rf.ReleaseVersionId == releaseVersionId
+                && rf.File.Type == FileType.Data
+                // Replacements should not be linked to any DataBlocks, so no need to include them here
+                && rf.File.ReplacingId == null
             )
             .Select(rf => new { SubjectId = rf.File.SubjectId!.Value, rf.Name })
-            .ToListAsync();
-
-        // Group defensively - a release version should only have one data file per subject, but we
-        // don't want to throw here if that ever isn't the case.
-        return dataReleaseFiles
-            .GroupBy(rf => rf.SubjectId)
-            .ToDictionary(group => group.Key, group => group.First().Name);
+            .ToDictionaryAsync(rf => rf.SubjectId, rf => rf.Name!);
     }
 
     public async Task<List<DataBlock>> ListDataBlocks(Guid releaseVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -186,7 +186,7 @@ public class DataBlockService : IDataBlockService
                     .FeaturedTables.Where(ks => ks.ReleaseVersionId == releaseVersion.Id)
                     .ToListAsync();
 
-                var dataSetNamesBySubjectId = await GetDataSetNamesBySubjectId(releaseVersion.Id);
+                var dataSetTitlesBySubjectId = await GetDataSetTitlesBySubjectId(releaseVersion.Id);
 
                 return dataBlocks
                     .Select(block =>
@@ -204,7 +204,7 @@ public class DataBlockService : IDataBlockService
                             HighlightName = featuredTable?.Name,
                             HighlightDescription = featuredTable?.Description,
                             Source = block.Source,
-                            DataSetName = dataSetNamesBySubjectId[block.Query.SubjectId],
+                            DataSetTitle = dataSetTitlesBySubjectId[block.Query.SubjectId],
                             ChartsCount = block.Charts.Count,
                             InContent = inContent,
                         };
@@ -496,7 +496,7 @@ public class DataBlockService : IDataBlockService
                 .AllAsync(ks => ks.DataBlockId != dataBlockVersion.Id);
     }
 
-    private async Task<Dictionary<Guid, string>> GetDataSetNamesBySubjectId(Guid releaseVersionId)
+    private async Task<Dictionary<Guid, string>> GetDataSetTitlesBySubjectId(Guid releaseVersionId)
     {
         return await _context
             .ReleaseFiles.Where(rf =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
@@ -17,6 +17,8 @@ public class DataBlockSummaryViewModel
 
     public string Source { get; set; } = "";
 
+    public string? DataSetName { get; set; }
+
     public bool InContent { get; set; }
 
     public int ChartsCount { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
@@ -1,25 +1,25 @@
 #nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
-public class DataBlockSummaryViewModel
+public record DataBlockSummaryViewModel
 {
-    public Guid Id { get; set; }
+    public required Guid Id { get; init; }
 
-    public string Heading { get; set; } = "";
+    public required string Heading { get; init; }
 
-    public string Name { get; set; } = "";
+    public required string Name { get; init; }
 
-    public DateTime? Created { get; set; }
+    public DateTime? Created { get; init; }
 
-    public string? HighlightName { get; set; }
+    public string? HighlightName { get; init; }
 
-    public string? HighlightDescription { get; set; }
+    public string? HighlightDescription { get; init; }
 
-    public string Source { get; set; } = "";
+    public string? Source { get; init; }
 
-    public string? DataSetName { get; set; }
+    public required string DataSetName { get; init; }
 
-    public bool InContent { get; set; }
+    public required bool InContent { get; init; }
 
-    public int ChartsCount { get; set; }
+    public required int ChartsCount { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
@@ -17,7 +17,7 @@ public record DataBlockSummaryViewModel
 
     public string? Source { get; init; }
 
-    public required string DataSetName { get; init; }
+    public required string DataSetTitle { get; init; }
 
     public required bool InContent { get; init; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -169,6 +169,7 @@ const ReleaseDataBlocksPage = ({
                   <th scope="col" className="govuk-!-width-one-quarter">
                     Name
                   </th>
+                  <th scope="col">Data set name</th>
                   <th scope="col">Has chart</th>
                   <th scope="col">In content</th>
                   <th scope="col">Created date</th>
@@ -181,6 +182,7 @@ const ReleaseDataBlocksPage = ({
                 {filteredDataBlocks.map(dataBlock => (
                   <tr key={dataBlock.id}>
                     <td>{dataBlock.name}</td>
+                    <td>{dataBlock.dataSetName ?? 'Not available'}</td>
                     <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
                     <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
                     <td>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -12,16 +12,36 @@ import {
   ReleaseRouteParams,
   releaseTableToolRoute,
 } from '@admin/routes/releaseRoutes';
+import { ReleaseDataBlockSummary } from '@admin/services/dataBlockService';
 import featuredTableService, {
   FeaturedTable,
 } from '@admin/services/featuredTableService';
 import FormattedDate from '@common/components/FormattedDate';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import SortedTableHeader, {
+  TableSort,
+} from '@common/components/SortedTableHeader';
 import WarningMessage from '@common/components/WarningMessage';
-import React, { useCallback, useMemo } from 'react';
+import orderBy from 'lodash/orderBy';
+import React, { useCallback, useMemo, useState } from 'react';
 import { generatePath, RouteComponentProps } from 'react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+
+type DataBlockSortColumn =
+  'name' | 'dataSetName' | 'hasChart' | 'inContent' | 'created';
+
+const dataBlockSortValues: Record<
+  DataBlockSortColumn,
+  (dataBlock: ReleaseDataBlockSummary) => string | boolean
+> = {
+  name: dataBlock => dataBlock.name.toLowerCase(),
+  dataSetName: dataBlock => dataBlock.dataSetName?.toLowerCase() ?? '',
+  hasChart: dataBlock => dataBlock.chartsCount > 0,
+  inContent: dataBlock => dataBlock.inContent,
+  created: dataBlock => dataBlock.created ?? '',
+};
 
 const ReleaseDataBlocksPage = ({
   match,
@@ -29,6 +49,11 @@ const ReleaseDataBlocksPage = ({
   const { publicationId, releaseVersionId } = match.params;
 
   const queryClient = useQueryClient();
+
+  const [sort, setSort] = useState<TableSort<DataBlockSortColumn>>({
+    column: 'name',
+    direction: 'ascending',
+  });
 
   const listFeaturedTablesQuery = useMemo(
     () => featuredTableQueries.list(releaseVersionId),
@@ -96,13 +121,36 @@ const ReleaseDataBlocksPage = ({
     },
   );
 
+  const filteredDataBlocks = useMemo(() => {
+    const unfeaturedDataBlocks = dataBlocks.filter(dataBlock => {
+      return !featuredTables.find(table => table.dataBlockId === dataBlock.id);
+    });
+
+    return orderBy(
+      unfeaturedDataBlocks,
+      // Sort by name as well, so that rows with equal values keep a stable order
+      [dataBlockSortValues[sort.column], dataBlockSortValues.name],
+      [sort.direction === 'ascending' ? 'asc' : 'desc', 'asc'],
+    );
+  }, [dataBlocks, featuredTables, sort]);
+
+  const handleSortChange = useCallback((column: DataBlockSortColumn) => {
+    setSort(currentSort =>
+      currentSort.column === column
+        ? {
+            column,
+            direction:
+              currentSort.direction === 'ascending'
+                ? 'descending'
+                : 'ascending',
+          }
+        : { column, direction: 'ascending' },
+    );
+  }, []);
+
   if (isLoadingDataBlocks || isLoadingFeaturedTables || isLoadingPermissions) {
     return <LoadingSpinner />;
   }
-
-  const filteredDataBlocks = dataBlocks.filter(dataBlock => {
-    return !featuredTables.find(table => table.dataBlockId === dataBlock.id);
-  });
 
   return (
     <>
@@ -159,71 +207,94 @@ const ReleaseDataBlocksPage = ({
       )}
 
       {filteredDataBlocks.length > 0 && (
-        <>
-          <h3>Data blocks</h3>
-
-          <div className="table-container">
-            <table data-testid="dataBlocks">
-              <thead>
-                <tr>
-                  <th scope="col" className="govuk-!-width-one-quarter">
-                    Name
-                  </th>
-                  <th scope="col">Data set name</th>
-                  <th scope="col">Has chart</th>
-                  <th scope="col">In content</th>
-                  <th scope="col">Created date</th>
-                  <th scope="col" className="govuk-table__header--actions">
-                    Actions
-                  </th>
+        <div className="table-container">
+          <table data-testid="dataBlocks">
+            <caption className="govuk-table__caption--m">
+              Data blocks
+              <VisuallyHidden> (column headers are sortable)</VisuallyHidden>
+            </caption>
+            <thead>
+              <tr>
+                <SortedTableHeader
+                  column="name"
+                  label="Data block"
+                  sort={sort}
+                  onClick={handleSortChange}
+                />
+                <SortedTableHeader
+                  column="dataSetName"
+                  label="Data file"
+                  sort={sort}
+                  onClick={handleSortChange}
+                />
+                <SortedTableHeader
+                  column="hasChart"
+                  label="Has chart"
+                  sort={sort}
+                  onClick={handleSortChange}
+                />
+                <SortedTableHeader
+                  column="inContent"
+                  label="In content"
+                  sort={sort}
+                  onClick={handleSortChange}
+                />
+                <SortedTableHeader
+                  column="created"
+                  label="Created date"
+                  sort={sort}
+                  onClick={handleSortChange}
+                />
+                <th scope="col" className="govuk-table__header--actions">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredDataBlocks.map(dataBlock => (
+                <tr key={dataBlock.id}>
+                  <td>{dataBlock.name}</td>
+                  <td>{dataBlock.dataSetName ?? 'Not available'}</td>
+                  <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
+                  <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
+                  <td>
+                    {dataBlock.created ? (
+                      <FormattedDate format="d MMMM yyyy HH:mm">
+                        {dataBlock.created}
+                      </FormattedDate>
+                    ) : (
+                      'Not available'
+                    )}
+                  </td>
+                  <td className="govuk-table__cell--actions govuk-!-width-one-quarter">
+                    <Link
+                      className="govuk-!-margin-bottom-0"
+                      unvisited
+                      data-testid={`Edit data block ${dataBlock.name}`}
+                      to={generatePath<ReleaseDataBlockRouteParams>(
+                        releaseDataBlockEditRoute.path,
+                        {
+                          publicationId,
+                          releaseVersionId,
+                          dataBlockId: dataBlock.id,
+                        },
+                      )}
+                    >
+                      {canUpdateRelease ? 'Edit block' : 'View block'}
+                    </Link>
+                    {canUpdateRelease && (
+                      <DataBlockDeletePlanModal
+                        releaseVersionId={releaseVersionId}
+                        dataBlockId={dataBlock.id}
+                        onConfirm={() => handleDeleteConfirm(dataBlock.id)}
+                      />
+                    )}
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {filteredDataBlocks.map(dataBlock => (
-                  <tr key={dataBlock.id}>
-                    <td>{dataBlock.name}</td>
-                    <td>{dataBlock.dataSetName ?? 'Not available'}</td>
-                    <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
-                    <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
-                    <td>
-                      {dataBlock.created ? (
-                        <FormattedDate format="d MMMM yyyy HH:mm">
-                          {dataBlock.created}
-                        </FormattedDate>
-                      ) : (
-                        'Not available'
-                      )}
-                    </td>
-                    <td className="govuk-table__cell--actions govuk-!-width-one-quarter">
-                      <Link
-                        className="govuk-!-margin-bottom-0"
-                        unvisited
-                        data-testid={`Edit data block ${dataBlock.name}`}
-                        to={generatePath<ReleaseDataBlockRouteParams>(
-                          releaseDataBlockEditRoute.path,
-                          {
-                            publicationId,
-                            releaseVersionId,
-                            dataBlockId: dataBlock.id,
-                          },
-                        )}
-                      >
-                        {canUpdateRelease ? 'Edit block' : 'View block'}
-                      </Link>
-                      {canUpdateRelease && (
-                        <DataBlockDeletePlanModal
-                          releaseVersionId={releaseVersionId}
-                          dataBlockId={dataBlock.id}
-                          onConfirm={() => handleDeleteConfirm(dataBlock.id)}
-                        />
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
       {canUpdateRelease && (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -121,7 +121,7 @@ const ReleaseDataBlocksPage = ({
     },
   );
 
-  const filteredDataBlocks = useMemo(() => {
+  const sortedDataBlocks = useMemo(() => {
     const unfeaturedDataBlocks = dataBlocks.filter(dataBlock => {
       return !featuredTables.find(table => table.dataBlockId === dataBlock.id);
     });
@@ -206,7 +206,7 @@ const ReleaseDataBlocksPage = ({
         />
       )}
 
-      {filteredDataBlocks.length > 0 && (
+      {sortedDataBlocks.length > 0 && (
         <div className="table-container">
           <table data-testid="dataBlocks">
             <caption className="govuk-table__caption--m">
@@ -216,12 +216,14 @@ const ReleaseDataBlocksPage = ({
             <thead>
               <tr>
                 <SortedTableHeader
+                  className="govuk-!-width-one-quarter"
                   column="name"
                   label="Data block"
                   sort={sort}
                   onClick={handleSortChange}
                 />
                 <SortedTableHeader
+                  className="govuk-!-width-one-quarter"
                   column="dataSetName"
                   label="Data file"
                   sort={sort}
@@ -251,7 +253,7 @@ const ReleaseDataBlocksPage = ({
               </tr>
             </thead>
             <tbody>
-              {filteredDataBlocks.map(dataBlock => (
+              {sortedDataBlocks.map(dataBlock => (
                 <tr key={dataBlock.id}>
                   <td>{dataBlock.name}</td>
                   <td>{dataBlock.dataSetName ?? 'Not available'}</td>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -3,8 +3,8 @@ import Link from '@admin/components/Link';
 import DataBlockDeletePlanModal from '@admin/pages/release/datablocks/components/DataBlockDeletePlanModal';
 import FeaturedTablesTable from '@admin/pages/release/datablocks/components/FeaturedTablesTable';
 import dataBlockQueries from '@admin/queries/dataBlockQueries';
-import permissionQueries from '@admin/queries/permissionQueries';
 import featuredTableQueries from '@admin/queries/featuredTableQueries';
+import permissionQueries from '@admin/queries/permissionQueries';
 import {
   releaseDataBlockCreateRoute,
   releaseDataBlockEditRoute,
@@ -22,12 +22,12 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import SortedTableHeader, {
   TableSort,
 } from '@common/components/SortedTableHeader';
-import WarningMessage from '@common/components/WarningMessage';
-import orderBy from 'lodash/orderBy';
-import React, { useCallback, useMemo, useState } from 'react';
-import { generatePath, RouteComponentProps } from 'react-router';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import VisuallyHidden from '@common/components/VisuallyHidden';
+import WarningMessage from '@common/components/WarningMessage';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import orderBy from 'lodash/orderBy';
+import { useCallback, useMemo, useState } from 'react';
+import { generatePath, RouteComponentProps } from 'react-router';
 
 type DataBlockSortColumn =
   'name' | 'dataSetName' | 'hasChart' | 'inContent' | 'created';

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -30,14 +30,14 @@ import { useCallback, useMemo, useState } from 'react';
 import { generatePath, RouteComponentProps } from 'react-router';
 
 type DataBlockSortColumn =
-  'name' | 'dataSetName' | 'hasChart' | 'inContent' | 'created';
+  'name' | 'dataSetTitle' | 'hasChart' | 'inContent' | 'created';
 
 const dataBlockSortValues: Record<
   DataBlockSortColumn,
   (dataBlock: ReleaseDataBlockSummary) => string | boolean
 > = {
   name: dataBlock => dataBlock.name.toLowerCase(),
-  dataSetName: dataBlock => dataBlock.dataSetName?.toLowerCase() ?? '',
+  dataSetTitle: dataBlock => dataBlock.dataSetTitle.toLowerCase(),
   hasChart: dataBlock => dataBlock.chartsCount > 0,
   inContent: dataBlock => dataBlock.inContent,
   created: dataBlock => dataBlock.created ?? '',
@@ -224,7 +224,7 @@ const ReleaseDataBlocksPage = ({
                 />
                 <SortedTableHeader
                   className="govuk-!-width-one-quarter"
-                  column="dataSetName"
+                  column="dataSetTitle"
                   label="Data file"
                   sort={sort}
                   onClick={handleSortChange}
@@ -256,7 +256,7 @@ const ReleaseDataBlocksPage = ({
               {sortedDataBlocks.map(dataBlock => (
                 <tr key={dataBlock.id}>
                   <td>{dataBlock.name}</td>
-                  <td>{dataBlock.dataSetName ?? 'Not available'}</td>
+                  <td>{dataBlock.dataSetTitle}</td>
                   <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
                   <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
                   <td>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -149,6 +149,7 @@ describe('ReleaseDataBlockEditPage', () => {
 
   const testDataBlockSummaries: ReleaseDataBlockSummary[] = [
     {
+      dataSetTitle: 'Test data set title 2',
       id: 'block-2',
       name: 'Test name 2',
       heading: 'Test title 2',
@@ -159,6 +160,7 @@ describe('ReleaseDataBlockEditPage', () => {
       inContent: false,
     },
     {
+      dataSetTitle: 'Test data set',
       id: testDataBlock.id,
       name: testDataBlock.name,
       heading: testDataBlock.heading,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -69,7 +69,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-02-01T15:00:00.0000000',
       heading: 'Block 4 heading',
       source: 'Block 4 source',
-      dataSetName: 'Data set 4',
+      dataSetName: 'A data set 4',
       inContent: false,
       chartsCount: 0,
     },
@@ -209,7 +209,7 @@ describe('ReleaseDataBlocksPage', () => {
     const dataBlocksRow2Cells = within(dataBlocksRows[2]).getAllByRole('cell');
     expect(dataBlocksRow2Cells).toHaveLength(6);
     expect(dataBlocksRow2Cells[0]).toHaveTextContent('Block 4');
-    expect(dataBlocksRow2Cells[1]).toHaveTextContent('Data set 4');
+    expect(dataBlocksRow2Cells[1]).toHaveTextContent('A data set 4');
     expect(dataBlocksRow2Cells[2]).toHaveTextContent('No');
     expect(dataBlocksRow2Cells[3]).toHaveTextContent('No');
     expect(dataBlocksRow2Cells[4]).toHaveTextContent('1 February 2021 15:00');
@@ -324,7 +324,7 @@ describe('ReleaseDataBlocksPage', () => {
     const dataBlocksRow2Cells = within(dataBlocksRows[2]).getAllByRole('cell');
     expect(dataBlocksRow2Cells).toHaveLength(6);
     expect(dataBlocksRow2Cells[0]).toHaveTextContent('Block 4');
-    expect(dataBlocksRow2Cells[1]).toHaveTextContent('Data set 4');
+    expect(dataBlocksRow2Cells[1]).toHaveTextContent('A data set 4');
     expect(dataBlocksRow2Cells[2]).toHaveTextContent('No');
     expect(dataBlocksRow2Cells[3]).toHaveTextContent('No');
     expect(dataBlocksRow2Cells[4]).toHaveTextContent('1 February 2021 15:00');
@@ -522,6 +522,130 @@ describe('ReleaseDataBlocksPage', () => {
           name: 'Delete block',
         }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('sorting data blocks', () => {
+    const getDataBlockNames = () =>
+      within(screen.getByTestId('dataBlocks'))
+        .getAllByRole('row')
+        .slice(1)
+        .map(row => within(row).getAllByRole('cell')[0].textContent);
+
+    beforeEach(() => {
+      dataBlockService.listDataBlocks.mockResolvedValue(testDataBlocks);
+      featuredTableService.listFeaturedTables.mockResolvedValue([]);
+    });
+
+    test('sorts by name in ascending order by default', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dataBlocks')).toBeInTheDocument();
+      });
+
+      expect(getDataBlockNames()).toEqual([
+        'Block 1',
+        'Block 2',
+        'Block 3',
+        'Block 4',
+      ]);
+
+      const nameHeader = screen.getByRole('columnheader', {
+        name: /Data block/,
+      });
+      expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+      expect(
+        screen.getByRole('columnheader', { name: /Data file/ }),
+      ).toHaveAttribute('aria-sort', 'none');
+    });
+
+    test('clicking the data block control toggles to descending order', async () => {
+      const { user } = renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dataBlocks')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Data block/ }));
+
+      expect(getDataBlockNames()).toEqual([
+        'Block 4',
+        'Block 3',
+        'Block 2',
+        'Block 1',
+      ]);
+      expect(
+        screen.getByRole('columnheader', { name: /Data block/ }),
+      ).toHaveAttribute('aria-sort', 'descending');
+      expect(
+        screen.getByRole('columnheader', { name: /Data file/ }),
+      ).toHaveAttribute('aria-sort', 'none');
+    });
+
+    test('clicking the data file control sorts by data set name', async () => {
+      const { user } = renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dataBlocks')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /Data file/ }));
+
+      // Block 3 has no data set name, so is sorted first
+      expect(getDataBlockNames()).toEqual([
+        'Block 3',
+        'Block 4',
+        'Block 1',
+        'Block 2',
+      ]);
+      expect(
+        screen.getByRole('columnheader', { name: /Data file/ }),
+      ).toHaveAttribute('aria-sort', 'ascending');
+
+      await user.click(screen.getByRole('button', { name: /Data file/ }));
+
+      expect(getDataBlockNames()).toEqual([
+        'Block 2',
+        'Block 1',
+        'Block 4',
+        'Block 3',
+      ]);
+      expect(
+        screen.getByRole('columnheader', { name: /Data file/ }),
+      ).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    test('clicking the in content control sorts by in content', async () => {
+      const { user } = renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('dataBlocks')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /In content/ }));
+
+      expect(getDataBlockNames()).toEqual([
+        'Block 2',
+        'Block 3',
+        'Block 4',
+        'Block 1',
+      ]);
+      expect(
+        screen.getByRole('columnheader', { name: /In content/ }),
+      ).toHaveAttribute('aria-sort', 'ascending');
+
+      await user.click(screen.getByRole('button', { name: /In content/ }));
+
+      expect(getDataBlockNames()).toEqual([
+        'Block 1',
+        'Block 2',
+        'Block 3',
+        'Block 4',
+      ]);
+      expect(
+        screen.getByRole('columnheader', { name: /In content/ }),
+      ).toHaveAttribute('aria-sort', 'descending');
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -40,6 +40,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: undefined,
       heading: 'Block 1 heading',
       source: 'Block 1 source',
+      dataSetName: 'Data set 1',
       inContent: true,
       chartsCount: 1,
     },
@@ -49,6 +50,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-01-01T15:00:00.0000000',
       heading: 'Block 2 heading',
       source: 'Block 2 source',
+      dataSetName: 'Data set 2',
       inContent: false,
       chartsCount: 0,
     },
@@ -67,6 +69,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-02-01T15:00:00.0000000',
       heading: 'Block 4 heading',
       source: 'Block 4 source',
+      dataSetName: 'Data set 4',
       inContent: false,
       chartsCount: 0,
     },
@@ -129,14 +132,15 @@ describe('ReleaseDataBlocksPage', () => {
     const featuredTablesRow1Cells = within(featuredTablesRows[1]).getAllByRole(
       'cell',
     );
-    expect(featuredTablesRow1Cells).toHaveLength(6);
+    expect(featuredTablesRow1Cells).toHaveLength(7);
     expect(featuredTablesRow1Cells[0]).toHaveTextContent('Block 1');
-    expect(featuredTablesRow1Cells[1]).toHaveTextContent('Yes');
+    expect(featuredTablesRow1Cells[1]).toHaveTextContent('Data set 1');
     expect(featuredTablesRow1Cells[2]).toHaveTextContent('Yes');
-    expect(featuredTablesRow1Cells[3]).toHaveTextContent('Featured 1');
-    expect(featuredTablesRow1Cells[4]).toHaveTextContent('Not available');
+    expect(featuredTablesRow1Cells[3]).toHaveTextContent('Yes');
+    expect(featuredTablesRow1Cells[4]).toHaveTextContent('Featured 1');
+    expect(featuredTablesRow1Cells[5]).toHaveTextContent('Not available');
     expect(
-      within(featuredTablesRow1Cells[5]).getByRole('link', {
+      within(featuredTablesRow1Cells[6]).getByRole('link', {
         name: 'Edit block',
       }),
     ).toHaveAttribute(
@@ -144,7 +148,7 @@ describe('ReleaseDataBlocksPage', () => {
       '/publication/publication-1/release/release-1/data-blocks/block-1',
     );
     expect(
-      within(featuredTablesRow1Cells[5]).getByRole('button', {
+      within(featuredTablesRow1Cells[6]).getByRole('button', {
         name: 'Delete block',
       }),
     ).toBeInTheDocument();
@@ -152,16 +156,17 @@ describe('ReleaseDataBlocksPage', () => {
     const featuredTablesRow2Cells = within(featuredTablesRows[2]).getAllByRole(
       'cell',
     );
-    expect(featuredTablesRow2Cells).toHaveLength(6);
+    expect(featuredTablesRow2Cells).toHaveLength(7);
     expect(featuredTablesRow2Cells[0]).toHaveTextContent('Block 3');
-    expect(featuredTablesRow2Cells[1]).toHaveTextContent('No');
+    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Not available');
     expect(featuredTablesRow2Cells[2]).toHaveTextContent('No');
-    expect(featuredTablesRow2Cells[3]).toHaveTextContent('Featured 3');
-    expect(featuredTablesRow2Cells[4]).toHaveTextContent(
+    expect(featuredTablesRow2Cells[3]).toHaveTextContent('No');
+    expect(featuredTablesRow2Cells[4]).toHaveTextContent('Featured 3');
+    expect(featuredTablesRow2Cells[5]).toHaveTextContent(
       '1 January 2021 15:00',
     );
     expect(
-      within(featuredTablesRow2Cells[5]).getByRole('link', {
+      within(featuredTablesRow2Cells[6]).getByRole('link', {
         name: 'Edit block',
       }),
     ).toHaveAttribute(
@@ -169,7 +174,7 @@ describe('ReleaseDataBlocksPage', () => {
       '/publication/publication-1/release/release-1/data-blocks/block-3',
     );
     expect(
-      within(featuredTablesRow2Cells[5]).getByRole('button', {
+      within(featuredTablesRow2Cells[6]).getByRole('button', {
         name: 'Delete block',
       }),
     ).toBeInTheDocument();
@@ -183,37 +188,39 @@ describe('ReleaseDataBlocksPage', () => {
     expect(dataBlocksRows).toHaveLength(3);
 
     const dataBlocksRow1Cells = within(dataBlocksRows[1]).getAllByRole('cell');
-    expect(dataBlocksRow1Cells).toHaveLength(5);
+    expect(dataBlocksRow1Cells).toHaveLength(6);
     expect(dataBlocksRow1Cells[0]).toHaveTextContent('Block 2');
-    expect(dataBlocksRow1Cells[1]).toHaveTextContent('No');
+    expect(dataBlocksRow1Cells[1]).toHaveTextContent('Data set 2');
     expect(dataBlocksRow1Cells[2]).toHaveTextContent('No');
-    expect(dataBlocksRow1Cells[3]).toHaveTextContent('1 January 2021 15:00');
+    expect(dataBlocksRow1Cells[3]).toHaveTextContent('No');
+    expect(dataBlocksRow1Cells[4]).toHaveTextContent('1 January 2021 15:00');
     expect(
-      within(dataBlocksRow1Cells[4]).getByRole('link', { name: 'Edit block' }),
+      within(dataBlocksRow1Cells[5]).getByRole('link', { name: 'Edit block' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/data-blocks/block-2',
     );
     expect(
-      within(dataBlocksRow1Cells[4]).getByRole('button', {
+      within(dataBlocksRow1Cells[5]).getByRole('button', {
         name: 'Delete block',
       }),
     ).toBeInTheDocument();
 
     const dataBlocksRow2Cells = within(dataBlocksRows[2]).getAllByRole('cell');
-    expect(dataBlocksRow2Cells).toHaveLength(5);
+    expect(dataBlocksRow2Cells).toHaveLength(6);
     expect(dataBlocksRow2Cells[0]).toHaveTextContent('Block 4');
-    expect(dataBlocksRow2Cells[1]).toHaveTextContent('No');
+    expect(dataBlocksRow2Cells[1]).toHaveTextContent('Data set 4');
     expect(dataBlocksRow2Cells[2]).toHaveTextContent('No');
-    expect(dataBlocksRow2Cells[3]).toHaveTextContent('1 February 2021 15:00');
+    expect(dataBlocksRow2Cells[3]).toHaveTextContent('No');
+    expect(dataBlocksRow2Cells[4]).toHaveTextContent('1 February 2021 15:00');
     expect(
-      within(dataBlocksRow2Cells[4]).getByRole('link', { name: 'Edit block' }),
+      within(dataBlocksRow2Cells[5]).getByRole('link', { name: 'Edit block' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/data-blocks/block-4',
     );
     expect(
-      within(dataBlocksRow2Cells[4]).getByRole('button', {
+      within(dataBlocksRow2Cells[5]).getByRole('button', {
         name: 'Delete block',
       }),
     ).toBeInTheDocument();
@@ -247,19 +254,20 @@ describe('ReleaseDataBlocksPage', () => {
     const featuredTablesRow1Cells = within(featuredTablesRows[1]).getAllByRole(
       'cell',
     );
-    expect(featuredTablesRow1Cells).toHaveLength(6);
+    expect(featuredTablesRow1Cells).toHaveLength(7);
     expect(featuredTablesRow1Cells[0]).toHaveTextContent('Block 1');
-    expect(featuredTablesRow1Cells[1]).toHaveTextContent('Yes');
+    expect(featuredTablesRow1Cells[1]).toHaveTextContent('Data set 1');
     expect(featuredTablesRow1Cells[2]).toHaveTextContent('Yes');
-    expect(featuredTablesRow1Cells[3]).toHaveTextContent('Featured 1');
-    expect(featuredTablesRow1Cells[4]).toHaveTextContent('Not available');
+    expect(featuredTablesRow1Cells[3]).toHaveTextContent('Yes');
+    expect(featuredTablesRow1Cells[4]).toHaveTextContent('Featured 1');
+    expect(featuredTablesRow1Cells[5]).toHaveTextContent('Not available');
     expect(
-      within(featuredTablesRow1Cells[5]).queryByRole('link', {
+      within(featuredTablesRow1Cells[6]).queryByRole('link', {
         name: 'Edit block',
       }),
     ).not.toBeInTheDocument();
     expect(
-      within(featuredTablesRow1Cells[5]).queryByRole('button', {
+      within(featuredTablesRow1Cells[6]).queryByRole('button', {
         name: 'Delete block',
       }),
     ).not.toBeInTheDocument();
@@ -267,21 +275,22 @@ describe('ReleaseDataBlocksPage', () => {
     const featuredTablesRow2Cells = within(featuredTablesRows[2]).getAllByRole(
       'cell',
     );
-    expect(featuredTablesRow2Cells).toHaveLength(6);
+    expect(featuredTablesRow2Cells).toHaveLength(7);
     expect(featuredTablesRow2Cells[0]).toHaveTextContent('Block 3');
-    expect(featuredTablesRow2Cells[1]).toHaveTextContent('No');
+    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Not available');
     expect(featuredTablesRow2Cells[2]).toHaveTextContent('No');
-    expect(featuredTablesRow2Cells[3]).toHaveTextContent('Featured 3');
-    expect(featuredTablesRow2Cells[4]).toHaveTextContent(
+    expect(featuredTablesRow2Cells[3]).toHaveTextContent('No');
+    expect(featuredTablesRow2Cells[4]).toHaveTextContent('Featured 3');
+    expect(featuredTablesRow2Cells[5]).toHaveTextContent(
       '1 January 2021 15:00',
     );
     expect(
-      within(featuredTablesRow2Cells[5]).queryByRole('link', {
+      within(featuredTablesRow2Cells[6]).queryByRole('link', {
         name: 'Edit block',
       }),
     ).not.toBeInTheDocument();
     expect(
-      within(featuredTablesRow2Cells[5]).queryByRole('button', {
+      within(featuredTablesRow2Cells[6]).queryByRole('button', {
         name: 'Delete block',
       }),
     ).not.toBeInTheDocument();
@@ -295,35 +304,37 @@ describe('ReleaseDataBlocksPage', () => {
     expect(dataBlocksRows).toHaveLength(3);
 
     const dataBlocksRow1Cells = within(dataBlocksRows[1]).getAllByRole('cell');
-    expect(dataBlocksRow1Cells).toHaveLength(5);
+    expect(dataBlocksRow1Cells).toHaveLength(6);
     expect(dataBlocksRow1Cells[0]).toHaveTextContent('Block 2');
-    expect(dataBlocksRow1Cells[1]).toHaveTextContent('No');
+    expect(dataBlocksRow1Cells[1]).toHaveTextContent('Data set 2');
     expect(dataBlocksRow1Cells[2]).toHaveTextContent('No');
-    expect(dataBlocksRow1Cells[3]).toHaveTextContent('1 January 2021 15:00');
+    expect(dataBlocksRow1Cells[3]).toHaveTextContent('No');
+    expect(dataBlocksRow1Cells[4]).toHaveTextContent('1 January 2021 15:00');
     expect(
-      within(dataBlocksRow1Cells[4]).queryByRole('link', {
+      within(dataBlocksRow1Cells[5]).queryByRole('link', {
         name: 'Edit block',
       }),
     ).not.toBeInTheDocument();
     expect(
-      within(dataBlocksRow1Cells[4]).queryByRole('button', {
+      within(dataBlocksRow1Cells[5]).queryByRole('button', {
         name: 'Delete block',
       }),
     ).not.toBeInTheDocument();
 
     const dataBlocksRow2Cells = within(dataBlocksRows[2]).getAllByRole('cell');
-    expect(dataBlocksRow2Cells).toHaveLength(5);
+    expect(dataBlocksRow2Cells).toHaveLength(6);
     expect(dataBlocksRow2Cells[0]).toHaveTextContent('Block 4');
-    expect(dataBlocksRow2Cells[1]).toHaveTextContent('No');
+    expect(dataBlocksRow2Cells[1]).toHaveTextContent('Data set 4');
     expect(dataBlocksRow2Cells[2]).toHaveTextContent('No');
-    expect(dataBlocksRow2Cells[3]).toHaveTextContent('1 February 2021 15:00');
+    expect(dataBlocksRow2Cells[3]).toHaveTextContent('No');
+    expect(dataBlocksRow2Cells[4]).toHaveTextContent('1 February 2021 15:00');
     expect(
-      within(dataBlocksRow2Cells[4]).queryByRole('link', {
+      within(dataBlocksRow2Cells[5]).queryByRole('link', {
         name: 'Edit block',
       }),
     ).not.toBeInTheDocument();
     expect(
-      within(dataBlocksRow2Cells[4]).queryByRole('button', {
+      within(dataBlocksRow2Cells[5]).queryByRole('button', {
         name: 'Delete block',
       }),
     ).not.toBeInTheDocument();
@@ -489,16 +500,17 @@ describe('ReleaseDataBlocksPage', () => {
       const featuredTablesRow1Cells = within(
         featuredTablesRows[1],
       ).getAllByRole('cell');
-      expect(featuredTablesRow1Cells).toHaveLength(6);
+      expect(featuredTablesRow1Cells).toHaveLength(7);
       expect(featuredTablesRow1Cells[0]).toHaveTextContent('Block 3');
-      expect(featuredTablesRow1Cells[1]).toHaveTextContent('No');
+      expect(featuredTablesRow1Cells[1]).toHaveTextContent('Not available');
       expect(featuredTablesRow1Cells[2]).toHaveTextContent('No');
-      expect(featuredTablesRow1Cells[3]).toHaveTextContent('Featured 3');
-      expect(featuredTablesRow1Cells[4]).toHaveTextContent(
+      expect(featuredTablesRow1Cells[3]).toHaveTextContent('No');
+      expect(featuredTablesRow1Cells[4]).toHaveTextContent('Featured 3');
+      expect(featuredTablesRow1Cells[5]).toHaveTextContent(
         '1 January 2021 15:00',
       );
       expect(
-        within(featuredTablesRow1Cells[5]).getByRole('link', {
+        within(featuredTablesRow1Cells[6]).getByRole('link', {
           name: 'Edit block',
         }),
       ).toHaveAttribute(
@@ -506,7 +518,7 @@ describe('ReleaseDataBlocksPage', () => {
         '/publication/publication-1/release/release-1/data-blocks/block-3',
       );
       expect(
-        within(featuredTablesRow1Cells[5]).getByRole('button', {
+        within(featuredTablesRow1Cells[6]).getByRole('button', {
           name: 'Delete block',
         }),
       ).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -40,7 +40,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: undefined,
       heading: 'Block 1 heading',
       source: 'Block 1 source',
-      dataSetName: 'Data set 1',
+      dataSetTitle: 'Data set 1',
       inContent: true,
       chartsCount: 1,
     },
@@ -50,7 +50,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-01-01T15:00:00.0000000',
       heading: 'Block 2 heading',
       source: 'Block 2 source',
-      dataSetName: 'Data set 2',
+      dataSetTitle: 'Data set 2',
       inContent: false,
       chartsCount: 0,
     },
@@ -60,6 +60,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-01-01T15:00:00.0000000',
       heading: 'Block 3 heading',
       source: 'Block 3 source',
+      dataSetTitle: 'Data set 3',
       inContent: false,
       chartsCount: 0,
     },
@@ -69,7 +70,7 @@ describe('ReleaseDataBlocksPage', () => {
       created: '2021-02-01T15:00:00.0000000',
       heading: 'Block 4 heading',
       source: 'Block 4 source',
-      dataSetName: 'A data set 4',
+      dataSetTitle: 'A data set 4',
       inContent: false,
       chartsCount: 0,
     },
@@ -158,7 +159,7 @@ describe('ReleaseDataBlocksPage', () => {
     );
     expect(featuredTablesRow2Cells).toHaveLength(7);
     expect(featuredTablesRow2Cells[0]).toHaveTextContent('Block 3');
-    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Not available');
+    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Data set 3');
     expect(featuredTablesRow2Cells[2]).toHaveTextContent('No');
     expect(featuredTablesRow2Cells[3]).toHaveTextContent('No');
     expect(featuredTablesRow2Cells[4]).toHaveTextContent('Featured 3');
@@ -277,7 +278,7 @@ describe('ReleaseDataBlocksPage', () => {
     );
     expect(featuredTablesRow2Cells).toHaveLength(7);
     expect(featuredTablesRow2Cells[0]).toHaveTextContent('Block 3');
-    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Not available');
+    expect(featuredTablesRow2Cells[1]).toHaveTextContent('Data set 3');
     expect(featuredTablesRow2Cells[2]).toHaveTextContent('No');
     expect(featuredTablesRow2Cells[3]).toHaveTextContent('No');
     expect(featuredTablesRow2Cells[4]).toHaveTextContent('Featured 3');
@@ -352,6 +353,7 @@ describe('ReleaseDataBlocksPage', () => {
     dataBlockService.listDataBlocks.mockResolvedValue([
       ...testDataBlocks,
       {
+        dataSetTitle: 'Data set title 5',
         id: 'block-5',
         name: 'Block 5',
         created: '2021-02-01T15:00:00.0000000',
@@ -361,6 +363,7 @@ describe('ReleaseDataBlocksPage', () => {
         chartsCount: 0,
       },
       {
+        dataSetTitle: 'Data set title 6',
         id: 'block-6',
         name: 'Block 6',
         created: '2021-02-01T15:00:00.0000000',
@@ -502,7 +505,7 @@ describe('ReleaseDataBlocksPage', () => {
       ).getAllByRole('cell');
       expect(featuredTablesRow1Cells).toHaveLength(7);
       expect(featuredTablesRow1Cells[0]).toHaveTextContent('Block 3');
-      expect(featuredTablesRow1Cells[1]).toHaveTextContent('Not available');
+      expect(featuredTablesRow1Cells[1]).toHaveTextContent('Data set 3');
       expect(featuredTablesRow1Cells[2]).toHaveTextContent('No');
       expect(featuredTablesRow1Cells[3]).toHaveTextContent('No');
       expect(featuredTablesRow1Cells[4]).toHaveTextContent('Featured 3');
@@ -583,7 +586,7 @@ describe('ReleaseDataBlocksPage', () => {
       ).toHaveAttribute('aria-sort', 'none');
     });
 
-    test('clicking the data file control sorts by data set name', async () => {
+    test('clicking the data file control sorts by data set title', async () => {
       const { user } = renderPage();
 
       await waitFor(() => {
@@ -592,12 +595,11 @@ describe('ReleaseDataBlocksPage', () => {
 
       await user.click(screen.getByRole('button', { name: /Data file/ }));
 
-      // Block 3 has no data set name, so is sorted first
       expect(getDataBlockNames()).toEqual([
-        'Block 3',
         'Block 4',
         'Block 1',
         'Block 2',
+        'Block 3',
       ]);
       expect(
         screen.getByRole('columnheader', { name: /Data file/ }),
@@ -606,10 +608,10 @@ describe('ReleaseDataBlocksPage', () => {
       await user.click(screen.getByRole('button', { name: /Data file/ }));
 
       expect(getDataBlockNames()).toEqual([
+        'Block 3',
         'Block 2',
         'Block 1',
         'Block 4',
-        'Block 3',
       ]);
       expect(
         screen.getByRole('columnheader', { name: /Data file/ }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
@@ -107,6 +107,7 @@ export default function FeaturedTablesTable({
               <th scope="col" className="govuk-!-width-one-quarter">
                 Data block name
               </th>
+              <th scope="col">Data set name</th>
               <th scope="col">Has chart</th>
               <th scope="col">In content</th>
               <th scope="col">Featured table name</th>
@@ -167,6 +168,7 @@ function FeaturedTablesRow({
   return (
     <tr>
       <td>{dataBlock.name}</td>
+      <td>{dataBlock.dataSetName ?? 'Not available'}</td>
       <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
       <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
       <td>{featuredTable.name}</td>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
@@ -107,7 +107,7 @@ export default function FeaturedTablesTable({
               <th scope="col" className="govuk-!-width-one-quarter">
                 Data block name
               </th>
-              <th scope="col">Data set name</th>
+              <th scope="col">Data file</th>
               <th scope="col">Has chart</th>
               <th scope="col">In content</th>
               <th scope="col">Featured table name</th>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
@@ -168,7 +168,7 @@ function FeaturedTablesRow({
   return (
     <tr>
       <td>{dataBlock.name}</td>
-      <td>{dataBlock.dataSetName ?? 'Not available'}</td>
+      <td>{dataBlock.dataSetTitle}</td>
       <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
       <td>{dataBlock.inContent ? 'Yes' : 'No'}</td>
       <td>{featuredTable.name}</td>

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -13,6 +13,7 @@ export interface ReleaseDataBlockSummary {
   highlightDescription?: string;
   heading: string;
   source?: string;
+  dataSetName?: string;
   chartsCount: number;
   inContent: boolean;
 }

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -13,7 +13,7 @@ export interface ReleaseDataBlockSummary {
   highlightDescription?: string;
   heading: string;
   source?: string;
-  dataSetName?: string;
+  dataSetTitle: string;
   chartsCount: number;
   inContent: boolean;
 }

--- a/src/explore-education-statistics-common/src/components/ChevronIcon.tsx
+++ b/src/explore-education-statistics-common/src/components/ChevronIcon.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const ChevronIcon = ({
+  className,
+  width = '1.2em',
+  direction,
+}: {
+  className?: string;
+  direction?: 'ascending' | 'descending';
+  width?: string;
+}) => (
+  <svg
+    aria-hidden
+    className={className}
+    focusable="false"
+    viewBox="0 0 22 22"
+    width={width}
+    fill="currentColor"
+  >
+    {direction === 'descending' && (
+      <path d="M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z" />
+    )}
+    {direction === 'ascending' && (
+      <path d="M6.5625 15L11 6.1313L15.4375 15L6.5625 15Z" />
+    )}
+    {!direction && (
+      <>
+        <path d="M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z" />
+        <path d="M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z" />
+      </>
+    )}
+  </svg>
+);
+
+export default ChevronIcon;

--- a/src/explore-education-statistics-common/src/components/SortedTableHeader.module.scss
+++ b/src/explore-education-statistics-common/src/components/SortedTableHeader.module.scss
@@ -1,0 +1,11 @@
+@use '~govuk-frontend/dist/govuk/base' as *;
+
+.button {
+  align-items: center;
+  display: inline-flex;
+  gap: govuk-spacing(1);
+}
+
+.icon {
+  flex: none;
+}

--- a/src/explore-education-statistics-common/src/components/SortedTableHeader.tsx
+++ b/src/explore-education-statistics-common/src/components/SortedTableHeader.tsx
@@ -1,4 +1,5 @@
 import ButtonText from '@common/components/ButtonText';
+import ChevronIcon from '@common/components/ChevronIcon';
 import styles from '@common/components/SortedTableHeader.module.scss';
 import classNames from 'classnames';
 import React from 'react';
@@ -42,27 +43,11 @@ export default function SortedTableHeader<TColumn extends string>({
       >
         {label}
 
-        <svg
-          aria-hidden
+        <ChevronIcon
           className={styles.icon}
-          focusable="false"
-          viewBox="0 0 22 22"
+          direction={sortedDirection}
           width="1.2em"
-          fill="currentColor"
-        >
-          {sortedDirection === 'descending' && (
-            <path d="M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z" />
-          )}
-          {sortedDirection === 'ascending' && (
-            <path d="M6.5625 15L11 6.1313L15.4375 15L6.5625 15Z" />
-          )}
-          {!sortedDirection && (
-            <>
-              <path d="M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z" />
-              <path d="M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z" />
-            </>
-          )}
-        </svg>
+        />
       </ButtonText>
     </th>
   );

--- a/src/explore-education-statistics-common/src/components/SortedTableHeader.tsx
+++ b/src/explore-education-statistics-common/src/components/SortedTableHeader.tsx
@@ -1,0 +1,69 @@
+import ButtonText from '@common/components/ButtonText';
+import styles from '@common/components/SortedTableHeader.module.scss';
+import classNames from 'classnames';
+import React from 'react';
+
+export type TableSortDirection = 'ascending' | 'descending';
+
+export interface TableSort<TColumn extends string = string> {
+  column: TColumn;
+  direction: TableSortDirection;
+}
+
+interface Props<TColumn extends string> {
+  className?: string;
+  column: TColumn;
+  label: string;
+  sort: TableSort<TColumn>;
+  onClick: (column: TColumn) => void;
+}
+
+/**
+ * A table header cell with a control for sorting the table by its column.
+ *
+ * Shows a single chevron for the direction the table is currently sorted in,
+ * or both chevrons when the table is sorted by another column.
+ */
+export default function SortedTableHeader<TColumn extends string>({
+  className,
+  column,
+  label,
+  sort,
+  onClick,
+}: Props<TColumn>) {
+  const sortedDirection = sort.column === column ? sort.direction : undefined;
+
+  return (
+    <th aria-sort={sortedDirection ?? 'none'} className={className} scope="col">
+      <ButtonText
+        className={classNames(styles.button, 'govuk-!-font-weight-bold')}
+        underline={false}
+        onClick={() => onClick(column)}
+      >
+        {label}
+
+        <svg
+          aria-hidden
+          className={styles.icon}
+          focusable="false"
+          viewBox="0 0 22 22"
+          width="1.2em"
+          fill="currentColor"
+        >
+          {sortedDirection === 'descending' && (
+            <path d="M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z" />
+          )}
+          {sortedDirection === 'ascending' && (
+            <path d="M6.5625 15L11 6.1313L15.4375 15L6.5625 15Z" />
+          )}
+          {!sortedDirection && (
+            <>
+              <path d="M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z" />
+              <path d="M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z" />
+            </>
+          )}
+        </svg>
+      </ButtonText>
+    </th>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/__tests__/SortedTableHeader.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/SortedTableHeader.test.tsx
@@ -1,0 +1,72 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SortedTableHeader, { TableSort } from '../SortedTableHeader';
+
+describe('SortedTableHeader', () => {
+  const renderHeader = (
+    sort: TableSort<'name' | 'date'>,
+    onClick: (column: 'name' | 'date') => void = jest.fn(),
+  ): void => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <SortedTableHeader
+              column="name"
+              label="Name"
+              sort={sort}
+              onClick={onClick}
+            />
+          </tr>
+        </thead>
+      </table>,
+    );
+  };
+
+  test('renders both chevrons when the table is sorted by another column', () => {
+    renderHeader({ column: 'date', direction: 'ascending' });
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Name' }).querySelectorAll('path'),
+    ).toHaveLength(2);
+  });
+
+  test('renders a single chevron when the table is sorted by this column ascending', () => {
+    renderHeader({ column: 'name', direction: 'ascending' });
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Name' }).querySelectorAll('path'),
+    ).toHaveLength(1);
+  });
+
+  test('renders a single chevron when the table is sorted by this column descending', () => {
+    renderHeader({ column: 'name', direction: 'descending' });
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Name' }).querySelectorAll('path'),
+    ).toHaveLength(1);
+  });
+
+  test('calls `onClick` with the column when the control is clicked', async () => {
+    const handleClick = jest.fn();
+
+    renderHeader({ column: 'date', direction: 'ascending' }, handleClick);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+
+    expect(handleClick).toHaveBeenCalledWith('name');
+  });
+});

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -202,8 +202,8 @@ Validate data block is in list
     user waits until page finishes loading
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name    testid:dataBlocks
-    user checks table column heading contains    1    2    Data set name    testid:dataBlocks
+    user checks table column heading contains    1    1    Data block    testid:dataBlocks
+    user checks table column heading contains    1    2    Data file    testid:dataBlocks
     user checks table column heading contains    1    3    Has chart    testid:dataBlocks
     user checks table column heading contains    1    4    In content    testid:dataBlocks
     user checks table column heading contains    1    5    Created date    testid:dataBlocks
@@ -270,7 +270,7 @@ Validate data block is in list again
 
     user waits until table is visible
     user checks table column heading contains    1    1    Data block name    testid:featuredTables
-    user checks table column heading contains    1    2    Data set name    testid:featuredTables
+    user checks table column heading contains    1    2    Data file    testid:featuredTables
     user checks table column heading contains    1    3    Has chart    testid:featuredTables
     user checks table column heading contains    1    4    In content    testid:featuredTables
     user checks table column heading contains    1    5    Featured table name    testid:featuredTables
@@ -424,7 +424,7 @@ Validate marked as 'In content' on data block list
     user waits until h2 is visible    Data blocks
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name    testid:dataBlocks
+    user checks table column heading contains    1    1    Data block    testid:dataBlocks
     user checks table column heading contains    1    4    In content    testid:dataBlocks
 
     user checks table body has x rows    1
@@ -556,7 +556,7 @@ Save chart and validate marked as 'Has chart' in data blocks list
     user waits until page finishes loading
 
     user waits until table is visible
-    user checks table column heading contains    1    1    Name    testid:dataBlocks
+    user checks table column heading contains    1    1    Data block    testid:dataBlocks
     user checks table column heading contains    1    3    Has chart    testid:dataBlocks
 
     user checks table body has x rows    1
@@ -969,6 +969,44 @@ Create data block with categorical and numerical data
 
     user clicks button    Save data block
     user waits until page contains    Delete this data block
+
+Validate sorting the data blocks list
+    user clicks link    Data blocks
+    user waits until h2 is visible    Data blocks
+    user waits until page finishes loading
+
+    user waits until table is visible
+    user checks table body has x rows    2    testid:dataBlocks
+
+    # Sorted by data block name ascending by default
+    user checks table cell contains    1    1    ${DATABLOCK_2_NAME}    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_NAME}    testid:dataBlocks
+
+    user clicks button    Data block    testid:dataBlocks
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_2_NAME}    testid:dataBlocks
+
+    # "UI test subject" sorts before "UI test subject - categorical and numerical"
+    user clicks button    Data file    testid:dataBlocks
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_2_NAME}    testid:dataBlocks
+
+    user clicks button    Data file    testid:dataBlocks
+    user checks table cell contains    1    1    ${DATABLOCK_2_NAME}    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_NAME}    testid:dataBlocks
+
+    # Only ${DATABLOCK_NAME} has a chart, and is the only one in content
+    user clicks button    Has chart    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_NAME}    testid:dataBlocks
+
+    user clicks button    In content    testid:dataBlocks
+    user checks table cell contains    2    1    ${DATABLOCK_NAME}    testid:dataBlocks
+
+    # ${DATABLOCK_NAME} was created first
+    user clicks button    Created date    testid:dataBlocks
+    user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
+
+    user clicks edit data block link    ${DATABLOCK_2_NAME}
 
 Configure geographic chart with categorical and numerical data sets
     user clicks link    Chart

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -203,14 +203,16 @@ Validate data block is in list
 
     user waits until table is visible
     user checks table column heading contains    1    1    Name    testid:dataBlocks
-    user checks table column heading contains    1    2    Has chart    testid:dataBlocks
-    user checks table column heading contains    1    3    In content    testid:dataBlocks
-    user checks table column heading contains    1    4    Created date    testid:dataBlocks
-    user checks table column heading contains    1    5    Actions    testid:dataBlocks
+    user checks table column heading contains    1    2    Data set name    testid:dataBlocks
+    user checks table column heading contains    1    3    Has chart    testid:dataBlocks
+    user checks table column heading contains    1    4    In content    testid:dataBlocks
+    user checks table column heading contains    1    5    Created date    testid:dataBlocks
+    user checks table column heading contains    1    6    Actions    testid:dataBlocks
 
     user checks table body has x rows    1    testid:dataBlocks
     user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
-    user checks table cell contains    1    3    No    testid:dataBlocks
+    user checks table cell contains    1    2    UI test subject    testid:dataBlocks
+    user checks table cell contains    1    4    No    testid:dataBlocks
 
 Start creating a featured table
     user clicks link    Create data block
@@ -268,16 +270,18 @@ Validate data block is in list again
 
     user waits until table is visible
     user checks table column heading contains    1    1    Data block name    testid:featuredTables
-    user checks table column heading contains    1    2    Has chart    testid:featuredTables
-    user checks table column heading contains    1    3    In content    testid:featuredTables
-    user checks table column heading contains    1    4    Featured table name    testid:featuredTables
-    user checks table column heading contains    1    5    Created date    testid:featuredTables
-    user checks table column heading contains    1    6    Actions    testid:featuredTables
+    user checks table column heading contains    1    2    Data set name    testid:featuredTables
+    user checks table column heading contains    1    3    Has chart    testid:featuredTables
+    user checks table column heading contains    1    4    In content    testid:featuredTables
+    user checks table column heading contains    1    5    Featured table name    testid:featuredTables
+    user checks table column heading contains    1    6    Created date    testid:featuredTables
+    user checks table column heading contains    1    7    Actions    testid:featuredTables
 
     user checks table body has x rows    1    testid:featuredTables
     user checks table cell contains    1    1    UI test featured table    testid:featuredTables
-    user checks table cell contains    1    3    No    testid:featuredTables
-    user checks table cell contains    1    4    UI test featured table name    testid:featuredTables
+    user checks table cell contains    1    2    UI test subject    testid:featuredTables
+    user checks table cell contains    1    4    No    testid:featuredTables
+    user checks table cell contains    1    5    UI test featured table name    testid:featuredTables
 
 Embed data block into release content
     user clicks link    Content
@@ -421,11 +425,11 @@ Validate marked as 'In content' on data block list
 
     user waits until table is visible
     user checks table column heading contains    1    1    Name    testid:dataBlocks
-    user checks table column heading contains    1    3    In content    testid:dataBlocks
+    user checks table column heading contains    1    4    In content    testid:dataBlocks
 
     user checks table body has x rows    1
     user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
-    user checks table cell contains    1    3    Yes    testid:dataBlocks
+    user checks table cell contains    1    4    Yes    testid:dataBlocks
 
 Navigate to Chart tab
     user clicks edit data block link    ${DATABLOCK_NAME}
@@ -553,11 +557,11 @@ Save chart and validate marked as 'Has chart' in data blocks list
 
     user waits until table is visible
     user checks table column heading contains    1    1    Name    testid:dataBlocks
-    user checks table column heading contains    1    2    Has chart    testid:dataBlocks
+    user checks table column heading contains    1    3    Has chart    testid:dataBlocks
 
     user checks table body has x rows    1
     user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
-    user checks table cell contains    1    2    Yes    testid:dataBlocks
+    user checks table cell contains    1    3    Yes    testid:dataBlocks
 
 Validate line chart embeds correctly
     user clicks link    Content

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -287,8 +287,8 @@ Edit data block for amendment
 
     user checks table body has x rows    1
     user checks table cell contains    1    1    ${DATABLOCK_NAME}
-    user checks table cell contains    1    2    Yes
     user checks table cell contains    1    3    Yes
+    user checks table cell contains    1    4    Yes
 
     user clicks edit data block link    ${DATABLOCK_NAME}
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -582,8 +582,8 @@ Edit data block for amendment
 
     user checks table body has x rows    1
     user checks table cell contains    1    1    ${DATABLOCK_NAME}
-    user checks table cell contains    1    2    Yes
     user checks table cell contains    1    3    Yes
+    user checks table cell contains    1    4    Yes
 
     user clicks edit data block link    ${DATABLOCK_NAME}
 

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -10,7 +10,7 @@ user waits until table is visible
 user checks table column heading contains
     [Arguments]    ${row}    ${column}    ${expected}    ${parent}=css:table    ${wait}=%{WAIT_SMALL}
     user waits until parent contains element    ${parent}
-    ...    xpath://thead/tr[${row}]/th[${column}][text()="${expected}"]
+    ...    xpath:.//thead/tr[${row}]/th[${column}][contains(., "${expected}")]
     ...    timeout=${wait}
 
 user checks row contains heading


### PR DESCRIPTION
This PR amends the admin datablocks (and featured tables) list page to show which data set the data block comes from in the listing tables.

**N.b the backend changes have been made by Claude, so could do with more reviewing from a BE dev**

Additionally, it adds sort functionality to the data blocks table (but not the featured tables table as that already has custom ordering in place). This may be reusable in other tables in future if it proves useful.

Users can sort by any of the columns (except action buttons column) and the chevrons indicate unsorted, sorted asc or desc.

I've taken reference from the following for implementing style and accessibility:

- https://design-patterns.service.justice.gov.uk/components/sortable-table/
- https://service-manual.nhs.uk/design-system/components/table#sortable-table
- https://service-manual.ons.gov.uk/design-system/components/table#example.example-table-sortable.html

Before:
<img width="980" height="495" alt="image" src="https://github.com/user-attachments/assets/4cab6c0d-bb32-466d-a8fb-3be9dea8d6f2" />

After:
<img width="1000" height="651" alt="file-16d8d2a9ec3c78b401ac5bc9880eaa5e" src="https://github.com/user-attachments/assets/04504242-206d-4c7f-a255-5469d06efaf1" />

