### PR TITLE
EES-7569 Fix UI tests

### DIFF
--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -39,33 +39,26 @@ Validate other selected step options
     user checks previous table tool step contains    5    Characteristic    Total
 
 Validate table data
-    user checks table column heading contains    1    1    2016/17
-    user checks table column heading contains    1    2    2015/16
-    user checks table column heading contains    1    3    2014/15
-    user checks table column heading contains    1    4    2013/14
-    user checks table column heading contains    1    5    2012/13
+    user checks table contains column heading    2016/17
+    user checks table contains column heading    2015/16
+    user checks table contains column heading    2014/15
+    user checks table contains column heading    2013/14
+    user checks table contains column heading    2012/13
 
-    user checks table row heading contains    1    1    Authorised absence rate
-    user checks table row heading contains    2    1    Overall absence rate
-    user checks table row heading contains    3    1    Unauthorised absence rate
+    user checks cell by row and column heading contains    Authorised absence rate    2016/17    3.4%
+    user checks cell by row and column heading contains    Authorised absence rate    2015/16    3.4%
+    user checks cell by row and column heading contains    Authorised absence rate    2014/15    3.5%
+    user checks cell by row and column heading contains    Authorised absence rate    2013/14    3.5%
+    user checks cell by row and column heading contains    Authorised absence rate    2012/13    4.2%
 
-    # Authorised absence rate
-    user checks table cell contains    1    1    3.4%
-    user checks table cell contains    1    2    3.4%
-    user checks table cell contains    1    3    3.5%
-    user checks table cell contains    1    4    3.5%
-    user checks table cell contains    1    5    4.2%
+    user checks cell by row and column heading contains    Overall absence rate    2016/17    4.7%
+    user checks cell by row and column heading contains    Overall absence rate    2015/16    4.6%
+    user checks cell by row and column heading contains    Overall absence rate    2014/15    4.6%
+    user checks cell by row and column heading contains    Overall absence rate    2013/14    4.5%
+    user checks cell by row and column heading contains    Overall absence rate    2012/13    5.3%
 
-    # Overall absence rate
-    user checks table cell contains    2    1    4.7%
-    user checks table cell contains    2    2    4.6%
-    user checks table cell contains    2    3    4.6%
-    user checks table cell contains    2    4    4.5%
-    user checks table cell contains    2    5    5.3%
-
-    # Unauthorised absence rate
-    user checks table cell contains    3    1    1.3%
-    user checks table cell contains    3    2    1.1%
-    user checks table cell contains    3    3    1.1%
-    user checks table cell contains    3    4    1.1%
-    user checks table cell contains    3    5    1.1%
+    user checks cell by row and column heading contains    Unauthorised absence rate    2016/17    1.3%
+    user checks cell by row and column heading contains    Unauthorised absence rate    2015/16    1.1%
+    user checks cell by row and column heading contains    Unauthorised absence rate    2014/15    1.1%
+    user checks cell by row and column heading contains    Unauthorised absence rate    2013/14    1.1%
+    user checks cell by row and column heading contains    Unauthorised absence rate    2012/13    1.1%

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -36,8 +36,7 @@ Validate next release and summary list items
     user checks element should contain    testid:Release type-value    Official statistics
     user checks element should contain    testid:Produced by-value    Department for Education
     user checks summary list contains    Published    26 March 2020
-    # Commented out temporarily until we have worked out how to fix this date in the seeder (EES-7238)
-    # user checks summary list contains    Last updated    8 June 2026
+    user checks summary list contains    Last updated    8 June 2026
     user checks element contains    testid:release-summary-block    3 updates
 
 Verify the release updates page
@@ -47,8 +46,7 @@ Verify the release updates page
     ...    ${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
 
     user checks table body has x rows    4    testid:release-updates-table
-    # Commented out temporarily until we have worked out how to fix this date in the seeder (EES-7238)
-    # user checks table cell contains    1    1    8 June 2026    testid:release-updates-table
+    user checks table cell contains    1    1    8 June 2026    testid:release-updates-table
     user checks table cell contains    1    2    First published    testid:release-updates-table
 
     user checks table cell contains    2    1    9 March 2022    testid:release-updates-table
@@ -77,34 +75,40 @@ Validate "Releases in this series" page
     ...    ${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
 
     user checks table body has x rows    7    testid:release-updates-table
-    user checks table cell contains    1    1    Academic year 2016/17    testid:release-updates-table
-    user checks table cell contains    1    2    26 March 2020    testid:release-updates-table
-    # Commented out temporarily until we have worked out how to fix this date in the seeder (EES-7238)
-    # user checks table cell contains    1    3    8 June 2026    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2016/17    2    26 March 2020
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2016/17    3    8 June 2026
+    ...    testid:release-updates-table
 
-    user checks table cell contains    2    1    Academic year 2009/10    testid:release-updates-table
-    user checks table cell contains    2    2    Not available    testid:release-updates-table
-    user checks table cell contains    2    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2009/10    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2009/10    3    Not available
+    ...    testid:release-updates-table
 
-    user checks table cell contains    3    1    Academic year 2010/11    testid:release-updates-table
-    user checks table cell contains    3    2    Not available    testid:release-updates-table
-    user checks table cell contains    3    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2010/11    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2010/11    3    Not available
+    ...    testid:release-updates-table
 
-    user checks table cell contains    4    1    Academic year 2011/12    testid:release-updates-table
-    user checks table cell contains    4    2    Not available    testid:release-updates-table
-    user checks table cell contains    4    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2011/12    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2011/12    3    Not available
+    ...    testid:release-updates-table
 
-    user checks table cell contains    5    1    Academic year 2012/13    testid:release-updates-table
-    user checks table cell contains    5    2    Not available    testid:release-updates-table
-    user checks table cell contains    5    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2012/13    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2012/13    3    Not available
+    ...    testid:release-updates-table
 
-    user checks table cell contains    6    1    Academic year 2013/14    testid:release-updates-table
-    user checks table cell contains    6    2    Not available    testid:release-updates-table
-    user checks table cell contains    6    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2013/14    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2013/14    3    Not available
+    ...    testid:release-updates-table
 
-    user checks table cell contains    7    1    Academic year 2014/15    testid:release-updates-table
-    user checks table cell contains    7    2    Not available    testid:release-updates-table
-    user checks table cell contains    7    3    Not available    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2014/15    2    Not available
+    ...    testid:release-updates-table
+    user checks table body row cell contains    Academic year 2014/15    3    Not available
+    ...    testid:release-updates-table
 
     user clicks link    Release home (latest release)
     user waits until page finishes loading
@@ -175,35 +179,31 @@ Validate Headlines facts and figures -- Data tables tab
     user waits until element contains    css:[data-testid="dataTableCaption"]
     ...    'Absence by characteristic' in England between 2012/13 and 2016/17    %{WAIT_SMALL}
 
-    user checks table column heading contains    1    1    2016/17    css:#releaseHeadlines-tables table
-    user checks table column heading contains    1    2    2015/16    css:#releaseHeadlines-tables table
-    user checks table column heading contains    1    3    2014/15    css:#releaseHeadlines-tables table
-    user checks table column heading contains    1    4    2013/14    css:#releaseHeadlines-tables table
-    user checks table column heading contains    1    5    2012/13    css:#releaseHeadlines-tables table
+    ${table}=    set variable    css:#releaseHeadlines-tables table
 
-    ${row}=    set variable    xpath://tbody/tr[th[normalize-space() = 'Authorised absence rate']]
-    user checks row contains heading    ${row}    Authorised absence rate
-    user checks row cell contains text    ${row}    1    3.4
-    user checks row cell contains text    ${row}    2    3.4
-    user checks row cell contains text    ${row}    3    3.5
-    user checks row cell contains text    ${row}    4    3.5
-    user checks row cell contains text    ${row}    5    4.2
+    user checks table contains column heading    2016/17    ${table}
+    user checks table contains column heading    2015/16    ${table}
+    user checks table contains column heading    2014/15    ${table}
+    user checks table contains column heading    2013/14    ${table}
+    user checks table contains column heading    2012/13    ${table}
 
-    ${row}=    set variable    xpath://tbody/tr[th[normalize-space() = 'Unauthorised absence rate']]
-    user checks row contains heading    ${row}    Unauthorised absence rate
-    user checks row cell contains text    ${row}    1    1.3
-    user checks row cell contains text    ${row}    2    1.1
-    user checks row cell contains text    ${row}    3    1.1
-    user checks row cell contains text    ${row}    4    1.1
-    user checks row cell contains text    ${row}    5    1.1
+    user checks cell by row and column heading contains    Authorised absence rate    2016/17    3.4    ${table}
+    user checks cell by row and column heading contains    Authorised absence rate    2015/16    3.4    ${table}
+    user checks cell by row and column heading contains    Authorised absence rate    2014/15    3.5    ${table}
+    user checks cell by row and column heading contains    Authorised absence rate    2013/14    3.5    ${table}
+    user checks cell by row and column heading contains    Authorised absence rate    2012/13    4.2    ${table}
 
-    ${row}=    set variable    xpath://tbody/tr[th[normalize-space() = 'Overall absence rate']]
-    user checks row contains heading    ${row}    Overall absence rate
-    user checks row cell contains text    ${row}    1    4.7
-    user checks row cell contains text    ${row}    2    4.6
-    user checks row cell contains text    ${row}    3    4.6
-    user checks row cell contains text    ${row}    4    4.5
-    user checks row cell contains text    ${row}    5    5.3
+    user checks cell by row and column heading contains    Unauthorised absence rate    2016/17    1.3    ${table}
+    user checks cell by row and column heading contains    Unauthorised absence rate    2015/16    1.1    ${table}
+    user checks cell by row and column heading contains    Unauthorised absence rate    2014/15    1.1    ${table}
+    user checks cell by row and column heading contains    Unauthorised absence rate    2013/14    1.1    ${table}
+    user checks cell by row and column heading contains    Unauthorised absence rate    2012/13    1.1    ${table}
+
+    user checks cell by row and column heading contains    Overall absence rate    2016/17    4.7    ${table}
+    user checks cell by row and column heading contains    Overall absence rate    2015/16    4.6    ${table}
+    user checks cell by row and column heading contains    Overall absence rate    2014/15    4.6    ${table}
+    user checks cell by row and column heading contains    Overall absence rate    2013/14    4.5    ${table}
+    user checks cell by row and column heading contains    Overall absence rate    2012/13    5.3    ${table}
 
     user checks section with ID contains elements and back to top link    releaseHeadlines-tables
     ...    Show full screen table

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -13,6 +13,12 @@ user checks table column heading contains
     ...    xpath://thead/tr[${row}]/th[${column}][text()="${expected}"]
     ...    timeout=${wait}
 
+user checks table contains column heading
+    [Arguments]    ${expected}    ${parent}=css:table    ${wait}=%{WAIT_SMALL}
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//thead/tr/th[text()="${expected}"]
+    ...    timeout=${wait}
+
 user checks row contains heading
     [Arguments]    ${row_elem}    ${heading}
     user waits until parent contains element    ${row_elem}    xpath:.//th[text()="${heading}"]
@@ -92,6 +98,23 @@ user checks headed table body row cell contains
     [Arguments]    ${row_heading}    ${cell}    ${content}    ${parent}=css:table    ${wait}=${timeout}
     user waits until parent contains element    ${parent}
     ...    xpath:.//tbody/tr/th[text()="${row_heading}"]/../td[${cell}][contains(., "${content}")]    timeout=${wait}
+
+user checks table body row cell contains
+    [Arguments]    ${row_cell_text}    ${cell}    ${content}    ${parent}=css:table    ${wait}=${timeout}
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//tbody/tr/td[1][contains(., "${row_cell_text}")]/../td[${cell}][contains(., "${content}")]
+    ...    timeout=${wait}
+
+user checks cell by row and column heading contains
+    [Arguments]    ${row_heading}    ${column_heading}    ${content}    ${parent}=css:table    ${wait}=${timeout}
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//thead/tr/th[normalize-space()="${column_heading}"]
+    ...    timeout=${wait}
+    ${column}=    set variable
+    ...    count(../../../thead/tr/th[normalize-space()="${column_heading}"]/preceding-sibling::th) + 1
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//tbody/tr[th[normalize-space()="${row_heading}"]]/td[${column}][contains(., "${content}")]
+    ...    timeout=${wait}
 
 user clicks link in table cell
     [Arguments]    ${row}    ${column}    ${link_text}    ${parent}=css:table


### PR DESCRIPTION
This PR fixes UI test failures where the tests were expecting specific years/values in specific table columns. This change now makes the tests agnostic to the column used, and instead just ensures that the data is there under the row/column with the label expected.

As part of this work, I also updated various releaseVersion's Published and PublishedDisplayDate on the publication `Seed publication - Pupil absence in schools in England` match our local seed data.