### PR TITLE
EES-7539 - Fix failing robot tests

### DIFF
--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -111,7 +111,6 @@ User verifies the 'Draft API data set' summary list
     user checks list contains exact items in order    testid:Actions
     ...    Preview API data set
     ...    View preview token log
-    ...    Unfinalise this data set version
     ...    Remove draft version
 
 User clicks on 'Preview API data set' link

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -149,7 +149,6 @@ User checks row data contents inside the 'Draft API data sets' summary table
     user checks list contains exact items in order    testid:Actions
     ...    Preview API data set
     ...    View preview token log
-    ...    Unfinalise this data set version
     ...    Remove draft version
 
 Add headline text block to Content page


### PR DESCRIPTION
This PR fixes two failing robot tests which were incorrectly asserting for the 'Unfinalize' button being present on a data set version which is version 1. This started to break after the bug fix https://github.com/dfe-analytical-services/explore-education-statistics/pull/7271 got merged. This change should've been in that PR in order to avoid breaking UI tests.