### PR TITLE
EES-7591 - migrate content api to bicep

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -59,9 +59,6 @@
     "publicAppGATrackingId": {
       "value": "G-GRPHH2FN0L"
     },
-    "enableSwagger": {
-      "value": true
-    },
     "memoryCacheOverridesDurationInSeconds": {
       "value": 10
     },

--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -5,9 +5,6 @@
     "skuPublic": {
       "value": "B1 Basic"
     },
-    "skuContent": {
-      "value": "P1V2 PremiumV2"
-    },
     "skuAdminSignalR": {
       "value": "Standard_S1"
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -5,9 +5,6 @@
     "skuPublic": {
       "value": "P1V2 PremiumV2"
     },
-    "skuContent": {
-      "value": "P1V2 PremiumV2"
-    },
     "skuAdminSignalR": {
       "value": "Standard_S1"
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -5,9 +5,6 @@
     "skuPublic": {
       "value": "P2V2 PremiumV2"
     },
-    "skuContent": {
-      "value": "P1V2 PremiumV2"
-    },
     "skuAdminSignalR": {
       "value": "Standard_S1"
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -5,9 +5,6 @@
     "skuPublic": {
       "value": "B1 Basic"
     },
-    "skuContent": {
-      "value": "S1 Standard"
-    },
     "skuImporter": {
       "value": "P1V2 PremiumV2"
     },

--- a/infrastructure/templates/admin/main.bicep
+++ b/infrastructure/templates/admin/main.bicep
@@ -122,6 +122,8 @@ module appServiceModule '../common/components/app-service/app-service.bicep' = {
     appServiceName: resourceNames.admin.appService
     minTlsVersion: minTlsVersion
     appServicePlanId: appServicePlanModule.outputs.planId
+    keyVaultName: resourceNames.keyVault.keyVault
+    legacyKeyVaultRoleAssignmentName: true
     connectionStrings: [
       {
         name: 'StatisticsDb'

--- a/infrastructure/templates/bicep-main-infrastructure-release/configuration/content-api-configuration.bicep
+++ b/infrastructure/templates/bicep-main-infrastructure-release/configuration/content-api-configuration.bicep
@@ -1,0 +1,19 @@
+import { AppServicePlanSku } from '../../common/components/app-service-plan/types.bicep'
+
+@export()
+type ContentApiConfig = {
+
+  @description('App Service SKU')
+  appServiceSku: AppServicePlanSku?
+}
+
+var defaultConfig = {
+  appServiceSku: {
+    tier: 'Premium'
+    name: 'P1V2'
+  }
+}
+
+@export()
+func mergeContentApiConfig(overridden ContentApiConfig) ContentApiConfig =>
+  union(defaultConfig, overridden)

--- a/infrastructure/templates/bicep-main-infrastructure-release/main.bicep
+++ b/infrastructure/templates/bicep-main-infrastructure-release/main.bicep
@@ -2,6 +2,7 @@ import { getResourceNames } from 'resource-names.bicep'
 import { Tags } from 'types.bicep'
 import { EnvironmentConfig, EnvironmentPipelineVariables, mergeEnvironmentConfig } from 'configuration/environment-configuration.bicep'
 import { AdminConfig, AdminPipelineVariables, mergeAdminConfig } from 'configuration/admin-configuration.bicep'
+import { ContentApiConfig, mergeContentApiConfig } from 'configuration/content-api-configuration.bicep'
 import { DataApiConfig, mergeDataApiConfig } from 'configuration/data-api-configuration.bicep'
 
 //
@@ -51,6 +52,16 @@ param adminPipelineVariables AdminPipelineVariables = {}
 
 
 //
+// Content API-specific config.
+//
+param contentApiConfigParam ContentApiConfig = {}
+
+// Merge default configuration with overridden configuration from params files.
+var contentApiConfig = mergeContentApiConfig(contentApiConfigParam)
+
+
+
+//
 // Data API-specific config.
 //
 param dataApiConfigParam DataApiConfig = {}
@@ -65,12 +76,16 @@ var dataApiConfig = mergeDataApiConfig(dataApiConfigParam)
 //
 
 @secure()
-@description('''Data API database user's password for Azure SQL databases.''')
-param dataApiAzureSqlPassword string = ''
-
-@secure()
 @description('''Admin database user's password for Azure SQL databases.''')
 param adminAzureSqlPassword string = ''
+
+@secure()
+@description('''Content API database user's password for Azure SQL databases.''')
+param contentApiAzureSqlPassword string = ''
+
+@secure()
+@description('''Data API database user's password for Azure SQL databases.''')
+param dataApiAzureSqlPassword string = ''
 
 @secure()
 @description('Password protecting the public app, the purpose of this is prevent accidential access to the application before it is publically avaliable (following GDS guidance).')
@@ -134,6 +149,25 @@ module adminModule '../admin/main.bicep' = {
     memoryCacheConfig: environmentConfig.memoryCacheConfig!
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     databaseUserPassword: adminAzureSqlPassword
+    tagValues: tags
+  }
+}
+
+module contentApiModuleDeploy '../content-api/main.bicep' = {
+  name: 'contentApiModuleDeploy'
+  params: {
+    resourceNames: resourceNames
+    appServiceSku: contentApiConfig.appServiceSku!
+    publicAppUrl: 'https://${environmentConfig.domain!}'
+    autoscaleAppServices: environmentConfig.autoscaleAppServices!
+    allowedOrigins: publicSiteAllowedOrigins
+    analyticsEnabled: environmentConfig.analyticsEnabled!
+    deployAlerts: true
+    detailedErrors: environmentConfig.detailedErrors!
+    enableSwagger: environmentConfig.enableSwagger!
+    minTlsVersion: minTlsVersion
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+    databaseUserPassword: contentApiAzureSqlPassword
     tagValues: tags
   }
 }

--- a/infrastructure/templates/bicep-main-infrastructure-release/parameters/main-test.bicepparam
+++ b/infrastructure/templates/bicep-main-infrastructure-release/parameters/main-test.bicepparam
@@ -20,3 +20,17 @@ param adminConfigParam = {
     name: 'S1'
   }
 }
+
+param contentApiConfigParam = {
+  appServiceSku: {
+    tier: 'Standard'
+    name: 'S1'
+  }
+}
+
+param dataApiConfigParam = {
+  appServiceSku: {
+    tier: 'Standard'
+    name: 'S1'
+  }
+}

--- a/infrastructure/templates/bicep-main-infrastructure-release/resource-names.bicep
+++ b/infrastructure/templates/bicep-main-infrastructure-release/resource-names.bicep
@@ -13,6 +13,11 @@ type ResourceNames = {
       fileShareName: string
     }
   }
+  contentApi: {
+    appService: string
+    appServicePlan: string
+    appInsights: string
+  }
   dataApi: {
     appService: string
     appServicePlan: string
@@ -41,6 +46,7 @@ type ResourceNames = {
     vnet: string
     subnets: {
       admin: string
+      contentApi: string
       dataApi: string
     }
   }
@@ -98,6 +104,11 @@ func getResourceNames(
       fileShareName: '${newResourcePrefix}-share-anlyt'
     }
   }
+  contentApi: {
+    appService: '${legacyResourcePrefix}-${abbreviations.webSitesAppService}-ees-content'
+    appServicePlan: '${legacyResourcePrefix}-${abbreviations.webServerFarms}-ees-content'
+    appInsights: '${legacyResourcePrefix}-${abbreviations.insightsComponents}-ees-content'
+  }
   dataApi: {
     appService: '${legacyResourcePrefix}-${abbreviations.webSitesAppService}-ees-data'
     appServicePlan: '${legacyResourcePrefix}-${abbreviations.webServerFarms}-ees-data'
@@ -126,6 +137,7 @@ func getResourceNames(
     vnet: '${legacyResourcePrefix}-vnet-ees'
     subnets: {
       admin: '${legacyResourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-ees-admin'
+      contentApi: '${legacyResourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-ees-content'
       dataApi: '${legacyResourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-ees-data'
     }
   }

--- a/infrastructure/templates/common/components/app-service/app-service.bicep
+++ b/infrastructure/templates/common/components/app-service/app-service.bicep
@@ -10,6 +10,9 @@ param appInsightsName string
 @description('Name of Key Vault to allow secret access to from this App Service.')
 param keyVaultName string?
 
+@description('Whether to use the default role assignment name generation or the legacy name generation scheme.')
+param legacyKeyVaultRoleAssignmentName bool = false
+
 @description('Minimum TLS version supported.')
 param minTlsVersion string
 
@@ -104,13 +107,13 @@ resource appSettings 'Microsoft.Web/sites/config@2025-03-01' = {
   })
 }
 
-var appServiceSecretsUserRoleAssignmentName = guid(resourceId('Microsoft.KeyVault/vaults', appServiceName), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6'), appServiceName)
-
 module appServiceSecretsUserRoleAssignmentModule '../../../common/components/key-vault/keyVaultRoleAssignment.bicep' = if (keyVaultName != null) {
   name: '${appServiceName}KeyVaultSecretsUserRoleAssignmentModule'
   params: {
     keyVaultName: keyVaultName!
-    roleAssignmentNameOverride: appServiceSecretsUserRoleAssignmentName
+    roleAssignmentNameOverride: legacyKeyVaultRoleAssignmentName 
+      ? guid(resourceId('Microsoft.KeyVault/vaults', keyVaultName!), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6'), 'Microsoft.Web/sites/${appServiceName}')
+      : null
     principalIds: [appService.identity.principalId]
     role: 'Secrets User'
   }

--- a/infrastructure/templates/common/components/app-service/app-service.bicep
+++ b/infrastructure/templates/common/components/app-service/app-service.bicep
@@ -117,7 +117,7 @@ module appServiceSecretsUserRoleAssignmentModule '../../../common/components/key
 }
 
 module vNetLink 'virtual-network-link.bicep' = if (vnetLink != null) {
-  name: '${appServiceName}VnetLinkModuleDeploy'
+  name: '${appServiceName}VnetLinkDeploy'
   params: {
     appServiceName: appService.name
     vNetName: vnetLink!.vnetName
@@ -126,7 +126,7 @@ module vNetLink 'virtual-network-link.bicep' = if (vnetLink != null) {
 }
 
 module stagingSlotModule 'swap-slot.bicep' = {
-  name: '${appServiceName}${deploySlotName}ModuleDeploy'
+  name: '${appServiceName}${deploySlotName}Deploy'
   params: {
     appServiceName: appService.name
     slotName: deploySlotName
@@ -138,7 +138,7 @@ module stagingSlotModule 'swap-slot.bicep' = {
 }
 
 module autoscaleSettingsModule 'autoscale-settings.bicep' = {
-  name: '${appServiceName}AutoscaleSettingsModuleDeploy'
+  name: '${appServiceName}AutoscaleSettingsDeploy'
   params: {
     appServiceName: appService.name
     appServicePlanId: appServicePlanId
@@ -147,7 +147,7 @@ module autoscaleSettingsModule 'autoscale-settings.bicep' = {
 }
 
 module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site.bicep' = {
-  name: '${appServiceName}AzureStorageAccountsConfigModuleDeploy'
+  name: '${appServiceName}StorageAccountsConfigDeploy'
   params: {
     siteName: appServiceName
     azureFileShares: azureFileShares
@@ -155,7 +155,7 @@ module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site.b
 }
 
 module alertsModule 'alerts.bicep' = if (alerts != null) {
-  name: '${appServiceName}AlertsModuleDeploy'
+  name: '${appServiceName}AlertsDeploy'
   params: {
     appServiceName: appServiceName
     alerts: alerts!

--- a/infrastructure/templates/common/components/app-service/swap-slot.bicep
+++ b/infrastructure/templates/common/components/app-service/swap-slot.bicep
@@ -49,7 +49,7 @@ resource stagingSlot 'Microsoft.Web/sites/slots@2025-03-01' = {
 }
 
 module stagingSlotVNetLink 'slot-virtual-network-link.bicep' = if (vnetLink != null) {
-  name: '${appServiceName}${slotName}VnetLinkModuleDeploy'
+  name: '${appServiceName}${slotName}VnetLinkDeploy'
   params: {
     appServiceName: appServiceName
     slotName: slotName
@@ -59,7 +59,7 @@ module stagingSlotVNetLink 'slot-virtual-network-link.bicep' = if (vnetLink != n
 }
 
 module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site-slot.bicep' = {
-  name: '${appServiceName}${slotName}AzureStorageAccountsConfigModuleDeploy'
+  name: '${appServiceName}${slotName}StorageAccountsConfigDeploy'
   params: {
     siteName: appServiceName
     slotName: slotName

--- a/infrastructure/templates/content-api/main.bicep
+++ b/infrastructure/templates/content-api/main.bicep
@@ -1,0 +1,134 @@
+import { ResourceNames } from '../bicep-main-infrastructure-release/resource-names.bicep'
+import { keyVaultRef } from '../bicep-main-infrastructure-release/functions.bicep'
+import { AppServicePlanSku } from '../common/components/app-service-plan/types.bicep'
+
+@description('Names of resources in this deploy.')
+param resourceNames ResourceNames
+
+@description('Minimum TLS version supported.')
+param minTlsVersion string
+
+@secure()
+@description('''The database user's password.''')
+param databaseUserPassword string
+
+@description('App Service Plan SKU.')
+param appServiceSku AppServicePlanSku
+
+@description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
+param logAnalyticsWorkspaceId string
+
+@description('Whether to display detailed error messages in this environment or not.')
+param detailedErrors bool
+
+@description('Whether or not to support Swagger routes for these APIs.')
+param enableSwagger bool
+
+@description('Whether or not to enable autoscaling of App Services in this environment.')
+param autoscaleAppServices bool
+
+@description('Public URL of the public site.')
+param publicAppUrl string
+
+@description('The origins supported for CORS calls to this App Service.')
+param allowedOrigins string[]
+
+@description('Whether analytics is enabled')
+param analyticsEnabled bool
+
+@description('Whether or not to deploy Azure Metric alerts.')
+param deployAlerts bool
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.keyVault.keyVault
+}
+
+var vaultUri = keyVault.properties.vaultUri
+
+var coreSqlServerFqdn = reference('Microsoft.Sql/servers/${resourceNames.databases.coreSqlServer}', '2025-02-01-preview').fullyQualifiedDomainName
+var publicSqlServerFqdn = reference('Microsoft.Sql/servers/${resourceNames.databases.publicSqlServer}', '2025-02-01-preview').fullyQualifiedDomainName
+
+var analyticsFileShareMountPath string = '\\mounts\\analytics'
+
+resource analyticsStorageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' existing = {
+  name: resourceNames.analytics.storage.storageAccountName
+}
+
+module appServicePlanModule '../common/components/app-service-plan/app-service-plan.bicep' = {
+  name: 'contentApiAppServicePlanModule'
+  params: {
+    planName: resourceNames.contentApi.appServicePlan
+    sku: appServiceSku
+    operatingSystem: 'Windows'
+    alerts: deployAlerts ? {
+      alertsGroupName: resourceNames.alertsGroup
+      cpuPercentage: true
+      memoryPercentage: true
+    } : null
+    tagValues: tagValues
+  }
+}
+
+module appInsightsModule '../common/components/monitoring/appInsights.bicep' = {
+  name: 'contentApiAppInsightsModuleDeploy'
+  params: {
+    appInsightsName: resourceNames.contentApi.appInsights
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+    alerts: deployAlerts ? {
+      alertsGroupName: resourceNames.alertsGroup
+      exceptionCount: true
+      exceptionServerCount: true
+      failedRequests: true
+    } : null
+    tagValues: tagValues
+  }
+}
+
+module appServiceModule '../common/components/app-service/app-service.bicep' = {
+  name: 'contentApiAppServiceModuleDeploy'
+  params: {
+    appServiceName: resourceNames.contentApi.appService
+    minTlsVersion: minTlsVersion
+    appServicePlanId: appServicePlanModule.outputs.planId
+    connectionStrings: [
+      {
+        name: 'StatisticsDb'
+        type: 'SQLAzure'
+        connectionString: 'Data Source=tcp:${publicSqlServerFqdn},1433;Initial Catalog=${resourceNames.databases.statisticsDb};User Id=content@${publicSqlServerFqdn};Password=${databaseUserPassword};'
+      }
+      {
+        name: 'ContentDb'
+        type: 'SQLAzure'
+        connectionString: 'Data Source=tcp:${coreSqlServerFqdn},1433;Initial Catalog=${resourceNames.databases.contentDb};User Id=content@${coreSqlServerFqdn};Password=${databaseUserPassword};'
+      }
+    ]
+    vnetLink: {
+      vnetName: resourceNames.vnet.vnet
+      subnetName: resourceNames.vnet.subnets.contentApi
+    }
+    appInsightsName: appInsightsModule.outputs.applicationInsightsName
+    detailedErrors: detailedErrors
+    autoscaleEnabled: autoscaleAppServices
+    allowedOrigins: allowedOrigins
+    azureFileShares: analyticsEnabled ? [
+      {
+        storageName: analyticsStorageAccount.name
+        storageAccountKey: analyticsStorageAccount.listKeys().keys[0].value
+        storageAccountName: analyticsStorageAccount.name
+        fileShareName: resourceNames.analytics.storage.fileShareName
+        mountPath: analyticsFileShareMountPath
+      }
+    ] : []
+    applicationAppSettings: {
+      PublicStorage: keyVaultRef(vaultUri, resourceNames.keyVault.secrets.publicStorageAccountConnectionString)
+      enableSwagger: enableSwagger
+      PublicApp__Url: publicAppUrl
+      Analytics__Enabled: analyticsEnabled
+      Analytics__BasePath: analyticsFileShareMountPath
+    }
+    tagValues: tagValues
+  }
+}

--- a/infrastructure/templates/content-api/main.bicep
+++ b/infrastructure/templates/content-api/main.bicep
@@ -93,6 +93,8 @@ module appServiceModule '../common/components/app-service/app-service.bicep' = {
     appServiceName: resourceNames.contentApi.appService
     minTlsVersion: minTlsVersion
     appServicePlanId: appServicePlanModule.outputs.planId
+    keyVaultName: resourceNames.keyVault.keyVault
+    legacyKeyVaultRoleAssignmentName: true
     connectionStrings: [
       {
         name: 'StatisticsDb'

--- a/infrastructure/templates/data-api/main.bicep
+++ b/infrastructure/templates/data-api/main.bicep
@@ -106,6 +106,8 @@ module appServiceModule '../common/components/app-service/app-service.bicep' = {
     appServiceName: resourceNames.dataApi.appService
     minTlsVersion: minTlsVersion
     appServicePlanId: appServicePlanModule.outputs.planId
+    keyVaultName: resourceNames.keyVault.keyVault
+    legacyKeyVaultRoleAssignmentName: true
     connectionStrings: [
       {
         name: 'StatisticsDb'

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -50,21 +50,6 @@
         "P3V2 PremiumV2"
       ]
     },
-    "skuContent": {
-      "type": "string",
-      "defaultValue": "S1 Standard",
-      "allowedValues": [
-        "B1 Basic",
-        "B2 Basic",
-        "B3 Basic",
-        "S1 Standard",
-        "S2 Standard",
-        "S3 Standard",
-        "P1V2 PremiumV2",
-        "P2V2 PremiumV2",
-        "P3V2 PremiumV2"
-      ]
-    },
     "skuImporter": {
       "type": "string",
       "defaultValue": "S1 Standard",
@@ -144,30 +129,6 @@
       "type": "array",
       "metadata": {
         "description": "Firewall restrictions for storage accounts, string array"
-      }
-    },
-    "sqlPublicContentApiUser": {
-      "type": "string",
-      "metadata": {
-        "description": "The username of the content api for the public SQL Server"
-      }
-    },
-    "sqlPublicContentApiPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The password of the content api user of the public SQL Server"
-      }
-    },
-    "sqlContentApiUser": {
-      "type": "string",
-      "metadata": {
-        "description": "The username of the content api for the private SQL Server"
-      }
-    },
-    "sqlContentApiPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The password of the content api user for the private SQL Server"
       }
     },
     "sqlPublisherUser": {
@@ -698,9 +659,6 @@
     "statisticsDbName": "statistics",
     "statisticsReplicaDbName": "statistics",
     "appInsightsWorkspaceName": "[concat(parameters('subscription'), '-', parameters('environment'), '-log')]",
-    "contentAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-content')]",
-    "contentPlanName": "[concat(parameters('subscription'), '-asp-', parameters('environment'), '-content')]",
-    "contentAppInsights": "[concat(parameters('subscription'), '-ai-', parameters('environment'), '-content')]",
     "adminSignalRName": "[concat(parameters('subscription'), '-sr-', parameters('environment'), '-admin')]",
     "publicAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-public-site')]",
     "publicAppUrl": "[concat('https://', parameters('domain'))]",
@@ -1206,8 +1164,7 @@
     "keyVaultSecretsUserPrincipalRefs": [
       "[concat('Microsoft.Web/sites/', variables('publisherAppName'))]",
       "[concat('Microsoft.Web/sites/', variables('notificationsAppName'))]",
-      "[concat('Microsoft.Web/sites/', variables('importerAppName'))]",
-      "[concat('Microsoft.Web/sites/', variables('contentAppName'))]"
+      "[concat('Microsoft.Web/sites/', variables('importerAppName'))]"
     ],
     "publicDataFileShareMountPathWindows": "\\mounts\\public-api-data",
     "publicDataFileShareName": "[concat(parameters('subscription'), '-ees-papi-share-data')]",
@@ -1243,235 +1200,6 @@
     }
   },
   "resources": [
-    {
-      "type": "Microsoft.Web/sites",
-      "name": "[variables('contentAppName')]",
-      "apiVersion": "2019-08-01",
-      "location": "[resourceGroup().location]",
-      "identity": {
-        "type": "SystemAssigned"
-      },
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "App Service",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "resources": [
-        {
-          "condition": "[parameters('useSubnets')]",
-          "name": "virtualNetwork",
-          "type": "config",
-          "apiVersion": "2018-11-01",
-          "location": "[resourceGroup().location]",
-          "properties": {
-            "subnetResourceId": "[variables('contentSubnetRef')]",
-            "swiftSupported": true
-          },
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
-          ]
-        }
-      ],
-      "properties": {
-        "serverFarmId": "[concat('/subscriptions/', subscription().subscriptionId,'/resourcegroups/', resourceGroup().name, '/providers/Microsoft.Web/serverfarms/', variables('contentPlanName'))]",
-        "httpsOnly": true,
-        "clientAffinityEnabled": false,
-        "siteConfig": {
-          "http20Enabled": true,
-          "minTlsVersion": "[parameters('minTlsVersion')]",
-          "ftpsState": "FtpsOnly",
-          "netFrameworkVersion": "v10.0",
-          "alwaysOn": true,
-          "webSocketsEnabled": false,
-          "remoteDebuggingEnabled": false,
-          "httpLoggingEnabled": true,
-          "detailedErrorLoggingEnabled": true,
-          "requestTracingEnabled": true,
-          "use32BitWorkerProcess": false,
-          "cors": {
-            "allowedOrigins": "[union(variables('publicAllowedOrigins'), array(format('https://{0}', reference(variables('resourceIds').afdEndpoint, variables('apiVersions').afdEndpoint).hostName)))]"
-          },
-          "connectionStrings": [
-            {
-              "name": "StatisticsDb",
-              "type": "SQLAzure",
-              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('publicSqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', variables('statisticsReplicaDbName'), ';User Id=', parameters('sqlPublicContentApiUser'), '@', reference(concat('Microsoft.Sql/servers/', variables('publicSqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlPublicContentApiPassword'), ';')]"
-            },
-            {
-              "name": "ContentDb",
-              "type": "SQLAzure",
-              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('coreSqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', variables('contentDbName'), ';User Id=', parameters('sqlContentApiUser'), '@', reference(concat('Microsoft.Sql/servers/', variables('coreSqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlContentApiPassword'), ';')]"
-            }
-          ]
-        }
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Web/serverfarms/', variables('contentPlanName'))]",
-        "[resourceId('Microsoft.Insights/components', variables('contentAppInsights'))]"
-      ]
-    },
-    {
-      "name": "[concat(variables('contentAppName'), '/appsettings')]",
-      "type": "Microsoft.Web/sites/config",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2019-08-01",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]",
-        "[variables('ees-storage-public')]"
-      ],
-      "properties": {
-        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('Microsoft.Insights/components', variables('contentAppInsights')), '2020-02-02').InstrumentationKey]",
-        "WEBSITE_NODE_DEFAULT_VERSION": "22.23.1",
-        "WEBSITE_CONTENTOVERVNET": "1",
-        "WEBSITE_RUN_FROM_PACKAGE": "1",
-        "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
-        "enableSwagger": "[parameters('enableSwagger')]",
-        "Analytics__Enabled": "[parameters('analyticsEnabled')]",
-        "Analytics__BasePath": "[parameters('analyticsFileShareMountPath')]"
-      }
-    },
-    {
-      "condition": "[parameters('analyticsEnabled')]",
-      "name": "[concat(variables('contentAppName'), '/azurestorageaccounts')]",
-      "type": "Microsoft.Web/sites/config",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2019-08-01",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
-      ],
-      "properties": {
-        "[variables('analyticsFileShareName')]": {
-          "type": "AzureFiles",
-          "accountName": "[variables('analyticsStorageAccountName')]",
-          "accessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('analyticsStorageAccountName')), '2018-02-01').keys[0].value]",
-          "shareName": "[variables('analyticsFileShareName')]",
-          "mountPath": "[parameters('analyticsFileShareMountPath')]",
-          "protocol": "Smb"
-        }
-      }
-    },
-    {
-      "apiVersion": "2018-11-01",
-      "type": "Microsoft.Web/sites/slots",
-      "name": "[concat(variables('contentAppName'), '/', parameters('deploySlotName'))]",
-      "kind": "app",
-      "location": "[resourceGroup().location]",
-      "comments": "This specifies the web app slots.",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "Web App",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "properties": {
-        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('contentPlanName'))]",
-        "httpsOnly": true,
-        "siteConfig": {
-          "http20Enabled": true,
-          "minTlsVersion": "[parameters('minTlsVersion')]",
-          "ftpsState": "FtpsOnly",
-          "netFrameworkVersion": "v10.0",
-          "alwaysOn": false,
-          "webSocketsEnabled": false,
-          "remoteDebuggingEnabled": false,
-          "httpLoggingEnabled": true,
-          "detailedErrorLoggingEnabled": true,
-          "requestTracingEnabled": true,
-          "use32BitWorkerProcess": false,
-          "cors": {
-            "allowedOrigins": "[union(variables('publicAllowedOrigins'), array(format('https://{0}', reference(variables('resourceIds').afdEndpoint, variables('apiVersions').afdEndpoint).hostName)))]"
-          }
-        }
-      },
-      "resources": [
-        {
-          "condition": "[parameters('useSubnets')]",
-          "name": "virtualNetwork",
-          "type": "config",
-          "apiVersion": "2018-11-01",
-          "location": "[resourceGroup().location]",
-          "properties": {
-            "subnetResourceId": "[variables('contentSubnetRef')]",
-            "swiftSupported": true
-          },
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/sites/slots', variables('contentAppName'), parameters('deploySlotName'))]"
-          ]
-        }
-      ],
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Web/serverfarms",
-      "sku": {
-        "Tier": "[first(skip(split(parameters('skuContent'), ' '), 1))]",
-        "Name": "[first(split(parameters('skuContent'), ' '))]"
-      },
-      "name": "[variables('contentPlanName')]",
-      "apiVersion": "2022-03-01",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "App Service plan",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "properties": {
-        "name": "[variables('contentPlanName')]",
-        "workerSizeId": "0",
-        "reserved": false,
-        "numberOfWorkers": "1",
-        "hostingEnvironment": ""
-      }
-    },
-    {
-      "type": "Microsoft.Insights/components",
-      "name": "[variables('contentAppInsights')]",
-      "apiVersion": "2020-02-02",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "Application Insights",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      },
-      "properties": {
-        "applicationId": "[variables('contentAppName')]",
-        "Request_Source": "AzureTfsExtensionAzureProject",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspaceName'))]"
-      }
-    },
     {
       "type": "Microsoft.SignalRService/signalR",
       "apiVersion": "2021-10-01",
@@ -3507,74 +3235,6 @@
         "principalId": "[reference(variables('keyVaultSecretsUserPrincipalRefs')[copyIndex()], '2022-09-01', 'Full').identity.principalId]",
         "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
         "principalType": "ServicePrincipal"
-      }
-    },
-    {
-      "name": "[concat(variables('contentAppName'), '-autoscale')]",
-      "apiVersion": "2014-04-01",
-      "type": "Microsoft.Insights/autoscaleSettings",
-      "location": "[resourceGroup().location]",
-      "tags": {},
-      "properties": {
-        "name": "[concat(variables('contentAppName'), '-autoscale')]",
-        "enabled": "[parameters('autoscaleAppServices')]",
-        "targetResourceUri": "[resourceId(subscription().subscriptionId, resourceGroup().name,'Microsoft.Web/serverfarms', variables('contentPlanName'))]",
-        "profiles": [
-          {
-            "name": "Auto created scale condition",
-            "capacity": {
-              "minimum": 2,
-              "maximum": 10,
-              "default": 2
-            },
-            "rules": [
-              {
-                "scaleAction": {
-                  "direction": "Increase",
-                  "type": "ChangeCount",
-                  "value": 1,
-                  "cooldown": "PT5M"
-                },
-                "metricTrigger": {
-                  "metricName": "CpuPercentage",
-                  "metricNamespace": "microsoft.web/serverfarms",
-                  "metricResourceUri": "[resourceId(subscription().subscriptionId, resourceGroup().name,'Microsoft.Web/serverfarms', variables('contentPlanName'))]",
-                  "operator": "GreaterThan",
-                  "statistic": "Average",
-                  "threshold": 70,
-                  "timeAggregation": "Average",
-                  "timeGrain": "PT1M",
-                  "timeWindow": "PT10M",
-                  "Dimensions": [],
-                  "dividePerInstance": false
-                }
-              },
-              {
-                "scaleAction": {
-                  "direction": "Decrease",
-                  "type": "ChangeCount",
-                  "value": 1,
-                  "cooldown": "PT5M"
-                },
-                "metricTrigger": {
-                  "metricName": "CpuPercentage",
-                  "metricNamespace": "microsoft.web/serverfarms",
-                  "metricResourceUri": "[resourceId(subscription().subscriptionId, resourceGroup().name,'Microsoft.Web/serverfarms', variables('contentPlanName'))]",
-                  "operator": "LessThan",
-                  "statistic": "Average",
-                  "threshold": 30,
-                  "timeAggregation": "Average",
-                  "timeGrain": "PT1M",
-                  "timeWindow": "PT10M",
-                  "Dimensions": [],
-                  "dividePerInstance": false
-                }
-              }
-            ]
-          }
-        ],
-        "notifications": [],
-        "targetResourceLocation": ""
       }
     },
     {

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -400,10 +400,6 @@
       "type": "string",
       "defaultValue": "storage"
     },
-    "enableSwagger": {
-      "type": "bool",
-      "defaultValue": false
-    },
     "memoryCacheEnabled": {
       "type": "bool",
       "defaultValue": true,
@@ -533,10 +529,6 @@
     "capacityStatisticsDb": {
       "type": "int"
     },
-    "deploySlotName": {
-      "type": "string",
-      "defaultValue": "deploy"
-    },
     "maxContentDbSizeBytes": {
       "type": "int",
       "defaultValue": 1073741824
@@ -605,20 +597,6 @@
       "defaultValue": true,
       "metadata": {
         "description": "Flag to determine if the public data database exists. TODO EES-5073 remove this when the public data database is available in every environment"
-      }
-    },
-    "analyticsEnabled": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Whether analytics is enabled"
-      }
-    },
-    "analyticsFileShareMountPath": {
-      "type": "string",
-      "defaultValue": "\\mounts\\analytics",
-      "metadata": {
-        "description": "Where analytics request files are saved before being processed"
       }
     },
     "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
@@ -1169,8 +1147,6 @@
     "publicDataFileShareMountPathWindows": "\\mounts\\public-api-data",
     "publicDataFileShareName": "[concat(parameters('subscription'), '-ees-papi-share-data')]",
     "publicDataStorageAccountName": "[concat(parameters('subscription'), 'eespapisa')]",
-    "analyticsFileShareName": "[concat(parameters('subscription'), '-ees-share-anlyt')]",
-    "analyticsStorageAccountName": "[concat(parameters('subscription'), 'eessaanlyt')]",
     "eventGridTopicNamePublicationChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-publication-changed')]",
     "eventGridTopicNameReleaseChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-changed')]",
     "eventGridTopicNameReleaseVersionChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-version-changed')]",


### PR DESCRIPTION
:warning: Faffy deploy ticket https://dfedigital.atlassian.net/browse/EES-7606 covers the manual pipeline changes needed while this ticket goes through the environments. :warning: 

This PR:
- migrates the Content API from ARM to Bicep, in a very similar style to PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/7283.

This is a simpler PR as the Data API migration also had to set up a good deal of new Bicep templates!

## What's moved?

- The Content API App Service.
- Its configuration.
- Its swap slot.
- Its swap slot's configuration.
- Its App Insights instance.
- Its App Service Plan.
- Its Autoscaling configuration.
- Its VNet links.
- Its Key Vault Secrets User role assignment.
- Its Analytics File Share mount.
- Its swap slot's Analytics File Share mount.