### PR TITLE
EES-7175 - Reduce availability test alert evaluation to 1 minute.

### DIFF
--- a/infrastructure/templates/common/components/monitoring/availability-test.bicep
+++ b/infrastructure/templates/common/components/monitoring/availability-test.bicep
@@ -49,7 +49,7 @@ param alertsGroupName string
 param alertSeverity Severity = 'Critical'
 
 @description('The frequency with which the alert rule evaluates the availability test results against the threshold.')
-param alertEvaluationFrequency EvaluationFrequency = 'PT5M'
+param alertEvaluationFrequency EvaluationFrequency = 'PT1M'
 
 @description('The timespan used to evaluate failed test location count against the threshold.')
 param alertWindowSize WindowSize = 'PT5M'
@@ -65,7 +65,7 @@ param tagValues object
 
 var severityLevel = severityMapping[alertSeverity]
 
-var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}.  This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. For more info, review guidance on diagnosing availability test failures https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation'
+var alertFullDescription = 'Fires when ${testDescription} fails from ${minFailedLocationsToAlert} or more of ${length(testLocations)} test locations. URL tested: ${url}.  This endpoint depends on FUAPI, PostgreSQL and Azure AI Search - if the Public API app itself is healthy, check those next. For more info, review guidance on [diagnosing availability test failures](https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/18320/Public-API-availability-alert-investigation).'
 
 resource availabilityTest 'Microsoft.Insights/webtests@2022-06-15' = {
   name: name


### PR DESCRIPTION
This PR changes the public API's availability test's alert evaluation configuration from every 5 minute to every 1 minute. 
Testing this change reduces the time in-between when 3 failed API calls from 3 location and the slack/teams message being sent. This also reduces the time the alert auto-closes.
This was the timings I recorded doing a quick test:

At 14:55, turned off public API
At 15:00 alert raised
At 15:02 turned on public API
At 15:09 alert resolved

This PR also slightly tweaks the message posted to the webhooks. 

<img width="1123" height="1267" alt="image" src="https://github.com/user-attachments/assets/d3fae030-0ada-45f7-b839-d6af8c488d8d" />
