### PR TITLE
EES-7585 Add missing slash after PUBLIC_URL

### DIFF
--- a/src/explore-education-statistics-common/src/services/api/index.ts
+++ b/src/explore-education-statistics-common/src/services/api/index.ts
@@ -24,7 +24,7 @@ export const dataApi = new Client({
 });
 
 export const frontendApi = new Client({
-  baseURL: `${process.env.PUBLIC_URL}api`,
+  baseURL: `${process.env.PUBLIC_URL}/api`,
   requestInterceptors: [networkActivityRequestInterceptor],
   responseInterceptors: [networkActivityResponseInterceptor],
 });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -50,7 +50,7 @@ const TableToolShare = ({ tableHeaders, query, isCropped }: Props) => {
         },
       });
 
-      setPermalinkUrl(`${process.env.PUBLIC_URL}data-tables/permalink/${id}`);
+      setPermalinkUrl(`${process.env.PUBLIC_URL}/data-tables/permalink/${id}`);
 
       setScreenReaderMessage(`Shareable link generated. ${linkInstructions}`);
     } catch (err) {

--- a/src/explore-education-statistics-frontend/test/publicUrl.test.ts
+++ b/src/explore-education-statistics-frontend/test/publicUrl.test.ts
@@ -1,0 +1,11 @@
+import { frontendApi } from '@common/services/api';
+
+describe('PUBLIC_URL', () => {
+  test('never ends with a slash, so paths can be appended to it', () => {
+    expect(process.env.PUBLIC_URL).not.toMatch(/\/$/);
+  });
+
+  test('builds the frontend api base url', () => {
+    expect(frontendApi.baseURL).toBe('http://localhost:3000/api');
+  });
+});

--- a/src/explore-education-statistics-frontend/test/setupTests.js
+++ b/src/explore-education-statistics-frontend/test/setupTests.js
@@ -7,6 +7,12 @@ import 'urlpattern-polyfill';
 
 loadEnvConfig(process.cwd());
 
+// Mirror the normalisation that `src/loadEnv.ts` applies at runtime, so tests
+// see the same PUBLIC_URL as the running app.
+if (process.env.PUBLIC_URL) {
+  process.env.PUBLIC_URL = process.env.PUBLIC_URL.replace(/\/+$/, '');
+}
+
 jest.setTimeout(10000);
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
search-publications was missing a forward slash in it’s request URL:
`https://dev.explore-education-statistics.service.gov.ukapi/search-publications`

The same situation was happening with permalinks.

This PR fixes this.

This bug occurred due to the work in EES-6779 where we changed how PUBLIC_URL was handled - it now always strips any trailing forward slash at the moment PUBLIC_URL is fetched - this made how we use PUBLIC_URL in the code consistent, as I noticed a double forward slash in a couple of cases.