### PR TITLE
Ees 7241 data replacement filters fe

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -112,6 +112,7 @@ describe('ReleaseDataFileReplacePage', () => {
     mapping: {
       indicators: { candidates: {}, mappings: {} },
       locations: { candidates: {}, mappings: {} },
+      filters: { candidates: {}, mappings: {} },
     },
   };
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
@@ -5,6 +5,7 @@ import dataReplacementService, {
   FilterMappingPlan,
   FilterMappingSource,
   PlanMappings,
+  ReplacementMapping,
   UpdateMappingPayload,
 } from '@admin/services/dataReplacementService';
 import React, { useCallback, useEffect, useMemo } from 'react';
@@ -19,6 +20,43 @@ interface Props {
   plan: DataReplacementPlan;
   reloadPlan: () => void;
 }
+
+type FilterMappings =
+  | FilterMappingPlan
+  | FilterMappingFilterGroups
+  | FilterMappingFilterItems<FilterMappingSource>;
+
+const findFilterMapping = (
+  filters: FilterMappings,
+  sourceKey: string,
+): ReplacementMapping<FilterMappingSource> | undefined => {
+  const mapping = filters.mappings[sourceKey];
+
+  if (mapping) {
+    return mapping;
+  }
+
+  for (let i = 0; i < Object.values(filters.mappings).length; i += 1) {
+    const child = Object.values(filters.mappings)[i];
+    if ('filterGroups' in child) {
+      const result = findFilterMapping(
+        child.filterGroups as FilterMappingFilterGroups,
+        sourceKey,
+      );
+      if (result) return result;
+    }
+
+    if ('filterItems' in child) {
+      const result = findFilterMapping(
+        child.filterItems as FilterMappingFilterItems<FilterMappingSource>,
+        sourceKey,
+      );
+      if (result) return result;
+    }
+  }
+
+  return undefined;
+};
 
 export default function DataFileReplacementDifferences({
   releaseVersionId,
@@ -56,26 +94,48 @@ export default function DataFileReplacementDifferences({
 
   const handleIndicatorsMappingUpdate = useCallback(
     async ({ sourceKey, candidateKey }: UpdateMappingPayload) => {
+      const currentMapping = planMappings.indicators.mappings[sourceKey];
+
+      if (!currentMapping) {
+        throw new Error(`Could not find indicator mapping: ${sourceKey}`);
+      }
+
+      const previousMapping = {
+        candidateKey: currentMapping.candidateKey,
+        type: currentMapping.type,
+      };
+
       updatePlanMappings(draft => {
         draft.indicators.mappings[sourceKey].candidateKey = candidateKey;
         draft.indicators.mappings[sourceKey].type = 'ManuallySet';
         return draft;
       });
-      await dataReplacementService.updatePlanIndicatorMappings(
-        releaseVersionId,
-        fileId,
-        replacementFileId,
-        [
-          {
-            originalId: sourceKey,
-            newReplacementId: candidateKey,
-          },
-        ],
-      );
 
-      reloadPlan();
+      try {
+        await dataReplacementService.updatePlanIndicatorMappings(
+          releaseVersionId,
+          fileId,
+          replacementFileId,
+          [
+            {
+              originalId: sourceKey,
+              newReplacementId: candidateKey,
+            },
+          ],
+        );
+
+        reloadPlan();
+      } catch (error) {
+        updatePlanMappings(draft => {
+          draft.indicators.mappings[sourceKey].candidateKey =
+            previousMapping.candidateKey;
+          draft.indicators.mappings[sourceKey].type = previousMapping.type;
+          return draft;
+        });
+      }
     },
     [
+      planMappings.indicators.mappings,
       updatePlanMappings,
       releaseVersionId,
       fileId,
@@ -86,26 +146,48 @@ export default function DataFileReplacementDifferences({
 
   const handleLocationsMappingUpdate = useCallback(
     async ({ sourceKey, candidateKey }: UpdateMappingPayload) => {
+      const currentMapping = planMappings.locations.mappings[sourceKey];
+
+      if (!currentMapping) {
+        throw new Error(`Could not find location mapping: ${sourceKey}`);
+      }
+
+      const previousMapping = {
+        candidateKey: currentMapping.candidateKey,
+        type: currentMapping.type,
+      };
+
       updatePlanMappings(draft => {
         draft.locations.mappings[sourceKey].candidateKey = candidateKey;
         draft.locations.mappings[sourceKey].type = 'ManuallySet';
         return draft;
       });
-      await dataReplacementService.updatePlanLocationMappings(
-        releaseVersionId,
-        fileId,
-        replacementFileId,
-        [
-          {
-            originalId: sourceKey,
-            newReplacementId: candidateKey,
-          },
-        ],
-      );
 
-      reloadPlan();
+      try {
+        await dataReplacementService.updatePlanLocationMappings(
+          releaseVersionId,
+          fileId,
+          replacementFileId,
+          [
+            {
+              originalId: sourceKey,
+              newReplacementId: candidateKey,
+            },
+          ],
+        );
+
+        reloadPlan();
+      } catch (error) {
+        updatePlanMappings(draft => {
+          draft.locations.mappings[sourceKey].candidateKey =
+            previousMapping.candidateKey;
+          draft.locations.mappings[sourceKey].type = previousMapping.type;
+          return draft;
+        });
+      }
     },
     [
+      planMappings.locations.mappings,
       updatePlanMappings,
       releaseVersionId,
       fileId,
@@ -118,64 +200,56 @@ export default function DataFileReplacementDifferences({
     async (updatePayload: UpdateMappingPayload, type: string) => {
       const { sourceKey, candidateKey } = updatePayload;
 
+      const currentMapping = findFilterMapping(planMappings.filters, sourceKey);
+
+      if (!currentMapping) {
+        throw new Error(`Could not find filter mapping: ${sourceKey}`);
+      }
+
+      const previousMapping = {
+        candidateKey: currentMapping.candidateKey,
+        type: currentMapping.type,
+      };
+
       updatePlanMappings(draft => {
-        const updateMapping = (
-          mappingsPlan:
-            | FilterMappingPlan
-            | FilterMappingFilterGroups
-            | FilterMappingFilterItems<FilterMappingSource>,
-        ): boolean => {
-          const mapping = mappingsPlan.mappings[sourceKey];
+        const mapping = findFilterMapping(draft.filters, sourceKey);
 
-          if (mapping) {
-            mapping.candidateKey = candidateKey;
-            mapping.type = 'ManuallySet';
-            return true;
-          }
-
-          return Object.values(mappingsPlan.mappings).some(childMapping => {
-            if ('filterGroups' in childMapping) {
-              return updateMapping(
-                childMapping.filterGroups as FilterMappingFilterGroups,
-              );
-            }
-
-            if ('filterItems' in childMapping) {
-              return updateMapping(
-                childMapping.filterItems as FilterMappingFilterItems<FilterMappingSource>,
-              );
-            }
-
-            return false;
-          });
-        };
-
-        updateMapping(draft.filters);
-
-        return draft;
+        if (mapping) {
+          mapping.candidateKey = candidateKey;
+          mapping.type = 'ManuallySet';
+        }
       });
 
-      const updateData = {
-        originalId: updatePayload.sourceKey,
-        newReplacementId: updatePayload.candidateKey,
+      const update = {
+        originalId: sourceKey,
+        newReplacementId: candidateKey,
       };
-      const filterUpdates = type === 'filter' ? [updateData] : [];
-      const filterGroupUpdates = type === 'group' ? [updateData] : [];
-      const filterItemUpdates = type === 'item' ? [updateData] : [];
 
-      await dataReplacementService.updatePlanFilterMappings(
-        releaseVersionId,
-        fileId,
-        replacementFileId,
-        filterUpdates,
-        filterGroupUpdates,
-        filterItemUpdates,
-      );
+      try {
+        await dataReplacementService.updatePlanFilterMappings(
+          releaseVersionId,
+          fileId,
+          replacementFileId,
+          type === 'filter' ? [update] : [],
+          type === 'group' ? [update] : [],
+          type === 'item' ? [update] : [],
+        );
 
-      reloadPlan();
+        reloadPlan();
+      } catch (error) {
+        updatePlanMappings(draft => {
+          const mapping = findFilterMapping(draft.filters, sourceKey);
+
+          if (mapping) {
+            mapping.candidateKey = previousMapping.candidateKey;
+            mapping.type = previousMapping.type;
+          }
+        });
+      }
     },
     [
       fileId,
+      planMappings.filters,
       releaseVersionId,
       reloadPlan,
       replacementFileId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
@@ -7,7 +7,7 @@ import dataReplacementService, {
   PlanMappings,
   UpdateMappingPayload,
 } from '@admin/services/dataReplacementService';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useImmer } from 'use-immer';
 import DataFileReplacementFilterDifferencesTable from '@admin/pages/release/data/components/DataFileReplacementFilterDifferencesTable';
 import DataFileReplacementDifferencesTable from './DataFileReplacementDifferencesTable';
@@ -30,6 +30,10 @@ export default function DataFileReplacementDifferences({
   const [planMappings, updatePlanMappings] = useImmer<PlanMappings>(
     plan.mapping,
   );
+
+  useEffect(() => {
+    updatePlanMappings(plan.mapping);
+  }, [plan.mapping, updatePlanMappings]);
 
   // instead of passing the datablocks down to the tables, it seems better to handle this here
   const indicatorReplacementGroups = useMemo(() => {
@@ -219,7 +223,7 @@ export default function DataFileReplacementDifferences({
       />
 
       <DataFileReplacementFilterDifferencesTable
-        filters={plan.mapping.filters}
+        filters={planMappings.filters}
         handleMappingUpdate={handleFiltersMappingUpdate}
       />
     </>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferences.tsx
@@ -1,20 +1,16 @@
 import dataReplacementService, {
   DataReplacementPlan,
-  IndicatorGroupReplacement,
-  LocationReplacement,
-  MappingsPlan,
+  FilterMappingFilterGroups,
+  FilterMappingFilterItems,
+  FilterMappingPlan,
+  FilterMappingSource,
   PlanMappings,
-  ReplacementMapping,
-  TargetReplacement,
   UpdateMappingPayload,
 } from '@admin/services/dataReplacementService';
 import React, { useCallback, useMemo } from 'react';
 import { useImmer } from 'use-immer';
-import pickBy from 'lodash/pickBy';
-import { Dictionary } from '@common/types';
-import DataFileReplacementDifferencesTable, {
-  TableMappingGroup,
-} from './DataFileReplacementDifferencesTable';
+import DataFileReplacementFilterDifferencesTable from '@admin/pages/release/data/components/DataFileReplacementFilterDifferencesTable';
+import DataFileReplacementDifferencesTable from './DataFileReplacementDifferencesTable';
 
 interface Props {
   releaseVersionId: string;
@@ -24,67 +20,6 @@ interface Props {
   reloadPlan: () => void;
 }
 
-const getNonAutoSetMappings = (mappings: MappingsPlan<unknown>['mappings']) => {
-  return pickBy(mappings, value => value.type !== 'AutoSet');
-};
-
-export function uniqueByLabel<T extends { label: string }>(items: T[]): T[] {
-  return Array.from(new Map(items.map(item => [item.label, item])).values());
-}
-
-/**
- * Builds the data for the tables.
- *
- * This is restricted to items in the groups that are in the replacement mappings.
- *
- * Returns an object containing both:
- * Groups of mapping ids with the same structure as the original groups (filters out empty groups)
- * A set of all mapping ids that both exist in the replacement mappings and the original groups
- *
- */
-function createTableMappingsAndGroups<
-  G extends IndicatorGroupReplacement | LocationReplacement,
-  R extends (G[keyof G] extends TargetReplacement ? G[keyof G] : never),
->(
-  replacementMappings: Dictionary<ReplacementMapping<unknown>>,
-  groups: G[],
-  childKey: keyof G,
-) {
-  return groups.reduce<{
-    allUniqueMappingIds: Set<string>;
-    groupedMappings: TableMappingGroup[];
-  }>(
-    ({ allUniqueMappingIds, groupedMappings }, group) => {
-      const children = (group[childKey] ?? []) as R[];
-
-      const filteredChildren = children.filter(
-        child => replacementMappings[child.id],
-      );
-      if (filteredChildren.length === 0)
-        return { allUniqueMappingIds, groupedMappings };
-
-      const mappings = filteredChildren.map(child => child.id);
-
-      mappings.forEach(childId => allUniqueMappingIds.add(childId));
-
-      return {
-        allUniqueMappingIds,
-        groupedMappings: [
-          ...groupedMappings,
-          {
-            label: group.label,
-            mappings,
-          },
-        ],
-      };
-    },
-    {
-      allUniqueMappingIds: new Set<string>(),
-      groupedMappings: [],
-    },
-  );
-}
-
 export default function DataFileReplacementDifferences({
   releaseVersionId,
   fileId,
@@ -92,14 +27,14 @@ export default function DataFileReplacementDifferences({
   plan,
   reloadPlan,
 }: Props) {
-  const groupsAndMappingsForTables = useMemo(() => {
-    // first determine the indicators
-    const indicatorsToShow = getNonAutoSetMappings(
-      plan.mapping.indicators.mappings,
-    );
+  const [planMappings, updatePlanMappings] = useImmer<PlanMappings>(
+    plan.mapping,
+  );
 
+  // instead of passing the datablocks down to the tables, it seems better to handle this here
+  const indicatorReplacementGroups = useMemo(() => {
     // combine all indicator groups from data blocks and footnotes and then dedupe by label
-    const allIndicatorGroups = [
+    return [
       ...plan.dataBlocks.flatMap(block =>
         Object.values(block.indicatorGroups || {}),
       ),
@@ -107,54 +42,13 @@ export default function DataFileReplacementDifferences({
         Object.values(footnote.indicatorGroups || {}),
       ),
     ];
+  }, [plan.dataBlocks, plan.footnotes]);
 
-    const uniqueIndicatorGroups = uniqueByLabel(allIndicatorGroups);
-
-    const groupedIndicatorMappings = createTableMappingsAndGroups(
-      indicatorsToShow,
-      uniqueIndicatorGroups,
-      'indicators',
-    );
-
-    const allLocations = plan.dataBlocks.flatMap(block =>
+  const locationReplacementGroups = useMemo(() => {
+    return plan.dataBlocks.flatMap(block =>
       Object.values(block.locations || {}),
     );
-
-    const uniqueLocationGroups = uniqueByLabel(allLocations);
-
-    // second determine the locations
-    const locationsToShow = getNonAutoSetMappings(
-      plan.mapping.locations.mappings,
-    );
-
-    const groupedLocationMappings = createTableMappingsAndGroups(
-      locationsToShow,
-      uniqueLocationGroups,
-      'locationAttributes',
-    );
-
-    // TODO: filters will follow a similar pattern
-
-    return {
-      indicators: {
-        allUniqueMappingIds: groupedIndicatorMappings.allUniqueMappingIds,
-        groupedMappings: groupedIndicatorMappings.groupedMappings,
-      },
-      locations: {
-        allUniqueMappingIds: groupedLocationMappings.allUniqueMappingIds,
-        groupedMappings: groupedLocationMappings.groupedMappings,
-      },
-    };
-  }, [
-    plan.dataBlocks,
-    plan.footnotes,
-    plan.mapping.indicators.mappings,
-    plan.mapping.locations.mappings,
-  ]);
-
-  const [planMappings, updatePlanMappings] = useImmer<PlanMappings>(
-    plan.mapping,
-  );
+  }, [plan.dataBlocks]);
 
   const handleIndicatorsMappingUpdate = useCallback(
     async ({ sourceKey, candidateKey }: UpdateMappingPayload) => {
@@ -216,6 +110,75 @@ export default function DataFileReplacementDifferences({
     ],
   );
 
+  const handleFiltersMappingUpdate = useCallback(
+    async (updatePayload: UpdateMappingPayload, type: string) => {
+      const { sourceKey, candidateKey } = updatePayload;
+
+      updatePlanMappings(draft => {
+        const updateMapping = (
+          mappingsPlan:
+            | FilterMappingPlan
+            | FilterMappingFilterGroups
+            | FilterMappingFilterItems<FilterMappingSource>,
+        ): boolean => {
+          const mapping = mappingsPlan.mappings[sourceKey];
+
+          if (mapping) {
+            mapping.candidateKey = candidateKey;
+            mapping.type = 'ManuallySet';
+            return true;
+          }
+
+          return Object.values(mappingsPlan.mappings).some(childMapping => {
+            if ('filterGroups' in childMapping) {
+              return updateMapping(
+                childMapping.filterGroups as FilterMappingFilterGroups,
+              );
+            }
+
+            if ('filterItems' in childMapping) {
+              return updateMapping(
+                childMapping.filterItems as FilterMappingFilterItems<FilterMappingSource>,
+              );
+            }
+
+            return false;
+          });
+        };
+
+        updateMapping(draft.filters);
+
+        return draft;
+      });
+
+      const updateData = {
+        originalId: updatePayload.sourceKey,
+        newReplacementId: updatePayload.candidateKey,
+      };
+      const filterUpdates = type === 'filter' ? [updateData] : [];
+      const filterGroupUpdates = type === 'group' ? [updateData] : [];
+      const filterItemUpdates = type === 'item' ? [updateData] : [];
+
+      await dataReplacementService.updatePlanFilterMappings(
+        releaseVersionId,
+        fileId,
+        replacementFileId,
+        filterUpdates,
+        filterGroupUpdates,
+        filterItemUpdates,
+      );
+
+      reloadPlan();
+    },
+    [
+      fileId,
+      releaseVersionId,
+      reloadPlan,
+      replacementFileId,
+      updatePlanMappings,
+    ],
+  );
+
   return (
     <>
       <h3>Mapping Dependencies</h3>
@@ -228,40 +191,37 @@ export default function DataFileReplacementDifferences({
         represented.
       </p>
 
-      {groupsAndMappingsForTables.indicators.allUniqueMappingIds.size > 0 && (
-        <DataFileReplacementDifferencesTable
-          tableId="replacements-differences-indicators-table"
-          itemType="indicator"
-          mappingsPlan={planMappings.indicators}
-          mappingGroups={groupsAndMappingsForTables.indicators.groupedMappings}
-          mappingsToShow={
-            groupsAndMappingsForTables.indicators.allUniqueMappingIds
-          }
-          handleMappingUpdate={handleIndicatorsMappingUpdate}
-          rowLabel="label"
-          mappedDataLabels={{
-            label: 'Label',
-            name: 'Name',
-          }}
-        />
-      )}
-      {groupsAndMappingsForTables.locations.allUniqueMappingIds.size > 0 && (
-        <DataFileReplacementDifferencesTable
-          tableId="replacements-differences-locations-table"
-          itemType="location"
-          mappingsPlan={planMappings.locations}
-          mappingGroups={groupsAndMappingsForTables.locations.groupedMappings}
-          mappingsToShow={
-            groupsAndMappingsForTables.locations.allUniqueMappingIds
-          }
-          handleMappingUpdate={handleLocationsMappingUpdate}
-          rowLabel="name"
-          mappedDataLabels={{
-            name: 'Name',
-            code: 'Code',
-          }}
-        />
-      )}
+      <DataFileReplacementDifferencesTable
+        tableId="replacements-differences-indicators-table"
+        itemType="indicator"
+        mappingsPlan={planMappings.indicators}
+        replacementGroups={indicatorReplacementGroups}
+        getGroupMappings={group => group.indicators}
+        handleMappingUpdate={handleIndicatorsMappingUpdate}
+        rowLabel="label"
+        mappedDataLabels={{
+          label: 'Label',
+          name: 'Name',
+        }}
+      />
+      <DataFileReplacementDifferencesTable
+        tableId="replacements-differences-locations-table"
+        itemType="location"
+        mappingsPlan={planMappings.locations}
+        replacementGroups={locationReplacementGroups}
+        getGroupMappings={group => group.locationAttributes}
+        handleMappingUpdate={handleLocationsMappingUpdate}
+        rowLabel="name"
+        mappedDataLabels={{
+          name: 'Name',
+          code: 'Code',
+        }}
+      />
+
+      <DataFileReplacementFilterDifferencesTable
+        filters={plan.mapping.filters}
+        handleMappingUpdate={handleFiltersMappingUpdate}
+      />
     </>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
@@ -12,8 +12,9 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import { Dictionary, KeysWithType } from '@common/types';
 import prefixNoun from '@common/utils/string/prefixNoun';
 import Yup from '@common/validation/yup';
-import React from 'react';
+import React, { useState } from 'react';
 import { TypeMapping } from '@admin/pages/release/data/components/DataFileReplacementDifferencesTable';
+import ErrorMessage from '@common/components/ErrorMessage';
 
 interface FormValues {
   selectedCandidate: string;
@@ -37,7 +38,7 @@ export type DifferencesItemMappingModalProps<
   allCandidateOptions: Dictionary<SourceItemType>;
   unmappedCandidateOptions: Dictionary<SourceItemType>;
   mapping: ReplacementMapping<SourceItemType>;
-  onSubmit: (payload: UpdateMappingPayload) => void;
+  onSubmit: (payload: UpdateMappingPayload) => Promise<void>;
 } & LabelProps<ItemType>;
 
 export default function DifferencesItemMappingModal<
@@ -69,7 +70,7 @@ export default function DifferencesItemMappingModal<
       };
 
   const handleSubmit = async ({ selectedCandidate }: FormValues) => {
-    onSubmit({
+    await onSubmit({
       sourceKey: mapping.source.id,
       candidateKey:
         selectedCandidate !== noMappingValue ? selectedCandidate : undefined,
@@ -83,11 +84,12 @@ export default function DifferencesItemMappingModal<
     return {
       value: id,
       label: candidate[rowLabel] as string,
-      hint: (hintLabelEntries && hintLabelEntries.length > 0)
-        ? `(${hintLabelEntries
-            .map(([key, label]) => `${label} : ${candidate[key]}`)
-            .join(', ')})`
-        : undefined,
+      hint:
+        hintLabelEntries && hintLabelEntries.length > 0
+          ? `(${hintLabelEntries
+              .map(([key, label]) => `${label} : ${candidate[key]}`)
+              .join(', ')})`
+          : undefined,
     };
   };
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
@@ -12,9 +12,8 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import { Dictionary, KeysWithType } from '@common/types';
 import prefixNoun from '@common/utils/string/prefixNoun';
 import Yup from '@common/validation/yup';
-import React, { useState } from 'react';
+import React from 'react';
 import { TypeMapping } from '@admin/pages/release/data/components/DataFileReplacementDifferencesTable';
-import ErrorMessage from '@common/components/ErrorMessage';
 
 interface FormValues {
   selectedCandidate: string;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesMappingModal.tsx
@@ -83,7 +83,7 @@ export default function DifferencesItemMappingModal<
     return {
       value: id,
       label: candidate[rowLabel] as string,
-      hint: hintLabelEntries
+      hint: (hintLabelEntries && hintLabelEntries.length > 0)
         ? `(${hintLabelEntries
             .map(([key, label]) => `${label} : ${candidate[key]}`)
             .join(', ')})`

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesTable.tsx
@@ -3,6 +3,7 @@ import TagGroup from '@common/components/TagGroup';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import React, { useMemo } from 'react';
 import {
+  FilterMappingSource,
   IndicatorGroupReplacement,
   IndicatorReplacement,
   IndicatorSource,
@@ -10,6 +11,7 @@ import {
   LocationReplacement,
   LocationSource,
   MappingsPlan,
+  ReplacementMapping,
   UpdateMappingPayload,
 } from '@admin/services/dataReplacementService';
 import DifferencesMappingTableRows from '@admin/pages/release/data/components/DataFileReplacementDifferencesTableRows';
@@ -27,6 +29,9 @@ export interface TypeMapping {
     group: LocationReplacement;
     target: LocationAttributeReplacement;
   };
+  filter: {
+    source: FilterMappingSource;
+  };
 }
 
 export type TableMappingGroup = {
@@ -34,29 +39,58 @@ export type TableMappingGroup = {
   mappings: string[];
 };
 
-type DataFileDifferencesReplacementTableProps<
-  ItemType extends keyof TypeMapping,
-> = {
-  tableId: string;
-  itemType: ItemType;
-  handleMappingUpdate: (payload: UpdateMappingPayload) => Promise<void>;
-  mappingsPlan: MappingsPlan<TypeMapping[ItemType]['source']>;
-  mappingsToShow: Set<string>;
-  mappingGroups: Array<TableMappingGroup>;
-} & LabelProps<ItemType>;
+export function uniqueByLabel<T extends { label: string }>(items: T[]): T[] {
+  return Array.from(new Map(items.map(item => [item.label, item])).values());
+}
+
+type TableItemType = 'indicator' | 'location';
+
+type DataFileDifferencesReplacementTableProps<ItemType extends TableItemType> =
+  {
+    tableId: string;
+    itemType: ItemType;
+    handleMappingUpdate: (payload: UpdateMappingPayload) => Promise<void>;
+    mappingsPlan: MappingsPlan<TypeMapping[ItemType]['source']>;
+    replacementGroups: Array<TypeMapping[ItemType]['group']>;
+    getGroupMappings: (
+      group: TypeMapping[ItemType]['group'],
+    ) => Array<TypeMapping[ItemType]['target']>;
+  } & LabelProps<ItemType>;
 
 export default function DataFileDifferencesReplacementTable<
-  ItemType extends keyof TypeMapping,
+  ItemType extends TableItemType,
 >({
   tableId,
   itemType,
   handleMappingUpdate,
   mappingsPlan,
-  mappingGroups,
+  replacementGroups,
+  getGroupMappings,
   mappedDataLabels,
   rowLabel,
-  mappingsToShow,
 }: DataFileDifferencesReplacementTableProps<ItemType>) {
+  const { mappingGroups, mappingsToShow } = useMemo(() => {
+    const mappings = mappingsPlan.mappings as Record<
+      string,
+      ReplacementMapping<TypeMapping[ItemType]['source']>
+    >;
+    const mappingIds = new Set<string>();
+
+    const groups = uniqueByLabel(replacementGroups).flatMap(group => {
+      const groupMappingIds = getGroupMappings(group)
+        .map(mapping => mapping.id)
+        .filter(id => mappings[id]?.type !== 'AutoSet' && mappings[id]);
+
+      groupMappingIds.forEach(id => mappingIds.add(id));
+
+      return groupMappingIds.length > 0
+        ? [{ label: group.label, mappings: groupMappingIds }]
+        : [];
+    });
+
+    return { mappingGroups: groups, mappingsToShow: mappingIds };
+  }, [getGroupMappings, mappingsPlan.mappings, replacementGroups]);
+
   const mappingCounts: {
     mapped: number;
     unmapped: number;
@@ -74,6 +108,10 @@ export default function DataFileDifferencesReplacementTable<
       unmapped: unmappedCount,
     };
   }, [mappingsPlan.mappings, mappingsToShow]);
+
+  if (mappingsToShow.size === 0) {
+    return null;
+  }
 
   return (
     <div className="table-container">

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementFilterDifferencesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementFilterDifferencesTable.tsx
@@ -1,0 +1,312 @@
+﻿import {
+  FilterMappingFilterGroups,
+  FilterMappingFilterItems,
+  FilterMappingPlan,
+  FilterMappingSource,
+  MappingType,
+  ReplacementMapping,
+  UpdateMappingPayload,
+} from '@admin/services/dataReplacementService';
+import React, { useMemo } from 'react';
+import { Dictionary } from '@common/types';
+import Tag from '@common/components/Tag';
+import ButtonText from '@common/components/ButtonText';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import DifferencesItemMappingModal from '@admin/pages/release/data/components/DataFileReplacementDifferencesMappingModal';
+import TagGroup from '@common/components/TagGroup';
+import DataFileReplacementMappingCountsTag from '@admin/pages/release/data/components/DataFileReplacementMappingCountsTag';
+
+export type TableHeaderCell = {
+  id: string;
+  label: string;
+  rowSpan: number;
+};
+
+export type TableRowData = {
+  headers: TableHeaderCell[];
+  mappingToEdit: ReplacementMapping<FilterMappingSource>;
+  allCandidates?: Dictionary<FilterMappingSource>;
+  unmappedCandidates: Dictionary<FilterMappingSource>;
+  level: number;
+};
+
+export type FilterTableData = {
+  rows: TableRowData[];
+  mappingCounts: {
+    mapped: number;
+    unmapped: number;
+    unmappedParents: number;
+  };
+};
+
+const CAN_MAP_VALUES: MappingType[] = ['Unset', 'ManuallySet'] as const;
+const CAN_SHOW_CHILDREN: MappingType[] = ['AutoSet', 'ManuallySet'] as const;
+
+type MappingsType =
+  | FilterMappingPlan
+  | FilterMappingFilterGroups
+  | FilterMappingFilterItems<FilterMappingSource>;
+
+/**
+ * This will generate a flat array of rows for the table, with each item specifying how many rows it covers, so it
+ * can encompass all the ancestor rows (i.e. row-span).
+ *
+ * If the mapping doesn't have a valid mapping, it won't traverse down.
+ */
+const buildFilterTableData = (filters: FilterMappingPlan) => {
+  const buildRows = (
+    currentFilters: MappingsType,
+    level = 0,
+  ): FilterTableData => {
+    const { candidates, mappings } = currentFilters;
+
+    const mappedCandidateKeys = new Set(
+      Object.values(mappings)
+        .map(mapping => mapping.candidateKey)
+        .filter(Boolean),
+    );
+
+    const unmappedCandidates = Object.fromEntries(
+      Object.entries(candidates).filter(
+        ([candidateId]) => !mappedCandidateKeys.has(candidateId),
+      ),
+    );
+
+    const allCandidates =
+      Object.keys(candidates).length > 0 ? candidates : undefined;
+
+    return Object.entries(mappings).reduce<FilterTableData>(
+      (result, [mappingId, mapping]) => {
+        const replacementMapping =
+          mapping as ReplacementMapping<FilterMappingSource>;
+
+        const selfCanBeMapped = CAN_MAP_VALUES.includes(
+          replacementMapping.type,
+        );
+        const canShowChildren = CAN_SHOW_CHILDREN.includes(
+          replacementMapping.type,
+        );
+
+        let childMappings: MappingsType | undefined;
+
+        if ('filterGroups' in mapping) {
+          childMappings = mapping.filterGroups as FilterMappingFilterGroups;
+        } else if ('filterItems' in mapping) {
+          childMappings =
+            mapping.filterItems as FilterMappingFilterItems<FilterMappingSource>;
+        }
+
+        const childData = childMappings
+          ? buildRows(childMappings, level + 1)
+          : {
+              rows: [],
+              mappingCounts: {
+                mapped: 0,
+                unmapped: 0,
+                unmappedParents: 0,
+              },
+            };
+
+        const selfCounts = {
+          mapped: replacementMapping.type === 'ManuallySet' ? 1 : 0,
+          unmapped: replacementMapping.type === 'Unset' ? 1 : 0,
+          unmappedParents:
+            replacementMapping.type === 'ParentNotMapped' ? 1 : 0,
+        };
+
+        const childRows = canShowChildren ? childData.rows : [];
+
+        // add this mapping first if it can be mapped
+        const rowsForMapping: TableRowData[] = [
+          ...(selfCanBeMapped
+            ? [
+                {
+                  headers: [],
+                  mappingToEdit: replacementMapping,
+                  level,
+                  allCandidates,
+                  unmappedCandidates,
+                },
+              ]
+            : []),
+          ...childRows,
+        ];
+
+        if (rowsForMapping.length > 0) {
+          rowsForMapping[0] = {
+            ...rowsForMapping[0],
+            headers: [
+              {
+                id: mappingId,
+                label: replacementMapping.source.label,
+                rowSpan: rowsForMapping.length,
+              },
+              ...rowsForMapping[0].headers,
+            ],
+          };
+        }
+
+        return {
+          rows: [...result.rows, ...rowsForMapping],
+          mappingCounts: {
+            mapped:
+              result.mappingCounts.mapped +
+              selfCounts.mapped +
+              childData.mappingCounts.mapped,
+            unmapped:
+              result.mappingCounts.unmapped +
+              selfCounts.unmapped +
+              childData.mappingCounts.unmapped,
+            unmappedParents:
+              result.mappingCounts.unmappedParents +
+              selfCounts.unmappedParents +
+              childData.mappingCounts.unmappedParents,
+          },
+        };
+      },
+      {
+        rows: [],
+        mappingCounts: {
+          mapped: 0,
+          unmapped: 0,
+          unmappedParents: 0,
+        },
+      },
+    );
+  };
+  return buildRows(filters);
+};
+
+type DataFileDifferencesReplacementTableProps = {
+  handleMappingUpdate: (
+    payload: UpdateMappingPayload,
+    type: string,
+  ) => Promise<void>;
+  filters?: FilterMappingPlan;
+};
+
+export default function DataFileReplacementFilterDifferencesTable({
+  filters,
+  handleMappingUpdate,
+}: DataFileDifferencesReplacementTableProps) {
+  const tableData = useMemo(
+    () => (filters ? buildFilterTableData(filters) : undefined),
+    [filters],
+  );
+
+  const outputHeaders = (row: TableRowData) => {
+    const rowLabel = row.mappingToEdit.source.id;
+    return row.headers.map(header =>
+      rowLabel === header.id && header.rowSpan === 1 ? (
+        <td key={header.id} rowSpan={header.rowSpan}>
+          {header.label}
+        </td>
+      ) : (
+        <th key={header.id} rowSpan={header.rowSpan} style={{ width: '10%' }}>
+          {header.label}
+        </th>
+      ),
+    );
+  };
+
+  if (tableData === undefined || tableData.rows.length === 0) return null;
+
+  return (
+    <div className="table-container">
+      <table className="dfe-table--vertical-align-middle ">
+        <caption className="govuk-!-margin-bottom-3 govuk-!-font-size-24">
+          Filters
+          <TagGroup className="govuk-!-margin-left-2">
+            <DataFileReplacementMappingCountsTag
+              mappingType="filter"
+              countType="unmapped"
+              count={
+                tableData.mappingCounts.unmapped +
+                tableData.mappingCounts.unmappedParents
+              }
+            />
+            {tableData.mappingCounts.unmappedParents > 0 && (
+              <Tag colour="red">
+                {tableData.mappingCounts.unmappedParents} not shown
+              </Tag>
+            )}
+            <DataFileReplacementMappingCountsTag
+              mappingType="filter"
+              countType="mapped"
+              count={tableData.mappingCounts.mapped}
+            />
+          </TagGroup>
+        </caption>
+
+        <tbody>
+          {tableData.rows.map(td => {
+            const mapping = td.mappingToEdit;
+            const { source, type, candidateKey } = td.mappingToEdit;
+
+            const isUnset = type === 'Unset';
+            const sourceLabelText = source.label;
+
+            const candidateText =
+              candidateKey && td.allCandidates?.[candidateKey]?.label;
+            const itemCurrentMapping = candidateText ?? 'No Mapping';
+
+            let payloadType: string = 'filter';
+            if (td.level === 2) {
+              payloadType = 'item';
+            } else if (td.level === 1) {
+              payloadType = 'group';
+            }
+
+            return (
+              <tr key={td.mappingToEdit.source.id}>
+                {outputHeaders(td)}
+
+                {td.level < 2 && <td colSpan={2 - td.level} />}
+
+                <td className="govuk-!-width-one-quarter">
+                  {isUnset ? (
+                    <Tag colour="red">not present</Tag>
+                  ) : (
+                    `${itemCurrentMapping}`
+                  )}
+                </td>
+
+                <td className="govuk-!-text-align-right govuk-!-width-one-quarter">
+                  {isUnset && (
+                    <ButtonText
+                      onClick={() =>
+                        handleMappingUpdate(
+                          { sourceKey: source.id, candidateKey: undefined },
+                          payloadType,
+                        )
+                      }
+                    >
+                      No mapping{' '}
+                      <VisuallyHidden>
+                        for {`${sourceLabelText}`}
+                      </VisuallyHidden>
+                    </ButtonText>
+                  )}
+
+                  {td.allCandidates && (
+                    <DifferencesItemMappingModal
+                      itemType="filter"
+                      allCandidateOptions={td.allCandidates}
+                      unmappedCandidateOptions={td.unmappedCandidates}
+                      mapping={mapping}
+                      onSubmit={payload => {
+                        handleMappingUpdate(payload, payloadType);
+                      }}
+                      rowLabel="label"
+                      mappedDataLabels={{ label: 'Label' }}
+                    />
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementFilterDifferencesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementFilterDifferencesTable.tsx
@@ -294,8 +294,8 @@ export default function DataFileReplacementFilterDifferencesTable({
                       allCandidateOptions={td.allCandidates}
                       unmappedCandidateOptions={td.unmappedCandidates}
                       mapping={mapping}
-                      onSubmit={payload => {
-                        handleMappingUpdate(payload, payloadType);
+                      onSubmit={async payload => {
+                        await handleMappingUpdate(payload, payloadType);
                       }}
                       rowLabel="label"
                       mappedDataLabels={{ label: 'Label' }}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
@@ -1,5 +1,6 @@
 import dataReplacementService, {
   DataReplacementPlan,
+  FilterMappingPlan,
 } from '@admin/services/dataReplacementService';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
@@ -19,6 +20,71 @@ beforeEach(() =>
   ),
 );
 
+const filterMappings: FilterMappingPlan = {
+  mappings: {
+    'filter-one': {
+      source: { id: 'filter-one', label: 'Filter one', name: 'filter_one' },
+      type: 'ManuallySet',
+      candidateKey: 'filter-one-candidate',
+      filterGroups: {
+        mappings: {
+          'group-one': {
+            source: { id: 'group-one', label: 'Group one' },
+            type: 'ManuallySet',
+            candidateKey: 'group-one-candidate',
+            filterItems: {
+              mappings: {
+                'item-one': {
+                  source: { id: 'item-one', label: 'Item one' },
+                  type: 'Unset',
+                },
+              },
+              candidates: {
+                'item-one-candidate': {
+                  id: 'item-one-candidate',
+                  label: 'Item one candidate',
+                },
+              },
+            },
+          },
+          'group-not-mapped': {
+            source: {
+              id: 'group-not-mapped',
+              label: 'Group not mapped',
+            },
+            type: 'ParentNotMapped',
+            filterItems: {
+              mappings: {
+                'item-not-mapped': {
+                  source: {
+                    id: 'item-not-mapped',
+                    label: 'Item not mapped',
+                  },
+                  type: 'ParentNotMapped',
+                },
+              },
+              candidates: {},
+            },
+          },
+        },
+        candidates: {
+          'group-one-candidate': {
+            id: 'group-one-candidate',
+            label: 'Group one candidate',
+          },
+        },
+      },
+    },
+  },
+  candidates: {
+    'filter-one-candidate': {
+      id: 'filter-one-candidate',
+      label: 'Filter one candidate',
+      name: 'filter_one_candidate',
+    },
+  },
+};
+
 const testReplacementPlan: DataReplacementPlan = {
   originalSubjectId: 'subId',
   replacementSubjectId: 'repId',
@@ -26,7 +92,7 @@ const testReplacementPlan: DataReplacementPlan = {
   hasDataBlockAndReplacementHasAdditionalFilter: false,
   footnotes: [],
   mapping: {
-    filters: { mappings: {}, candidates: {} },
+    filters: filterMappings,
     indicators: {
       mappings: {
         enrolments_again: {
@@ -632,5 +698,63 @@ describe('DataFileReplacementDifferences', () => {
     );
 
     expect(enrolmentsAgainRow.childNodes[2]).toHaveTextContent('No Mapping');
+  });
+
+  test('renders the filter, group and item mapping hierarchy', () => {
+    sharedRender();
+
+    const filtersTable = screen.getByText('Filters').closest('table');
+    expect(filtersTable).not.toBeNull();
+
+    const caption = within(filtersTable!)
+      .getByText('Filters')
+      .closest('caption');
+    expect(caption).toHaveTextContent('3 unmapped filters');
+    expect(caption).toHaveTextContent('2 not shown');
+    expect(caption).toHaveTextContent('2 mapped filters');
+
+    const rows = within(filtersTable!).getAllByRole('row');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('Filter one');
+    expect(rows[0]).toHaveTextContent('Filter one candidate');
+    expect(rows[1]).toHaveTextContent('Group one');
+    expect(rows[1]).toHaveTextContent('Group one candidate');
+    expect(rows[2]).toHaveTextContent('Item one');
+    expect(rows[2]).toHaveTextContent('not present');
+    expect(filtersTable).not.toHaveTextContent('Group not mapped');
+    expect(filtersTable).not.toHaveTextContent('Item not mapped');
+  });
+
+  test('maps a filter item to a replacement candidate', async () => {
+    const { user } = sharedRender();
+
+    const filtersTable = screen.getByText('Filters').closest('table');
+    expect(filtersTable).not.toBeNull();
+
+    await user.click(
+      within(filtersTable!).getByRole('button', { name: 'Map item Item one' }),
+    );
+
+    const modal = await screen.findByRole('dialog');
+    await user.click(within(modal).getByLabelText('Item one candidate'));
+    await user.click(within(modal).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        dataReplacementService.updatePlanFilterMappings,
+      ).toHaveBeenCalledWith(
+        'releaseVersionId',
+        'fileId',
+        'replacementFileId',
+        [],
+        [],
+        [
+          {
+            originalId: 'item-one',
+            newReplacementId: 'item-one-candidate',
+          },
+        ],
+      );
+    });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
@@ -26,6 +26,7 @@ const testReplacementPlan: DataReplacementPlan = {
   hasDataBlockAndReplacementHasAdditionalFilter: false,
   footnotes: [],
   mapping: {
+    filters: { mappings: {}, candidates: {} },
     indicators: {
       mappings: {
         enrolments_again: {
@@ -223,6 +224,7 @@ const testReplacementPlanWithLocation: DataReplacementPlan = {
   hasDataBlockAndReplacementHasAdditionalFilter: false,
   footnotes: [],
   mapping: {
+    filters: { mappings: {}, candidates: {} },
     indicators: {
       mappings: {
         enrolments_again: {
@@ -455,13 +457,8 @@ describe('DataFileReplacementDifferences', () => {
       tableId: indicatorsTableId,
       itemType: 'indicator',
       mappingsPlan: testReplacementPlanWithLocation.mapping.indicators,
-      mappingGroups: [
-        {
-          label: 'Enrolment Group',
-          mappings: ['enrolments_again', 'enrolments'],
-        },
-      ],
-      mappingsToShow: new Set(['enrolments_again', 'enrolments']),
+      replacementGroups: expect.any(Array),
+      getGroupMappings: expect.any(Function),
       rowLabel: 'label',
       mappedDataLabels: {
         label: 'Label',
@@ -473,13 +470,8 @@ describe('DataFileReplacementDifferences', () => {
       tableId: locationsTableId,
       itemType: 'location',
       mappingsPlan: testReplacementPlanWithLocation.mapping.locations,
-      mappingGroups: [
-        {
-          label: 'Country',
-          mappings: ['country-england'],
-        },
-      ],
-      mappingsToShow: new Set(['country-england']),
+      replacementGroups: expect.any(Array),
+      getGroupMappings: expect.any(Function),
       rowLabel: 'name',
       mappedDataLabels: {
         name: 'Name',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferences.test.tsx
@@ -4,6 +4,7 @@ import dataReplacementService, {
 } from '@admin/services/dataReplacementService';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
+import cloneDeep from 'lodash/cloneDeep';
 import DataFileReplacementDifferencesTable from '../DataFileReplacementDifferencesTable';
 import DataFileReplacementDifferences from '../DataFileReplacementDifferences';
 
@@ -741,6 +742,13 @@ describe('DataFileReplacementDifferences', () => {
 
     await waitFor(() => {
       expect(
+        within(filtersTable!).getByText('Item one candidate'),
+      ).toBeVisible();
+      expect(within(filtersTable!).queryByText('not present')).toBeNull();
+    });
+
+    await waitFor(() => {
+      expect(
         dataReplacementService.updatePlanFilterMappings,
       ).toHaveBeenCalledWith(
         'releaseVersionId',
@@ -755,6 +763,42 @@ describe('DataFileReplacementDifferences', () => {
           },
         ],
       );
+    });
+  });
+
+  test('refreshes the internal mappings when the plan is reloaded', async () => {
+    const { rerender } = sharedRender();
+    const reloadedFilters = cloneDeep(filterMappings);
+    const reloadedItem =
+      reloadedFilters.mappings['filter-one'].filterGroups.mappings['group-one']
+        .filterItems.mappings['item-one'];
+
+    reloadedItem.type = 'ManuallySet';
+    reloadedItem.candidateKey = 'item-one-candidate';
+
+    rerender(
+      <DataFileReplacementDifferences
+        replacementFileId="replacementFileId"
+        reloadPlan={jest.fn()}
+        fileId="fileId"
+        releaseVersionId="releaseVersionId"
+        plan={{
+          ...testReplacementPlan,
+          mapping: {
+            ...testReplacementPlan.mapping,
+            filters: reloadedFilters,
+          },
+        }}
+      />,
+    );
+
+    const filtersTable = screen.getByText('Filters').closest('table');
+    expect(filtersTable).not.toBeNull();
+
+    await waitFor(() => {
+      expect(
+        within(filtersTable!).getByText('Item one candidate'),
+      ).toBeVisible();
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferencesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementDifferencesTable.test.tsx
@@ -4,9 +4,7 @@ import {
 } from '@admin/services/dataReplacementService';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
-import DataFileReplacementDifferencesTable, {
-  TableMappingGroup,
-} from '@admin/pages/release/data/components/DataFileReplacementDifferencesTable';
+import DataFileReplacementDifferencesTable from '@admin/pages/release/data/components/DataFileReplacementDifferencesTable';
 
 jest.mock('@admin/services/dataReplacementService');
 
@@ -99,14 +97,27 @@ const mappingsPlan: IndicatorsMappingsPlan = {
     },
   },
 };
-const mappingsGroup: TableMappingGroup[] = [
+const indicatorReplacementGroups = [
   {
+    id: 'enrolment-group',
     label: 'Enrolment Group',
-    mappings: ['enrolments_again', 'enrolments'],
+    valid: false,
+    indicators: [
+      {
+        id: 'enrolments_again',
+        label: 'Enrolments Again',
+        name: 'Enrolments_Again',
+        valid: false,
+      },
+      {
+        id: 'enrolments',
+        label: 'Enrolments',
+        name: 'Enrolments',
+        valid: false,
+      },
+    ],
   },
 ];
-
-const mappingsToShow = new Set(['enrolments_again', 'enrolments']);
 
 const locationsMappingPlan: LocationMappingsPlan = {
   mappings: {
@@ -128,14 +139,21 @@ const locationsMappingPlan: LocationMappingsPlan = {
   },
 };
 
-const locationsMappingGroup: TableMappingGroup[] = [
+const locationReplacementGroups = [
   {
     label: 'Country',
-    mappings: ['country-england'],
+    valid: false,
+    locationAttributes: [
+      {
+        id: 'country-england',
+        name: 'England',
+        label: 'England',
+        code: 'E92000001',
+        valid: false,
+      },
+    ],
   },
 ];
-
-const locationsMappingsToShow = new Set(['country-england']);
 
 describe('DataFileReplacementDifferences', () => {
   const indicatorsTableId = 'replacements-differences-indicators-table';
@@ -148,8 +166,8 @@ describe('DataFileReplacementDifferences', () => {
         tableId={indicatorsTableId}
         itemType="indicator"
         mappingsPlan={mappingsPlan}
-        mappingGroups={mappingsGroup}
-        mappingsToShow={mappingsToShow}
+        replacementGroups={indicatorReplacementGroups}
+        getGroupMappings={group => group.indicators}
         handleMappingUpdate={handler}
         rowLabel="label"
         mappedDataLabels={{
@@ -166,8 +184,8 @@ describe('DataFileReplacementDifferences', () => {
         itemType="location"
         handleMappingUpdate={handler}
         mappingsPlan={locationsMappingPlan}
-        mappingsToShow={locationsMappingsToShow}
-        mappingGroups={locationsMappingGroup}
+        replacementGroups={locationReplacementGroups}
+        getGroupMappings={group => group.locationAttributes}
         rowLabel="name"
         mappedDataLabels={{
           name: 'Name',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -348,6 +348,7 @@ describe('DataReplacementPlan', () => {
     mapping: {
       indicators: { candidates: {}, mappings: {} },
       locations: { candidates: {}, mappings: {} },
+      filters: { candidates: {}, mappings: {} },
     },
   };
 
@@ -415,6 +416,7 @@ describe('DataReplacementPlan', () => {
     mapping: {
       indicators: { candidates: {}, mappings: {} },
       locations: { candidates: {}, mappings: {} },
+      filters: { candidates: {}, mappings: {} },
     },
   };
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -64,6 +64,7 @@ describe('DataFilesReplacementTableRow', () => {
     mapping: {
       indicators: { mappings: {}, candidates: {} },
       locations: { mappings: {}, candidates: {} },
+      filters: { mappings: {}, candidates: {} },
     },
   };
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -147,6 +147,7 @@ describe('ReleaseDataUploadsSection', () => {
     mapping: {
       indicators: { mappings: {}, candidates: {} },
       locations: { mappings: {}, candidates: {} },
+      filters: { mappings: {}, candidates: {} },
     },
   };
 

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -119,11 +119,15 @@ export interface ApiDataSetVersionPlan {
   valid: boolean;
 }
 
-type MappingType = 'Unset' | 'ManuallySet' | 'AutoSet' | 'ParentNotMapped';
+export type MappingType =
+  'Unset' | 'ManuallySet' | 'AutoSet' | 'ParentNotMapped';
 
-export interface ReplacementMapping<TSource> {
+export interface Replacement<TSource> {
   type: MappingType;
   source: TSource;
+}
+
+export interface ReplacementMapping<TSource> extends Replacement<TSource> {
   candidateKey?: string;
 }
 
@@ -132,43 +136,80 @@ export type UpdateMappingPayload = {
   candidateKey?: string;
 };
 
-export interface MappingsPlan<TSource> {
-  candidates: Dictionary<TSource>;
-  mappings: Dictionary<ReplacementMapping<TSource>>;
-}
-
-export type MappingWithKey<TSource> = {
-  sourceKey: string;
-} & ReplacementMapping<TSource>;
-
-export interface IndicatorSource {
+export interface FilterMappingSource {
   id: string;
-  name: string; // csv column name
   label: string;
 }
 
-export interface LocationSource {
+export type Candidates<TSource = CandidateSource> = Dictionary<TSource>;
+export type Mappings<
+  TSource = CandidateSource,
+  TMapping = ReplacementMapping<TSource>,
+> = Dictionary<TMapping>;
+
+export interface MappingsPlan<
+  TSource = CandidateSource,
+  TMapping = ReplacementMapping<TSource>,
+> {
+  candidates: Candidates<TSource>;
+  mappings: Mappings<TSource, TMapping>;
+}
+
+export type FilterMappingFilterItems<TSource> = MappingsPlan<
+  TSource,
+  ReplacementMapping<FilterMappingSource>
+>;
+
+export interface FilterGroupMappings<
+  TSource,
+> extends ReplacementMapping<TSource> {
+  filterItems: FilterMappingFilterItems<TSource>;
+}
+
+export type FilterMappingFilterGroups = MappingsPlan<
+  FilterMappingSource,
+  FilterGroupMappings<FilterMappingSource>
+>;
+
+export interface FilterMappingReplacementMapping<
+  TSource,
+> extends ReplacementMapping<TSource> {
+  filterGroups: FilterMappingFilterGroups;
+}
+
+export interface CandidateSource {
   id: string;
-  code: string;
   name: string;
+}
+
+export interface FilterSource extends CandidateSource {
+  label: string;
+}
+
+export interface IndicatorSource extends CandidateSource {
+  label: string;
+}
+
+export interface LocationSource extends CandidateSource {
+  code: string;
 }
 
 export type IndicatorCandidate = IndicatorSource;
 
-export type SourceItem = IndicatorSource | LocationSource; /* | FilterSource */
-
 export type IndicatorMapping = ReplacementMapping<IndicatorSource>;
 export type LocationMapping = ReplacementMapping<LocationSource>;
 
-export type IndicatorMappingWithKey = MappingWithKey<IndicatorSource>;
-export type LocationMappingWithKey = MappingWithKey<LocationSource>;
-
 export type IndicatorsMappingsPlan = MappingsPlan<IndicatorSource>;
 export type LocationMappingsPlan = MappingsPlan<LocationSource>;
+export type FilterMappingPlan = MappingsPlan<
+  FilterSource,
+  FilterMappingReplacementMapping<FilterSource>
+>;
 
 export type PlanMappings = {
   indicators: IndicatorsMappingsPlan;
   locations: LocationMappingsPlan;
+  filters: FilterMappingPlan;
 };
 
 export interface IndicatorsMapping {
@@ -214,6 +255,23 @@ type PlanMappingLocationUpdateResponse = {
   replacementName: string;
   status: MappingType;
 }[];
+
+type FilterMappingResponse = {
+  originalId: string;
+  originalLabel: string;
+  originalColumnName: string;
+
+  replacementId?: string;
+  replacementLabel?: string;
+  replacementColumnName?: string;
+
+  status: MappingType;
+};
+type PlanMappingFilterUpdateResponse = {
+  filters: FilterMappingResponse[];
+  filterGroups: FilterMappingResponse[];
+  filterItems: FilterMappingResponse[];
+};
 
 const dataReplacementService = {
   async getReplacementPlan(
@@ -318,6 +376,28 @@ const dataReplacementService = {
       );
 
     return planLocationMappings;
+  },
+  async updatePlanFilterMappings(
+    releaseVersionId: string,
+    originalDataFileId: string,
+    replacementDataFileId: string,
+    filterUpdates: { originalId: string; newReplacementId?: string }[],
+    filterGroupUpdates: { originalId: string; newReplacementId?: string }[],
+    filterItemUpdates: { originalId: string; newReplacementId?: string }[],
+  ): Promise<PlanMappingFilterUpdateResponse> {
+    const filterMappings: PlanMappingFilterUpdateResponse = await client.patch(
+      `releases/${releaseVersionId}/data/replacements/mapping/filters`,
+      {
+        originalDataFileId,
+        replacementDataFileId,
+        filterUpdates,
+        filterGroupUpdates,
+        filterItemUpdates,
+      },
+    );
+
+    // the service can only return what it knows, it's up to the caller to integrate into its own data
+    return filterMappings;
   },
   replaceData(
     releaseVersionId: string,


### PR DESCRIPTION
Adds data replacement filter mapping.

Adds hierarchy mapping, filters, groups and items.

Adds API calls.

Adds unit tests.

Some help with refactoring made with Codex/GPT-5.6 towards the end.




