### PR TITLE
EES-7272 Remove breadcrumbs from homepage

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -68,13 +68,13 @@ const Page = ({
       >
         {customBannerContent}
 
-        <Breadcrumbs
-          breadcrumbs={
-            isHomepage
-              ? undefined
-              : breadcrumbs.concat([{ name: breadcrumbLabel || title }])
-          }
-        />
+        {!isHomepage && (
+          <Breadcrumbs
+            breadcrumbs={breadcrumbs.concat([
+              { name: breadcrumbLabel || title },
+            ])}
+          />
+        )}
 
         <main
           className="govuk-main-wrapper app-main-class"

--- a/src/explore-education-statistics-frontend/src/components/__tests__/Page.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/Page.test.tsx
@@ -20,6 +20,20 @@ describe('Page', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('renders the breadcrumbs by default', () => {
+    render(<Page title="Page Title" />);
+    expect(
+      screen.queryByRole('navigation', { name: 'Breadcrumb' }),
+    ).toBeInTheDocument();
+  });
+
+  test('does not render the breadcrumbs on the homepage', () => {
+    render(<Page title="Page Title" isHomepage />);
+    expect(
+      screen.queryByRole('navigation', { name: 'Breadcrumb' }),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders the caption inside h1 if required', () => {
     render(
       <Page

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -45,8 +45,7 @@ Validate homepage
     user checks page contains link with text and url    explore.statistics@education.gov.uk
     ...    mailto:explore.statistics@education.gov.uk
 
-    user checks breadcrumb count should be    1
-    user checks nth breadcrumb contains    1    Home
+    user checks page does not contain element    css:[data-testid="breadcrumbs--list"]
 
     user checks page contains link with text and url    Open Government Licence v3.0
     ...    https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/


### PR DESCRIPTION
This PR removes the breadcrumbs from the homepage, in line with GDS guidance.