### PR TITLE
EES-7578 Add `CsvOnly` locations to `DataSetFileVersionGeographicLevels`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/DataSetFileVersionGeographicLevelsMigrationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/DataSetFileVersionGeographicLevelsMigrationControllerTests.cs
@@ -1,0 +1,353 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Bau;
+
+public class DataSetFileVersionGeographicLevelsMigrationControllerTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public async Task WhenCsvHasLevelThatWasNotImported_AddsCsvOnlyLevel()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.Region]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            BuildCsv("National", "Regional", "School")
+        );
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+            Assert.Equal(1, result.Processed);
+            Assert.Equal(0, result.Remaining);
+            Assert.Empty(result.Errors);
+            Assert.Equal(["School"], result.Added[file.Id]);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal(
+                [(GeographicLevel.Country, false), (GeographicLevel.Region, false), (GeographicLevel.School, true)],
+                geographicLevels
+            );
+        }
+    }
+
+    [Fact]
+    public async Task WhenCsvLevelsMatchImportedLevels_SetsAllToNotCsvOnly()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.Region]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            BuildCsv("National", "Regional")
+        );
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+            Assert.Equal(1, result.Processed);
+            Assert.Empty(result.Added);
+            Assert.Empty(result.Errors);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal([(GeographicLevel.Country, false), (GeographicLevel.Region, false)], geographicLevels);
+        }
+    }
+
+    [Fact]
+    public async Task WhenDryRun_PersistsNothing()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            BuildCsv("National", "School")
+        );
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels();
+
+            Assert.True(result.IsDryRun);
+            Assert.Equal(1, result.Processed);
+            Assert.Equal(["School"], result.Added[file.Id]);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal([(GeographicLevel.Country, (bool?)null)], geographicLevels);
+        }
+    }
+
+    [Fact]
+    public async Task WhenFileHasNoUnsetLevels_IsNotProcessed()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country]);
+        file.DataSetFileVersionGeographicLevels[0].CsvOnly = false;
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+
+        await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
+
+        var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+            .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+        Assert.Equal(0, result.Processed);
+        Assert.Equal(0, result.Remaining);
+        privateBlobStorageService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task WhenMoreFilesThanNum_ProcessesBatchAndReportsRemaining()
+    {
+        var files = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+            .GenerateList(3);
+
+        var contentDbContextId = await SeedFiles([.. files]);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        files.ForEach(file =>
+            privateBlobStorageService.SetupGetDownloadStream(PrivateReleaseFiles, file.Path(), BuildCsv("National"))
+        );
+
+        await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
+
+        var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+            .MigrateCsvOnlyGeographicLevels(dryRun: false, num: 2);
+
+        Assert.Equal(2, result.Processed);
+        Assert.Equal(1, result.Remaining);
+    }
+
+    [Fact]
+    public async Task WhenSkipIsSet_StepsPastFiles()
+    {
+        var files = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+            .GenerateList(3);
+
+        var contentDbContextId = await SeedFiles([.. files]);
+
+        var expectedFile = files.OrderBy(f => f.Id).Last();
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            expectedFile.Path(),
+            BuildCsv("National", "School")
+        );
+
+        await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
+
+        var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+            .MigrateCsvOnlyGeographicLevels(dryRun: false, skip: 2);
+
+        Assert.Equal(1, result.Processed);
+        Assert.Equal(["School"], result.Added[expectedFile.Id]);
+    }
+
+    [Fact]
+    public async Task WhenBlobIsMissing_ReportsErrorAndLeavesFileUnset()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService
+            .Setup(s => s.GetDownloadStream(PrivateReleaseFiles, file.Path(), true, default))
+            .ReturnsAsync(new Either<ActionResult, Stream>(new NotFoundResult()));
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+            Assert.Equal(0, result.Processed);
+            Assert.Equal(1, result.Remaining);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains(file.Id.ToString(), error);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal([(GeographicLevel.Country, (bool?)null)], geographicLevels);
+        }
+    }
+
+    [Fact]
+    public async Task WhenCsvHasNoGeographicLevelColumn_ReportsErrorAndLeavesFileUnset()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            "time_period,time_identifier\n2020,Calendar year"
+        );
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+            Assert.Equal(0, result.Processed);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains("geographic_level", error);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal([(GeographicLevel.Country, (bool?)null)], geographicLevels);
+        }
+    }
+
+    [Fact]
+    public async Task WhenImportedLevelIsNotInCsv_ReportsErrorAndLeavesThatLevelUnset()
+    {
+        File file = _dataFixture
+            .DefaultFile(FileType.Data)
+            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.Region]);
+
+        var contentDbContextId = await SeedFiles(file);
+
+        var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(MockBehavior.Strict);
+        privateBlobStorageService.SetupGetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            BuildCsv("National", "School")
+        );
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var result = await BuildController(contentDbContext, privateBlobStorageService.Object)
+                .MigrateCsvOnlyGeographicLevels(dryRun: false);
+
+            Assert.Equal(1, result.Processed);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains("Regional", error);
+        }
+
+        await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        {
+            var geographicLevels = await GetGeographicLevels(contentDbContext, file.Id);
+
+            Assert.Equal(
+                [
+                    (GeographicLevel.Country, false),
+                    (GeographicLevel.Region, (bool?)null),
+                    (GeographicLevel.School, true),
+                ],
+                geographicLevels
+            );
+        }
+    }
+
+    private async Task<string> SeedFiles(params File[] files)
+    {
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using var contentDbContext = InMemoryContentDbContext(contentDbContextId);
+        contentDbContext.Files.AddRange(files);
+        await contentDbContext.SaveChangesAsync();
+
+        return contentDbContextId;
+    }
+
+    private static async Task<List<(GeographicLevel, bool?)>> GetGeographicLevels(
+        ContentDbContext contentDbContext,
+        Guid fileId
+    ) =>
+        await contentDbContext
+            .DataSetFileVersionGeographicLevels.Where(gl => gl.DataSetFileVersionId == fileId)
+            .OrderBy(gl => gl.GeographicLevel)
+            .Select(gl => new ValueTuple<GeographicLevel, bool?>(gl.GeographicLevel, gl.CsvOnly))
+            .ToListAsync();
+
+    private static string BuildCsv(params string[] geographicLevels) =>
+        string.Join(
+            "\n",
+            [
+                "time_period,time_identifier,geographic_level",
+                .. geographicLevels.Select(gl => $"2020,Calendar year,{gl}"),
+            ]
+        );
+
+    private static DataSetFileVersionGeographicLevelsMigrationController BuildController(
+        ContentDbContext contentDbContext,
+        IPrivateBlobStorageService privateBlobStorageService
+    ) =>
+        new(
+            contentDbContext,
+            privateBlobStorageService,
+            Mock.Of<ILogger<DataSetFileVersionGeographicLevelsMigrationController>>()
+        );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
@@ -485,6 +485,54 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
+        public async Task WhenDataSetHasCsvOnlyGeographicLevels_ExcludesThemFromGeographicLevels()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                        .WithCsvOnlyGeographicLevels([GeographicLevel.School])
+                )
+                .WithReleaseVersion(releaseVersion);
+
+            DataImport dataImport = _dataFixture
+                .DefaultDataImport()
+                .WithFile(dataSet.File)
+                .WithStatus(DataImportStatus.COMPLETE);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.DataImports.Add(dataImport);
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(releaseVersion.Id);
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.Equal(["National"], result.DataSets[0].Meta.GeographicLevels);
+            }
+        }
+
+        [Fact]
         public async Task WhenDataSetHasNoSummary_ReturnsNullSummary()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileVersionGeographicLevelsMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileVersionGeographicLevelsMigrationController.cs
@@ -1,0 +1,193 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+// TODO EES-7584 Remove once every DataSetFileVersionGeographicLevel.CsvOnly has been set
+[Route("api/bau")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class DataSetFileVersionGeographicLevelsMigrationController(
+    ContentDbContext contentDbContext,
+    IPrivateBlobStorageService privateBlobStorageService,
+    ILogger<DataSetFileVersionGeographicLevelsMigrationController> logger
+) : ControllerBase
+{
+    private const string GeographicLevelColumn = "geographic_level";
+
+    public class MigrationResult
+    {
+        public bool IsDryRun { get; set; }
+
+        public int Processed { get; set; }
+
+        public int Remaining { get; set; }
+
+        public Dictionary<Guid, List<string>> Added { get; set; } = new();
+
+        public List<string> Errors { get; set; } = [];
+    }
+
+    [HttpPut("migrate-csv-only-geographic-levels")]
+    public async Task<MigrationResult> MigrateCsvOnlyGeographicLevels(
+        [FromQuery] bool dryRun = true,
+        [FromQuery] int num = 20,
+        [FromQuery] int skip = 0,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var files = await contentDbContext
+            .Files.Include(f => f.DataSetFileVersionGeographicLevels)
+            .Where(f => f.DataSetFileVersionGeographicLevels.Any(gl => gl.CsvOnly == null))
+            .OrderBy(f => f.Id)
+            .Skip(skip)
+            .Take(num)
+            .ToListAsync(cancellationToken);
+
+        var result = new MigrationResult { IsDryRun = dryRun };
+
+        foreach (var file in files)
+        {
+            var csvGeographicLevels = await GetCsvGeographicLevels(file, result.Errors, cancellationToken);
+
+            if (csvGeographicLevels == null)
+            {
+                continue;
+            }
+
+            var addedGeographicLevels = SetCsvOnly(file, csvGeographicLevels, result.Errors);
+
+            if (addedGeographicLevels.Count > 0)
+            {
+                result.Added.Add(file.Id, addedGeographicLevels.Select(gl => gl.GetEnumLabel()).ToList());
+            }
+
+            result.Processed++;
+        }
+
+        if (!dryRun)
+        {
+            await contentDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        result.Remaining = await contentDbContext.Files.CountAsync(
+            f => f.DataSetFileVersionGeographicLevels.Any(gl => gl.CsvOnly == null),
+            cancellationToken
+        );
+
+        return result;
+    }
+
+    private async Task<HashSet<GeographicLevel>?> GetCsvGeographicLevels(
+        File file,
+        List<string> errors,
+        CancellationToken cancellationToken
+    )
+    {
+        var streamProvider = () => GetDataFileStream(file, cancellationToken);
+        var csvGeographicLevelLabels = new HashSet<string>();
+
+        try
+        {
+            var csvHeaders = await CsvUtils.GetCsvHeaders(streamProvider);
+            var geographicLevelColumnIndex = csvHeaders.FindIndex(header => header.Equals(GeographicLevelColumn));
+
+            if (geographicLevelColumnIndex == -1)
+            {
+                AddError(errors, file, $"CSV has no {GeographicLevelColumn} column");
+                return null;
+            }
+
+            await CsvUtils.ForEachRow(
+                streamProvider,
+                (rowValues, _, _) =>
+                {
+                    csvGeographicLevelLabels.Add(rowValues[geographicLevelColumnIndex]);
+                    return Task.FromResult(true);
+                }
+            );
+
+            return csvGeographicLevelLabels.Select(EnumToEnumLabelConverter<GeographicLevel>.FromProvider).ToHashSet();
+        }
+        catch (Exception e)
+        {
+            AddError(errors, file, $"could not read the CSV: {e.Message}");
+            return null;
+        }
+    }
+
+    private async Task<Stream> GetDataFileStream(File file, CancellationToken cancellationToken)
+    {
+        var stream = await privateBlobStorageService.GetDownloadStream(
+            PrivateReleaseFiles,
+            file.Path(),
+            cancellationToken: cancellationToken
+        );
+
+        return stream.IsLeft
+            ? throw new InvalidOperationException($"no blob found for File {file.Id} at {file.Path()}")
+            : stream.Right;
+    }
+
+    private List<GeographicLevel> SetCsvOnly(
+        File file,
+        HashSet<GeographicLevel> csvGeographicLevels,
+        List<string> errors
+    )
+    {
+        foreach (var geographicLevel in file.DataSetFileVersionGeographicLevels)
+        {
+            if (csvGeographicLevels.Contains(geographicLevel.GeographicLevel))
+            {
+                geographicLevel.CsvOnly = false;
+            }
+            else
+            {
+                // Every recorded geographic level was imported from a row of this CSV, so this suggests
+                // the file has been replaced, or that we are reading the wrong blob. Leave the row unset
+                // so that the data set is revisited.
+                AddError(
+                    errors,
+                    file,
+                    $"geographic level {geographicLevel.GeographicLevel.GetEnumLabel()} is recorded but is not in the CSV"
+                );
+            }
+        }
+
+        var csvOnlyGeographicLevels = csvGeographicLevels
+            .Except(file.DataSetFileVersionGeographicLevels.Select(gl => gl.GeographicLevel))
+            .OrderBy(gl => gl)
+            .ToList();
+
+        contentDbContext.DataSetFileVersionGeographicLevels.AddRange(
+            csvOnlyGeographicLevels.Select(gl => new DataSetFileVersionGeographicLevel
+            {
+                DataSetFileVersionId = file.Id,
+                GeographicLevel = gl,
+                CsvOnly = true,
+            })
+        );
+
+        return csvOnlyGeographicLevels;
+    }
+
+    private void AddError(List<string> errors, File file, string message)
+    {
+        var error = $"File {file.Id} ({file.Filename}): {message}";
+        logger.LogError("{Error}", error);
+        errors.Add(error);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,13 +12,15 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel")]
+    partial class Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.10")
+                .HasAnnotation("ProductVersion", "10.0.11")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -2585,7 +2588,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "User")
-                        .WithMany()
+                        .WithMany("UserPreReleaseRoles")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -2612,7 +2615,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "User")
-                        .WithMany()
+                        .WithMany("UserPublicationRoles")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -2781,6 +2784,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Theme", b =>
                 {
                     b.Navigation("Publications");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.User", b =>
+                {
+                    b.Navigation("UserPreReleaseRoles");
+
+                    b.Navigation("UserPublicationRoles");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.DataBlock", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "CsvOnly",
+                table: "DataSetFileVersionGeographicLevels",
+                type: "bit",
+                nullable: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "CsvOnly", table: "DataSetFileVersionGeographicLevels");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,6 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
     /// <inheritdoc />
     public partial class Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel : Migration
     {
+        private const string MigrationId = "20260828112013";
+
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -15,6 +18,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 table: "DataSetFileVersionGeographicLevels",
                 type: "bit",
                 nullable: true
+            );
+
+            migrationBuilder.SqlFromFile(
+                MigrationConstants.ContentMigrationsPath,
+                $"{MigrationId}_{nameof(Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel)}.sql"
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260828112013_Ees7578AddCsvOnlyToDataSetFileVersionGeographicLevel.sql
@@ -1,0 +1,30 @@
+﻿-- Set CsvOnly for the DataSetFileVersionGeographicLevels rows whose value can be proven without
+-- reading the data file CSV. Rows left NULL are picked up by the BAU migration endpoint, which
+-- reads the CSV to find geographic levels that were never imported.
+
+-- Every existing row is a geographic level that was imported, so nothing here can be CSV-only.
+-- The only question is whether the file also contained levels that were dropped during import.
+
+-- A file whose import dropped no rows contained no levels beyond those that were imported.
+UPDATE gl
+SET gl.CsvOnly = 0
+FROM dbo.DataSetFileVersionGeographicLevels gl
+JOIN dbo.DataImports di ON di.FileId = gl.DataSetFileVersionId
+WHERE gl.CsvOnly IS NULL
+  AND di.Status = 'COMPLETE'
+  AND di.TotalRows IS NOT NULL
+  AND di.ExpectedImportedRows IS NOT NULL
+  AND di.TotalRows = di.ExpectedImportedRows;
+
+-- Solo-importable levels are only imported when a file consists solely of that level, so a file
+-- with one of them recorded contained nothing else.
+UPDATE gl
+SET gl.CsvOnly = 0
+FROM dbo.DataSetFileVersionGeographicLevels gl
+WHERE gl.CsvOnly IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM dbo.DataSetFileVersionGeographicLevels solo
+      WHERE solo.DataSetFileVersionId = gl.DataSetFileVersionId
+        AND solo.GeographicLevel IN ('SCH', 'PROV', 'INST', 'PA')
+  );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -89,7 +89,13 @@ public record ReleaseDataContentDataSetMetaDto
 
     private static string[] GetOrderedGeographicLevels(
         IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels
-    ) => [.. dataSetFileVersionGeographicLevels.Select(level => level.GeographicLevel.GetEnumLabel()).Order()];
+    ) =>
+        [
+            .. dataSetFileVersionGeographicLevels
+                .Where(level => level.CsvOnly != true)
+                .Select(level => level.GeographicLevel.GetEnumLabel())
+                .Order(),
+        ];
 
     private static string[] GetOrderedFilters(
         IEnumerable<FilterMeta> filters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -144,6 +144,47 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
             }
 
             [Fact]
+            public async Task FilterByGeographicLevel_CsvOnlyLevelsAreExcluded()
+            {
+                Publication publication = DataFixture
+                    .DefaultPublication()
+                    .WithReleases(_ => [DataFixture.DefaultRelease(publishedVersions: 1)])
+                    .WithTheme(DataFixture.DefaultTheme());
+
+                ReleaseFile releaseFile = DataFixture
+                    .DefaultReleaseFile()
+                    .WithReleaseVersion(publication.Releases[0].Versions[0])
+                    .WithFile(
+                        DataFixture
+                            .DefaultFile(FileType.Data)
+                            .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                            .WithCsvOnlyGeographicLevels([GeographicLevel.Institution])
+                    );
+
+                await fixture.GetContentDbContext().AddTestData(context => context.ReleaseFiles.Add(releaseFile));
+
+                var csvOnlyQuery = new DataSetFileListRequest(
+                    GeographicLevel: GeographicLevel.Institution.GetEnumValue()
+                );
+                var csvOnlyResponse = await ListDataSetFiles(csvOnlyQuery);
+
+                csvOnlyResponse
+                    .AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>()
+                    .AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0);
+
+                var importedQuery = new DataSetFileListRequest(GeographicLevel: GeographicLevel.Country.GetEnumValue());
+                var importedResponse = await ListDataSetFiles(importedQuery);
+
+                var pagedResult = importedResponse.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 1);
+                Assert.Equal(
+                    [GeographicLevel.Country.GetEnumLabel()],
+                    Assert.Single(pagedResult.Results).Meta.GeographicLevels
+                );
+            }
+
+            [Fact]
             public async Task FilterByPublicationId_Success()
             {
                 var (publication1, publication2) = DataFixture

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataImportGeneratorExtensions.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -55,6 +56,11 @@ public static class DataImportGeneratorExtensions
         this Generator<DataImport> generator,
         int expectedImportedRows
     ) => generator.ForInstance(s => s.SetExpectedImportedRows(expectedImportedRows));
+
+    public static Generator<DataImport> WithGeographicLevels(
+        this Generator<DataImport> generator,
+        HashSet<GeographicLevel>? geographicLevels
+    ) => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
 
     public static Generator<DataImport> WithImportedRows(this Generator<DataImport> generator, int importedRows) =>
         generator.ForInstance(s => s.SetImportedRows(importedRows));
@@ -143,6 +149,11 @@ public static class DataImportGeneratorExtensions
         this InstanceSetters<DataImport> setters,
         int expectedImportedRows
     ) => setters.Set(d => d.ExpectedImportedRows, expectedImportedRows);
+
+    public static InstanceSetters<DataImport> SetGeographicLevels(
+        this InstanceSetters<DataImport> setters,
+        HashSet<GeographicLevel>? geographicLevels
+    ) => setters.Set(d => d.GeographicLevels, geographicLevels);
 
     public static InstanceSetters<DataImport> SetImportedRows(
         this InstanceSetters<DataImport> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileVersionGeographicLevelGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileVersionGeographicLevelGeneratorExtensions.cs
@@ -32,6 +32,11 @@ public static class DataSetFileVersionGeographicLevelGeneratorExtensions
         GeographicLevel geographicLevel
     ) => generator.ForInstance(s => s.SetGeographicLevel(geographicLevel));
 
+    public static Generator<DataSetFileVersionGeographicLevel> WithCsvOnly(
+        this Generator<DataSetFileVersionGeographicLevel> generator,
+        bool? csvOnly
+    ) => generator.ForInstance(s => s.SetCsvOnly(csvOnly));
+
     public static InstanceSetters<DataSetFileVersionGeographicLevel> SetDataSetFileVersion(
         this InstanceSetters<DataSetFileVersionGeographicLevel> setters,
         File dataSetFileVersion
@@ -49,4 +54,9 @@ public static class DataSetFileVersionGeographicLevelGeneratorExtensions
         this InstanceSetters<DataSetFileVersionGeographicLevel> setters,
         GeographicLevel geographicLevel
     ) => setters.Set(f => f.GeographicLevel, geographicLevel);
+
+    public static InstanceSetters<DataSetFileVersionGeographicLevel> SetCsvOnly(
+        this InstanceSetters<DataSetFileVersionGeographicLevel> setters,
+        bool? csvOnly
+    ) => setters.Set(f => f.CsvOnly, csvOnly);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -55,6 +55,11 @@ public static class FileGeneratorExtensions
         List<GeographicLevel> geographicLevels
     ) => generator.ForInstance(s => s.SetDataSetFileVersionGeographicLevels(geographicLevels));
 
+    public static Generator<File> WithCsvOnlyGeographicLevels(
+        this Generator<File> generator,
+        List<GeographicLevel> geographicLevels
+    ) => generator.ForInstance(s => s.SetCsvOnlyGeographicLevels(geographicLevels));
+
     public static Generator<File> WithCreatedByUser(this Generator<File> generator, User user) =>
         generator.ForInstance(s => s.SetFileCreatedByUser(user));
 
@@ -160,6 +165,25 @@ public static class FileGeneratorExtensions
                         GeographicLevel = gl,
                     })
                     .ToList()
+        );
+
+    public static InstanceSetters<File> SetCsvOnlyGeographicLevels(
+        this InstanceSetters<File> setters,
+        List<GeographicLevel> geographicLevels
+    ) =>
+        setters.Set(
+            file => file.DataSetFileVersionGeographicLevels,
+            (_, file) =>
+                [
+                    .. file.DataSetFileVersionGeographicLevels,
+                    .. geographicLevels.Select(gl => new DataSetFileVersionGeographicLevel
+                    {
+                        DataSetFileVersionId = file.Id,
+                        DataSetFileVersion = file,
+                        GeographicLevel = gl,
+                        CsvOnly = true,
+                    }),
+                ]
         );
 
     public static InstanceSetters<File> SetFileCreatedByUser(this InstanceSetters<File> setters, User? user) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileVersionGeographicLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileVersionGeographicLevel.cs
@@ -11,5 +11,11 @@ public class DataSetFileVersionGeographicLevel
 
     public GeographicLevel GeographicLevel { get; set; }
 
+    /// <summary>
+    /// Null means this row predates the CsvOnly backfill and its value isn't known yet. Reads filter on
+    /// `CsvOnly != true`, so null rows behave exactly as false ones do and data sets that haven't been
+    /// backfilled keep displaying the geographic levels they always have. Once the backfill is complete,
+    /// this will be made non-nullable in EES-7584.
+    /// </summary>
     public bool? CsvOnly { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileVersionGeographicLevel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileVersionGeographicLevel.cs
@@ -10,4 +10,6 @@ public class DataSetFileVersionGeographicLevel
     public File DataSetFileVersion { get; set; } = null!;
 
     public GeographicLevel GeographicLevel { get; set; }
+
+    public bool? CsvOnly { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
@@ -1,0 +1,1194 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
+using Footnote = GovUk.Education.ExploreEducationStatistics.Data.Model.Footnote;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests;
+
+public class DataSetFileServiceTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    public class ListDataSetFilesTests : DataSetFileServiceTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).GenerateList(2))
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service);
+
+                var pagedResult = result.AssertRight();
+
+                Assert.Equal(2, pagedResult.Paging.TotalResults);
+                Assert.Equal(2, pagedResult.Results.Count);
+
+                foreach (var releaseFile in releaseFiles)
+                {
+                    var viewModel = Assert.Single(pagedResult.Results, r => r.FileId == releaseFile.FileId);
+
+                    Assert.Equal(releaseFile.File.DataSetFileId, viewModel.Id);
+                    Assert.Equal(releaseFile.File.Filename, viewModel.Filename);
+                    Assert.Equal(releaseFile.File.DisplaySize(), viewModel.FileSize);
+                    Assert.Equal(releaseFile.Name, viewModel.Title);
+                    Assert.Equal(releaseFile.Summary, viewModel.Content);
+
+                    Assert.Equal(publication.ThemeId, viewModel.Theme.Id);
+                    Assert.Equal(publication.Theme.Title, viewModel.Theme.Title);
+
+                    Assert.Equal(publication.Id, viewModel.Publication.Id);
+                    Assert.Equal(publication.Title, viewModel.Publication.Title);
+                    Assert.Equal(publication.Slug, viewModel.Publication.Slug);
+
+                    Assert.Equal(releaseFile.ReleaseVersion.Id, viewModel.Release.Id);
+                    Assert.Equal(releaseFile.ReleaseVersion.Release.Title, viewModel.Release.Title);
+                    Assert.Equal(releaseFile.ReleaseVersion.Release.Slug, viewModel.Release.Slug);
+
+                    Assert.True(viewModel.LatestData);
+                    Assert.False(viewModel.IsSuperseded);
+                    Assert.Equal(releaseFile.ReleaseVersion.PublishedDisplayDate, viewModel.Published);
+                    Assert.Equal(releaseFile.Published, viewModel.LastUpdated);
+
+                    Assert.Null(viewModel.Api);
+
+                    Assert.Equal(releaseFile.File.DataSetFileMeta!.NumDataFileRows, viewModel.Meta.NumDataFileRows);
+                    Assert.Equal(
+                        releaseFile
+                            .File.DataSetFileVersionGeographicLevels.Select(gl => gl.GeographicLevel.GetEnumLabel())
+                            .Order()
+                            .ToList(),
+                        viewModel.Meta.GeographicLevels
+                    );
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CsvOnlyGeographicLevels_ExcludedFromViewModel()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFile(
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                        .WithCsvOnlyGeographicLevels([GeographicLevel.Institution])
+                );
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service);
+
+                var pagedResult = result.AssertRight();
+
+                var viewModel = Assert.Single(pagedResult.Results);
+                Assert.Equal([GeographicLevel.Country.GetEnumLabel()], viewModel.Meta.GeographicLevels);
+            }
+        }
+
+        [Fact]
+        public async Task FilterByGeographicLevel_CsvOnlyLevelsDoNotMatchWhenMultipleGeogLvls()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFiles([
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Institution]),
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                        .WithCsvOnlyGeographicLevels([GeographicLevel.Institution]),
+                ])
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service, geographicLevel: GeographicLevel.Institution);
+
+                var pagedResult = result.AssertRight();
+
+                var viewModel = Assert.Single(pagedResult.Results);
+                Assert.Equal(releaseFiles[0].FileId, viewModel.FileId);
+            }
+        }
+
+        [Fact]
+        public async Task LatestOnlyDefaultsToTrue_ReturnsFilesOfLatestPublishedReleaseOnly()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ =>
+                    [
+                        _dataFixture.DefaultRelease(publishedVersions: 1, year: 2023),
+                        _dataFixture.DefaultRelease(publishedVersions: 1, year: 2024),
+                    ]
+                )
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersions(publication.Releases.Select(r => r.Versions[0]))
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).GenerateList(2))
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service);
+
+                var pagedResult = result.AssertRight();
+
+                var viewModel = Assert.Single(pagedResult.Results);
+                Assert.Equal(publication.LatestPublishedReleaseVersionId, viewModel.Release.Id);
+            }
+        }
+
+        [Fact]
+        public async Task LatestOnlyFalse_ReturnsFilesOfAllLatestPublishedReleaseVersions()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ =>
+                    [
+                        _dataFixture.DefaultRelease(publishedVersions: 1, year: 2023),
+                        _dataFixture.DefaultRelease(publishedVersions: 1, year: 2024),
+                    ]
+                )
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersions(publication.Releases.Select(r => r.Versions[0]))
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).GenerateList(2))
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service, latestOnly: false);
+
+                var pagedResult = result.AssertRight();
+
+                Assert.Equal(
+                    releaseFiles.Select(rf => rf.FileId).Order().ToList(),
+                    pagedResult.Results.Select(vm => vm.FileId).Order().ToList()
+                );
+            }
+        }
+
+        [Fact]
+        public async Task AmendedRelease_ReturnsFilesOfLatestVersionOnly()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var dataSetFileId = Guid.NewGuid();
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersions(publication.Releases[0].Versions)
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).WithDataSetFileId(dataSetFileId).GenerateList(2))
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service, latestOnly: false);
+
+                var pagedResult = result.AssertRight();
+
+                var latestVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 1);
+                var viewModel = Assert.Single(pagedResult.Results);
+                Assert.Equal(latestVersion.Id, viewModel.Release.Id);
+            }
+        }
+
+        [Fact]
+        public async Task FileHasDataReplacementInProgress_Excluded()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFiles([
+                    _dataFixture.DefaultFile(FileType.Data),
+                    _dataFixture.DefaultFile(FileType.Data).WithReplacingId(Guid.NewGuid()),
+                ])
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await ListDataSetFiles(service);
+
+                var pagedResult = result.AssertRight();
+
+                var viewModel = Assert.Single(pagedResult.Results);
+                Assert.Equal(releaseFiles[0].FileId, viewModel.FileId);
+            }
+        }
+
+        [Fact]
+        public async Task Pagination_ReturnsRequestedPage()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).GenerateList(3))
+                .GenerateList();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var page1Result = await ListDataSetFiles(service, page: 1, pageSize: 2);
+                var page2Result = await ListDataSetFiles(service, page: 2, pageSize: 2);
+
+                var page1 = page1Result.AssertRight();
+                var page2 = page2Result.AssertRight();
+
+                Assert.Equal(3, page1.Paging.TotalResults);
+                Assert.Equal(2, page1.Paging.TotalPages);
+                Assert.Equal(2, page1.Results.Count);
+
+                Assert.Equal(2, page2.Paging.Page);
+                Assert.Single(page2.Results);
+            }
+        }
+
+        private static async Task<
+            Either<ActionResult, PaginatedListViewModel<DataSetFileSummaryViewModel>>
+        > ListDataSetFiles(
+            DataSetFileService service,
+            Guid? themeId = null,
+            Guid? publicationId = null,
+            Guid? releaseVersionId = null,
+            GeographicLevel? geographicLevel = null,
+            bool? latestOnly = null,
+            DataSetType? dataSetType = null,
+            string? searchTerm = null,
+            DataSetsListRequestSortBy? sort = null,
+            SortDirection? sortDirection = null,
+            int page = 1,
+            int pageSize = 10
+        )
+        {
+            return await service.ListDataSetFiles(
+                themeId: themeId,
+                publicationId: publicationId,
+                releaseVersionId: releaseVersionId,
+                geographicLevel: geographicLevel,
+                latestOnly: latestOnly,
+                dataSetType: dataSetType,
+                searchTerm: searchTerm,
+                sort: sort,
+                sortDirection: sortDirection,
+                page: page,
+                pageSize: pageSize
+            );
+        }
+    }
+
+    public class GetDataSetFileTests : DataSetFileServiceTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithPublicApiDataSetId(Guid.NewGuid())
+                .WithPublicApiDataSetVersion(major: 2, minor: 1)
+                .WithFile(
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                        .WithCsvOnlyGeographicLevels([GeographicLevel.Institution])
+                );
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync(
+                    """
+                    col_1,col_2
+                    1,2
+                    3,4
+                    """.ToStream()
+                );
+
+            var footnotes = new List<Footnote>
+            {
+                new() { Id = Guid.NewGuid(), Content = "Footnote 1" },
+                new() { Id = Guid.NewGuid(), Content = "Footnote 2" },
+            };
+
+            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
+            footnoteRepository
+                .Setup(s => s.GetFootnotes(releaseVersion.Id, releaseFile.File.SubjectId))
+                .ReturnsAsync(footnotes);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    footnoteRepository: footnoteRepository.Object
+                );
+
+                var result = await service.GetDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                var viewModel = result.AssertRight();
+
+                Assert.Equal(releaseFile.File.DataSetFileId, viewModel.Id);
+                Assert.Equal(releaseFile.Name, viewModel.Title);
+                Assert.Equal(releaseFile.Summary, viewModel.Summary);
+
+                Assert.Equal(releaseVersion.Id, viewModel.Release.Id);
+                Assert.Equal(releaseVersion.Release.Title, viewModel.Release.Title);
+                Assert.Equal(releaseVersion.Release.Slug, viewModel.Release.Slug);
+                Assert.Equal(releaseVersion.Type, viewModel.Release.Type);
+                Assert.True(viewModel.Release.IsLatestPublishedRelease);
+                Assert.False(viewModel.Release.IsSuperseded);
+                Assert.Equal(releaseVersion.PublishedDisplayDate, viewModel.Release.Published);
+                Assert.Equal(releaseFile.Published, viewModel.Release.LastUpdated);
+
+                Assert.Equal(publication.Id, viewModel.Release.Publication.Id);
+                Assert.Equal(publication.Title, viewModel.Release.Publication.Title);
+                Assert.Equal(publication.Slug, viewModel.Release.Publication.Slug);
+                Assert.Equal(publication.Theme.Title, viewModel.Release.Publication.ThemeTitle);
+
+                Assert.Equal(releaseFile.FileId, viewModel.File.Id);
+                Assert.Equal(releaseFile.File.Filename, viewModel.File.Name);
+                Assert.Equal(releaseFile.File.DisplaySize(), viewModel.File.Size);
+                Assert.Equal(releaseFile.File.SubjectId, viewModel.File.SubjectId);
+
+                var meta = releaseFile.File.DataSetFileMeta!;
+
+                Assert.Equal(meta.NumDataFileRows, viewModel.File.Meta.NumDataFileRows);
+                // Csv-only geographic levels should be excluded
+                Assert.Equal([GeographicLevel.Country.GetEnumLabel()], viewModel.File.Meta.GeographicLevels);
+                Assert.Equal(
+                    TimePeriodLabelFormatter.Format(
+                        meta.TimePeriodRange.Start.Period,
+                        meta.TimePeriodRange.Start.TimeIdentifier
+                    ),
+                    viewModel.File.Meta.TimePeriodRange.From
+                );
+                Assert.Equal(
+                    TimePeriodLabelFormatter.Format(
+                        meta.TimePeriodRange.End.Period,
+                        meta.TimePeriodRange.End.TimeIdentifier
+                    ),
+                    viewModel.File.Meta.TimePeriodRange.To
+                );
+                Assert.Equal(meta.Filters.Select(f => f.Label).ToList(), viewModel.File.Meta.Filters);
+                Assert.Equal(meta.Indicators.Select(i => i.Label).ToList(), viewModel.File.Meta.Indicators);
+
+                Assert.Equal(
+                    meta.Filters.Select(f => new LabelValue(f.Label, f.ColumnName))
+                        .Concat(meta.Indicators.Select(i => new LabelValue(i.Label, i.ColumnName)))
+                        .OrderBy(variable => variable.Value)
+                        .ToList(),
+                    viewModel.File.Variables
+                );
+
+                Assert.Equal(["col_1", "col_2"], viewModel.File.DataCsvPreview.Headers);
+                Assert.Equal(2, viewModel.File.DataCsvPreview.Rows.Count);
+                Assert.Equal(["1", "2"], viewModel.File.DataCsvPreview.Rows[0]);
+                Assert.Equal(["3", "4"], viewModel.File.DataCsvPreview.Rows[1]);
+
+                Assert.Equal(2, viewModel.Footnotes.Count);
+                Assert.Equal(footnotes[0].Id, viewModel.Footnotes[0].Id);
+                Assert.Equal(footnotes[0].Content, viewModel.Footnotes[0].Label);
+                Assert.Equal(footnotes[1].Id, viewModel.Footnotes[1].Id);
+                Assert.Equal(footnotes[1].Content, viewModel.Footnotes[1].Label);
+
+                Assert.NotNull(viewModel.Api);
+                Assert.Equal(releaseFile.PublicApiDataSetId, viewModel.Api.Id);
+                Assert.Equal("2.1", viewModel.Api.Version);
+            }
+        }
+
+        [Fact]
+        public async Task AmendedRelease_ReturnsFileOfLatestVersion()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var previousVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 0);
+            var latestVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 1);
+
+            var dataSetFileId = Guid.NewGuid();
+
+            var releaseFiles = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersions([previousVersion, latestVersion])
+                .WithFiles(_dataFixture.DefaultFile(FileType.Data).WithDataSetFileId(dataSetFileId).GenerateList(2))
+                .GenerateList();
+
+            var latestReleaseFile = releaseFiles.Single(rf => rf.ReleaseVersionId == latestVersion.Id);
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(latestVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == latestReleaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync("col_1\n1".ToStream());
+
+            var footnoteRepository = new Mock<IFootnoteRepository>(MockBehavior.Strict);
+            footnoteRepository
+                .Setup(s => s.GetFootnotes(latestVersion.Id, latestReleaseFile.File.SubjectId))
+                .ReturnsAsync([]);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    footnoteRepository: footnoteRepository.Object
+                );
+
+                var result = await service.GetDataSetFile(dataSetFileId, CancellationToken.None);
+
+                var viewModel = result.AssertRight();
+
+                Assert.Equal(latestVersion.Id, viewModel.Release.Id);
+                Assert.Equal(latestReleaseFile.FileId, viewModel.File.Id);
+            }
+        }
+
+        [Fact]
+        public async Task NoReleaseFile_ReturnsNotFound()
+        {
+            await using var contentDbContext = InMemoryContentDbContext();
+
+            var service = SetupService(contentDbContext);
+
+            var result = await service.GetDataSetFile(Guid.NewGuid(), CancellationToken.None);
+
+            result.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task ReleaseVersionNotPublished_ReturnsNotFound()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await service.GetDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseVersionPublishedInFuture_ReturnsNotFound()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ =>
+                    [
+                        _dataFixture
+                            .DefaultRelease()
+                            .WithVersions([
+                                _dataFixture.DefaultReleaseVersion().WithPublished(DateTimeOffset.UtcNow.AddDays(1)),
+                            ]),
+                    ]
+                )
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await service.GetDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseVersionNotLatestPublished_ReturnsNotFound()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var previousVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 0);
+
+            // The data set file only exists on the previous version, i.e. it was removed on amendment
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(previousVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(previousVersion.Id, CancellationToken.None))
+                .ReturnsAsync(false);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext, releaseVersionRepository: releaseVersionRepository.Object);
+
+                var result = await service.GetDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task BlobStreamUnavailable_ReturnsError()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync(new NotFoundResult());
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object
+                );
+
+                var result = await service.GetDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                result.AssertNotFound();
+            }
+        }
+    }
+
+    public class DownloadDataSetFileTests : DataSetFileServiceTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync("Test csv".ToStream());
+
+            IAnalyticsCaptureRequest? capturedRequest = null;
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager
+                .Setup(s => s.Add(It.IsAny<IAnalyticsCaptureRequest>(), CancellationToken.None))
+                .Callback((IAnalyticsCaptureRequest request, CancellationToken _) => capturedRequest = request)
+                .Returns(Task.CompletedTask);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    analyticsManager: analyticsManager.Object
+                );
+
+                var result = await service.DownloadDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                var fileStreamResult = Assert.IsType<FileStreamResult>(result);
+                Assert.Equal("text/csv", fileStreamResult.ContentType);
+                Assert.Equal(releaseFile.File.Filename, fileStreamResult.FileDownloadName);
+                Assert.Equal("Test csv", fileStreamResult.FileStream.ReadToEnd());
+
+                var captureRequest = Assert.IsType<CaptureCsvDownloadRequest>(capturedRequest);
+                Assert.Equal(publication.Title, captureRequest.PublicationName);
+                Assert.Equal(releaseVersion.Id, captureRequest.ReleaseVersionId);
+                Assert.Equal(releaseVersion.Release.Title, captureRequest.ReleaseName);
+                Assert.Equal(releaseVersion.Release.Label, captureRequest.ReleaseLabel);
+                Assert.Equal(releaseFile.File.SubjectId, captureRequest.SubjectId);
+                Assert.Equal(releaseFile.Name, captureRequest.DataSetTitle);
+            }
+        }
+
+        [Fact]
+        public async Task NoReleaseFile_ReturnsNotFound()
+        {
+            await using var contentDbContext = InMemoryContentDbContext();
+
+            var service = SetupService(contentDbContext);
+
+            var result = await service.DownloadDataSetFile(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task ReleaseVersionNotLatestPublished_ReturnsNotFound()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var previousVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 0);
+
+            // The data set file only exists on the previous version, i.e. it was removed on amendment
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(previousVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(previousVersion.Id, CancellationToken.None))
+                .ReturnsAsync(false);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext, releaseVersionRepository: releaseVersionRepository.Object);
+
+                var result = await service.DownloadDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                Assert.IsType<NotFoundResult>(result);
+            }
+        }
+
+        [Fact]
+        public async Task AnalyticsErrors_StillReturnsFile()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync("Test csv".ToStream());
+
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager
+                .Setup(s => s.Add(It.IsAny<IAnalyticsCaptureRequest>(), CancellationToken.None))
+                .ThrowsAsync(new Exception("Analytics error"));
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    analyticsManager: analyticsManager.Object
+                );
+
+                var result = await service.DownloadDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                var fileStreamResult = Assert.IsType<FileStreamResult>(result);
+                Assert.Equal("Test csv", fileStreamResult.FileStream.ReadToEnd());
+            }
+        }
+
+        [Fact]
+        public async Task FileHasNoSubjectId_SkipsAnalytics()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            File file = _dataFixture.DefaultFile(FileType.Data);
+            file.SubjectId = null;
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(file);
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync("Test csv".ToStream());
+
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    analyticsManager: analyticsManager.Object
+                );
+
+                var result = await service.DownloadDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                Assert.IsType<FileStreamResult>(result);
+                analyticsManager.VerifyNoOtherCalls();
+            }
+        }
+
+        [Fact]
+        public async Task BlobStreamUnavailable_ReturnsError()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ReleaseFile releaseFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+            releaseVersionRepository
+                .Setup(s => s.IsLatestPublishedReleaseVersion(releaseVersion.Id, CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var releaseFileBlobService = new Mock<IReleaseFileBlobService>(MockBehavior.Strict);
+            releaseFileBlobService
+                .Setup(s =>
+                    s.GetDownloadStream(It.Is<ReleaseFile>(rf => rf.Id == releaseFile.Id), CancellationToken.None)
+                )
+                .ReturnsAsync(new NotFoundResult());
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(
+                    contentDbContext,
+                    releaseVersionRepository: releaseVersionRepository.Object,
+                    releaseFileBlobService: releaseFileBlobService.Object,
+                    analyticsManager: new Mock<IAnalyticsManager>().Object
+                );
+
+                var result = await service.DownloadDataSetFile(
+                    releaseFile.File.DataSetFileId!.Value,
+                    CancellationToken.None
+                );
+
+                Assert.IsType<NotFoundResult>(result);
+            }
+        }
+    }
+
+    public class ListSitemapItemsTests : DataSetFileServiceTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)])
+                .WithTheme(_dataFixture.DefaultTheme());
+
+            var previousVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 0);
+            var latestVersion = publication.Releases[0].Versions.Single(rv => rv.Version == 1);
+
+            ReleaseFile previousVersionFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(previousVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            ReleaseFile latestVersionFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(latestVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data));
+
+            ReleaseFile ancillaryFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(latestVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Ancillary));
+
+            ReleaseFile replacementInProgressFile = _dataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(latestVersion)
+                .WithFile(_dataFixture.DefaultFile(FileType.Data).WithReplacingId(Guid.NewGuid()));
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.AddRange(
+                    previousVersionFile,
+                    latestVersionFile,
+                    ancillaryFile,
+                    replacementInProgressFile
+                );
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupService(contentDbContext);
+
+                var result = await service.ListSitemapItems();
+
+                var sitemapItems = result.AssertRight();
+
+                var sitemapItem = Assert.Single(sitemapItems); // only on latest version with FileType.Data
+                Assert.Equal(latestVersionFile.File.DataSetFileId!.Value.ToString(), sitemapItem.Id);
+                Assert.Equal(latestVersionFile.Published, sitemapItem.LastModified);
+            }
+        }
+    }
+
+    private static DataSetFileService SetupService(
+        ContentDbContext contentDbContext,
+        IReleaseVersionRepository? releaseVersionRepository = null,
+        IReleaseFileBlobService? releaseFileBlobService = null,
+        IFootnoteRepository? footnoteRepository = null,
+        IAnalyticsManager? analyticsManager = null,
+        ILogger<DataSetFileService>? logger = null
+    )
+    {
+        return new DataSetFileService(
+            contentDbContext,
+            releaseVersionRepository ?? Mock.Of<IReleaseVersionRepository>(MockBehavior.Strict),
+            releaseFileBlobService ?? Mock.Of<IReleaseFileBlobService>(MockBehavior.Strict),
+            footnoteRepository ?? Mock.Of<IFootnoteRepository>(MockBehavior.Strict),
+            analyticsManager ?? Mock.Of<IAnalyticsManager>(),
+            logger ?? Mock.Of<ILogger<DataSetFileService>>()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -462,6 +462,51 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
+        public async Task WhenDataSetHasCsvOnlyGeographicLevels_ExcludesThemFromGeographicLevels()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(
+                    _dataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country])
+                        .WithCsvOnlyGeographicLevels([GeographicLevel.School])
+                )
+                .WithReleaseVersion(releaseVersion);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug
+                );
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.Equal(["National"], result.DataSets[0].Meta.GeographicLevels);
+            }
+        }
+
+        [Fact]
         public async Task WhenDataSetHasNoSummary_ReturnsEmptySummary()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -94,7 +94,8 @@ public class DataSetFileService(
             .ToDictionaryAsync(
                 file => file.Id,
                 file =>
-                    file.DataSetFileVersionGeographicLevels.Select(gl => gl.GeographicLevel.GetEnumLabel())
+                    file.DataSetFileVersionGeographicLevels.Where(gl => gl.CsvOnly != true)
+                        .Select(gl => gl.GeographicLevel.GetEnumLabel())
                         .Order()
                         .ToList(),
                 cancellationToken: cancellationToken
@@ -339,6 +340,7 @@ public class DataSetFileService(
         {
             NumDataFileRows = meta.NumDataFileRows,
             GeographicLevels = dataSetFileVersionGeographicLevels
+                .Where(gl => gl.CsvOnly != true)
                 .Select(gl => gl.GeographicLevel.GetEnumLabel())
                 .ToList(),
             TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
@@ -582,7 +584,9 @@ internal static class ReleaseFileQueryableExtensions
     {
         return geographicLevel.HasValue
             ? query.Where(rf =>
-                rf.File.DataSetFileVersionGeographicLevels.Any(gl => gl.GeographicLevel == geographicLevel)
+                rf.File.DataSetFileVersionGeographicLevels.Any(gl =>
+                    gl.GeographicLevel == geographicLevel && gl.CsvOnly != true
+                )
             )
             : query;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -88,7 +88,13 @@ public record ReleaseDataContentDataSetMetaDto
 
     private static string[] GetOrderedGeographicLevels(
         IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels
-    ) => [.. dataSetFileVersionGeographicLevels.Select(level => level.GeographicLevel.GetEnumLabel()).Order()];
+    ) =>
+        [
+            .. dataSetFileVersionGeographicLevels
+                .Where(level => level.CsvOnly != true)
+                .Select(level => level.GeographicLevel.GetEnumLabel())
+                .Order(),
+        ];
 
     private static string[] GetOrderedFilters(
         IEnumerable<FilterMeta> filters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -122,6 +122,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(16)
             .WithExpectedImportedRows(16)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
@@ -301,10 +302,9 @@ public class ProcessorStage3Tests
                 .Single(f => f.Type == FileType.Data && f.SubjectId == import.File.SubjectId);
 
             Assert.NotNull(file.DataSetFileVersionGeographicLevels);
-            var geographicLevel = Assert.Single(
-                file.DataSetFileVersionGeographicLevels.Select(gl => gl.GeographicLevel).ToList()
-            );
-            Assert.Equal(GeographicLevel.LocalAuthority, geographicLevel);
+            var geographicLevel = Assert.Single(file.DataSetFileVersionGeographicLevels);
+            Assert.Equal(GeographicLevel.LocalAuthority, geographicLevel.GeographicLevel);
+            Assert.False(geographicLevel.CsvOnly);
 
             Assert.NotNull(file.DataSetFileMeta);
 
@@ -334,6 +334,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(16)
             .WithExpectedImportedRows(16)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         var unexpectedImportedObservation = _fixture.DefaultObservation().WithSubject(_subject).Generate();
@@ -467,6 +468,7 @@ public class ProcessorStage3Tests
             .WithExpectedImportedRows(16)
             .WithImportedRows(4)
             .WithLastProcessedRowIndex(3)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         var alreadyImportedObservations = _fixture.DefaultObservation().WithSubject(_subject).Generate(4);
@@ -616,6 +618,7 @@ public class ProcessorStage3Tests
             .WithExpectedImportedRows(16)
             .WithImportedRows(10)
             .WithLastProcessedRowIndex(9)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         var alreadyImportedObservations = _fixture.DefaultObservation().WithSubject(_subject).Generate(10);
@@ -758,6 +761,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(16)
             .WithExpectedImportedRows(8)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority, GeographicLevel.School])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
@@ -888,6 +892,15 @@ public class ProcessorStage3Tests
             // of 2.  However, only alternate rows are being imported in this scenario,
             // meaning that we expect to see the CsvRows 2, 4, 6, 8 etc up to 18.
             Enumerable.Range(0, 8).ForEach(i => Assert.Equal((i * 2) + 2, observations[i].CsvRow));
+
+            // Verify that the ignored School level is still recorded against the file, flagged as CSV only.
+            var file = contentDbContext
+                .Files.Include(f => f.DataSetFileVersionGeographicLevels)
+                .Single(f => f.Type == FileType.Data && f.SubjectId == import.File.SubjectId);
+
+            file.DataSetFileVersionGeographicLevels.Select(gl => (gl.GeographicLevel, gl.CsvOnly))
+                .ToList()
+                .AssertDeepEqualTo([(GeographicLevel.LocalAuthority, false), (GeographicLevel.School, true)]);
         }
     }
 
@@ -906,6 +919,7 @@ public class ProcessorStage3Tests
             .WithExpectedImportedRows(8)
             .WithImportedRows(4)
             .WithLastProcessedRowIndex(6)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority, GeographicLevel.School])
             .Generate();
 
         // Generate already-imported Observations with alternating CsvRow numbers
@@ -1058,6 +1072,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(16)
             .WithExpectedImportedRows(16)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
@@ -1196,6 +1211,7 @@ public class ProcessorStage3Tests
             .WithStatus(CANCELLED)
             .WithTotalRows(16)
             .WithExpectedImportedRows(16)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
@@ -1326,6 +1342,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(16)
             .WithExpectedImportedRows(16)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))
@@ -1500,6 +1517,7 @@ public class ProcessorStage3Tests
             .WithStatus(STAGE_3)
             .WithTotalRows(5)
             .WithExpectedImportedRows(5)
+            .WithGeographicLevels([GeographicLevel.LocalAuthority])
             .Generate();
 
         await using (var contentDbContext = InMemoryContentDbContext(_contentDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -286,15 +286,15 @@ public class DataImportServiceTests
                 .Files.Include(f => f.DataSetFileVersionGeographicLevels)
                 .Single(f => f.SubjectId == subject.Id);
 
-            var geogLvls = updatedFile.DataSetFileVersionGeographicLevels.ToDictionary(
+            var geogLvlToCsvOnlyMap = updatedFile.DataSetFileVersionGeographicLevels.ToDictionary(
                 gl => gl.GeographicLevel,
                 gl => gl.CsvOnly
             );
-            Assert.Equal(4, geogLvls.Count);
-            Assert.False(geogLvls[GeographicLevel.Country]);
-            Assert.False(geogLvls[GeographicLevel.LocalAuthority]);
-            Assert.False(geogLvls[GeographicLevel.Region]);
-            Assert.True(geogLvls[GeographicLevel.School]);
+            Assert.Equal(4, geogLvlToCsvOnlyMap.Count);
+            Assert.False(geogLvlToCsvOnlyMap[GeographicLevel.Country]);
+            Assert.False(geogLvlToCsvOnlyMap[GeographicLevel.LocalAuthority]);
+            Assert.False(geogLvlToCsvOnlyMap[GeographicLevel.Region]);
+            Assert.True(geogLvlToCsvOnlyMap[GeographicLevel.School]);
 
             Assert.NotNull(updatedFile.DataSetFileMeta);
             var meta = updatedFile.DataSetFileMeta;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -267,7 +267,18 @@ public class DataImportServiceTests
 
         var service = BuildDataImportService(contentDbContextId, statisticsDbContextId);
 
-        await service.WriteDataSetFileMeta(file.Id, subject.Id, totalRows);
+        await service.WriteDataSetFileMeta(
+            file.Id,
+            subject.Id,
+            totalRows,
+            csvGeographicLevels:
+            [
+                GeographicLevel.Country,
+                GeographicLevel.LocalAuthority,
+                GeographicLevel.Region,
+                GeographicLevel.School,
+            ]
+        );
 
         await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
         {
@@ -275,11 +286,15 @@ public class DataImportServiceTests
                 .Files.Include(f => f.DataSetFileVersionGeographicLevels)
                 .Single(f => f.SubjectId == subject.Id);
 
-            var geogLvls = updatedFile.DataSetFileVersionGeographicLevels.Select(gl => gl.GeographicLevel).ToList();
-            Assert.Equal(3, geogLvls.Count);
-            Assert.Contains(GeographicLevel.Country, geogLvls);
-            Assert.Contains(GeographicLevel.LocalAuthority, geogLvls);
-            Assert.Contains(GeographicLevel.Region, geogLvls);
+            var geogLvls = updatedFile.DataSetFileVersionGeographicLevels.ToDictionary(
+                gl => gl.GeographicLevel,
+                gl => gl.CsvOnly
+            );
+            Assert.Equal(4, geogLvls.Count);
+            Assert.False(geogLvls[GeographicLevel.Country]);
+            Assert.False(geogLvls[GeographicLevel.LocalAuthority]);
+            Assert.False(geogLvls[GeographicLevel.Region]);
+            Assert.True(geogLvls[GeographicLevel.School]);
 
             Assert.NotNull(updatedFile.DataSetFileMeta);
             var meta = updatedFile.DataSetFileMeta;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -267,18 +267,21 @@ public class DataImportServiceTests
 
         var service = BuildDataImportService(contentDbContextId, statisticsDbContextId);
 
-        await service.WriteDataSetFileMeta(
-            file.Id,
-            subject.Id,
-            totalRows,
-            csvGeographicLevels:
+        var import = new DataImport
+        {
+            FileId = file.Id,
+            SubjectId = subject.Id,
+            TotalRows = totalRows,
+            GeographicLevels =
             [
                 GeographicLevel.Country,
                 GeographicLevel.LocalAuthority,
                 GeographicLevel.Region,
                 GeographicLevel.School,
-            ]
-        );
+            ],
+        };
+
+        await service.WriteDataSetFileMeta(import);
 
         await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -49,16 +49,7 @@ public class FileImportServiceTests
 
         var dataImportService = new Mock<IDataImportService>(Strict);
         dataImportService.Setup(s => s.UpdateStatus(import.Id, COMPLETE, 100)).Returns(Task.CompletedTask);
-        dataImportService
-            .Setup(s =>
-                s.WriteDataSetFileMeta(
-                    import.FileId,
-                    import.SubjectId,
-                    import.TotalRows!.Value,
-                    import.GeographicLevels
-                )
-            )
-            .Returns(Task.CompletedTask);
+        dataImportService.Setup(s => s.WriteDataSetFileMeta(import)).Returns(Task.CompletedTask);
 
         var dataSetMappingService = new Mock<IDataSetMappingService>(Strict);
         dataSetMappingService
@@ -129,57 +120,6 @@ public class FileImportServiceTests
         }
 
         VerifyAllMocks(dataImportService);
-    }
-
-    [Fact]
-    public async Task CompleteImport_NoGeographicLevels()
-    {
-        var file = new File { Id = Guid.NewGuid(), Filename = "my_data_file.csv" };
-
-        var import = new DataImport
-        {
-            Id = Guid.NewGuid(),
-            Errors = new List<DataImportError>(),
-            FileId = file.Id,
-            File = file,
-            SubjectId = Guid.NewGuid(),
-            Status = STAGE_3,
-            ExpectedImportedRows = 2,
-            TotalRows = 65,
-            GeographicLevels = null,
-        };
-
-        var dataImportService = new Mock<IDataImportService>(Strict);
-        dataImportService.Setup(s => s.FailImport(import.Id, It.IsAny<string[]>())).Returns(Task.CompletedTask);
-
-        var dataSetMappingService = new Mock<IDataSetMappingService>(Strict);
-        dataSetMappingService
-            .Setup(s => s.CreateInitialDataSetMappingIfReplacement(import.FileId))
-            .Returns(Task.CompletedTask);
-
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            await statisticsDbContext.Observation.AddRangeAsync(
-                new Observation { SubjectId = import.SubjectId },
-                new Observation { SubjectId = import.SubjectId }
-            );
-
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = BuildFileImportService(
-                dataImportService: dataImportService.Object,
-                dataSetMappingService: dataSetMappingService.Object
-            );
-
-            await Assert.ThrowsAsync<Exception>(() => service.CompleteImport(import, statisticsDbContext));
-        }
-
-        VerifyAllMocks(dataImportService, dataSetMappingService);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -43,12 +44,20 @@ public class FileImportServiceTests
             Status = STAGE_3,
             ExpectedImportedRows = 2,
             TotalRows = 65,
+            GeographicLevels = [GeographicLevel.Country, GeographicLevel.School],
         };
 
         var dataImportService = new Mock<IDataImportService>(Strict);
         dataImportService.Setup(s => s.UpdateStatus(import.Id, COMPLETE, 100)).Returns(Task.CompletedTask);
         dataImportService
-            .Setup(s => s.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value))
+            .Setup(s =>
+                s.WriteDataSetFileMeta(
+                    import.FileId,
+                    import.SubjectId,
+                    import.TotalRows!.Value,
+                    import.GeographicLevels
+                )
+            )
             .Returns(Task.CompletedTask);
 
         var dataSetMappingService = new Mock<IDataSetMappingService>(Strict);
@@ -120,6 +129,57 @@ public class FileImportServiceTests
         }
 
         VerifyAllMocks(dataImportService);
+    }
+
+    [Fact]
+    public async Task CompleteImport_NoGeographicLevels()
+    {
+        var file = new File { Id = Guid.NewGuid(), Filename = "my_data_file.csv" };
+
+        var import = new DataImport
+        {
+            Id = Guid.NewGuid(),
+            Errors = new List<DataImportError>(),
+            FileId = file.Id,
+            File = file,
+            SubjectId = Guid.NewGuid(),
+            Status = STAGE_3,
+            ExpectedImportedRows = 2,
+            TotalRows = 65,
+            GeographicLevels = null,
+        };
+
+        var dataImportService = new Mock<IDataImportService>(Strict);
+        dataImportService.Setup(s => s.FailImport(import.Id, It.IsAny<string[]>())).Returns(Task.CompletedTask);
+
+        var dataSetMappingService = new Mock<IDataSetMappingService>(Strict);
+        dataSetMappingService
+            .Setup(s => s.CreateInitialDataSetMappingIfReplacement(import.FileId))
+            .Returns(Task.CompletedTask);
+
+        var statisticsDbContextId = Guid.NewGuid().ToString();
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            await statisticsDbContext.Observation.AddRangeAsync(
+                new Observation { SubjectId = import.SubjectId },
+                new Observation { SubjectId = import.SubjectId }
+            );
+
+            await statisticsDbContext.SaveChangesAsync();
+        }
+
+        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+        {
+            var service = BuildFileImportService(
+                dataImportService: dataImportService.Object,
+                dataSetMappingService: dataSetMappingService.Object
+            );
+
+            await Assert.ThrowsAsync<Exception>(() => service.CompleteImport(import, statisticsDbContext));
+        }
+
+        VerifyAllMocks(dataImportService, dataSetMappingService);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -128,18 +128,19 @@ public class DataImportService(IDbContextSupplier dbContextSupplier, ILogger<Dat
         await context.SaveChangesAsync();
     }
 
-    public async Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int numDataFileRows)
+    public async Task WriteDataSetFileMeta(
+        Guid fileId,
+        Guid subjectId,
+        int numDataFileRows,
+        HashSet<GeographicLevel> csvGeographicLevels
+    )
     {
         await using var contentDbContext = dbContextSupplier.CreateDbContext<ContentDbContext>();
         await using var statisticsDbContext = dbContextSupplier.CreateDbContext<StatisticsDbContext>();
 
         var observations = statisticsDbContext.Observation.AsNoTracking().Where(o => o.SubjectId == subjectId);
 
-        var geographicLevels = observations
-            .Select(o => o.Location.GeographicLevel)
-            .Distinct()
-            .OrderBy(gl => gl)
-            .ToList();
+        var importedGeographicLevels = observations.Select(o => o.Location.GeographicLevel).Distinct().ToList();
 
         var timePeriods = observations
             .Select(o => new { o.Year, o.TimeIdentifier })
@@ -191,8 +192,14 @@ public class DataImportService(IDbContextSupplier dbContextSupplier, ILogger<Dat
         var file = contentDbContext.Files.Single(f => f.Type == FileType.Data && f.SubjectId == subjectId);
         file.DataSetFileMeta = dataSetFileMeta;
 
-        var dataSetFileVersionGeographicLevels = geographicLevels
-            .Select(gl => new DataSetFileVersionGeographicLevel { DataSetFileVersionId = fileId, GeographicLevel = gl })
+        var dataSetFileVersionGeographicLevels = csvGeographicLevels
+            .OrderBy(gl => gl)
+            .Select(gl => new DataSetFileVersionGeographicLevel
+            {
+                DataSetFileVersionId = fileId,
+                GeographicLevel = gl,
+                CsvOnly = !importedGeographicLevels.Contains(gl),
+            })
             .ToList();
         contentDbContext.DataSetFileVersionGeographicLevels.AddRange(dataSetFileVersionGeographicLevels);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -128,13 +128,10 @@ public class DataImportService(IDbContextSupplier dbContextSupplier, ILogger<Dat
         await context.SaveChangesAsync();
     }
 
-    public async Task WriteDataSetFileMeta(
-        Guid fileId,
-        Guid subjectId,
-        int numDataFileRows,
-        HashSet<GeographicLevel> csvGeographicLevels
-    )
+    public async Task WriteDataSetFileMeta(DataImport import)
     {
+        var subjectId = import.SubjectId;
+
         await using var contentDbContext = dbContextSupplier.CreateDbContext<ContentDbContext>();
         await using var statisticsDbContext = dbContextSupplier.CreateDbContext<StatisticsDbContext>();
 
@@ -183,7 +180,7 @@ public class DataImportService(IDbContextSupplier dbContextSupplier, ILogger<Dat
 
         var dataSetFileMeta = new DataSetFileMeta
         {
-            NumDataFileRows = numDataFileRows,
+            NumDataFileRows = import.TotalRows!.Value,
             TimePeriodRange = new TimePeriodRangeMeta { Start = timePeriods.First(), End = timePeriods.Last() },
             Filters = filters,
             Indicators = indicators,
@@ -192,11 +189,12 @@ public class DataImportService(IDbContextSupplier dbContextSupplier, ILogger<Dat
         var file = contentDbContext.Files.Single(f => f.Type == FileType.Data && f.SubjectId == subjectId);
         file.DataSetFileMeta = dataSetFileMeta;
 
+        var csvGeographicLevels = import.GeographicLevels!;
         var dataSetFileVersionGeographicLevels = csvGeographicLevels
             .OrderBy(gl => gl)
             .Select(gl => new DataSetFileVersionGeographicLevel
             {
-                DataSetFileVersionId = fileId,
+                DataSetFileVersionId = import.FileId,
                 GeographicLevel = gl,
                 CsvOnly = !importedGeographicLevels.Contains(gl),
             })

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataSetMappingService.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using AngleSharp.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -123,12 +123,7 @@ public class FileImportService(
         try
         {
             await dataSetMappingService.CreateInitialDataSetMappingIfReplacement(import.FileId);
-            await dataImportService.WriteDataSetFileMeta(
-                import.FileId,
-                import.SubjectId,
-                import.TotalRows!.Value,
-                import.GeographicLevels ?? throw new ArgumentException("Import must have GeographicLevels")
-            );
+            await dataImportService.WriteDataSetFileMeta(import);
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -123,7 +123,12 @@ public class FileImportService(
         try
         {
             await dataSetMappingService.CreateInitialDataSetMappingIfReplacement(import.FileId);
-            await dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
+            await dataImportService.WriteDataSetFileMeta(
+                import.FileId,
+                import.SubjectId,
+                import.TotalRows!.Value,
+                import.GeographicLevels ?? throw new ArgumentException("Import must have GeographicLevels")
+            );
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -25,10 +25,5 @@ public interface IDataImportService
         int? lastProcessedRowIndex = null
     );
 
-    Task WriteDataSetFileMeta(
-        Guid fileId,
-        Guid subjectId,
-        int numDataFileRows,
-        HashSet<GeographicLevel> csvGeographicLevels
-    );
+    Task WriteDataSetFileMeta(DataImport import);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -25,5 +25,10 @@ public interface IDataImportService
         int? lastProcessedRowIndex = null
     );
 
-    Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int numDataFileRows);
+    Task WriteDataSetFileMeta(
+        Guid fileId,
+        Guid subjectId,
+        int numDataFileRows,
+        HashSet<GeographicLevel> csvGeographicLevels
+    );
 }


### PR DESCRIPTION
This PR adds DataSetFileVersionGeographicLevel.CsvOnly so that we record every geographic level found in a data set's CSV, not just the ones that made it into the statistics DB.

Until now, DataSetFileVersionGeographicLevels was populated from the imported observations, so any geographic level that was in the CSV but dropped during import was never recorded at all. CSV are not imported to the stats DB when solo-importable levels (Institution, PlanningArea, Provider, School) are imported alongside other geographic levels e.g. a file of country, region and school rows imports as country and region only, and we lose the fact the CSV ever had school data in it. Since users can download the CSV, that information is worth having.

All preexisting geographic levels are by default set to null (minus those set the migrationn sql file). We've done this to avoid addinng an additional "isMigrated" type column to track what has and hasn't been migrated. By having CsvOnly be null, the addtional `where CsvOnly != true` check still returns data sets where their geog lvls are still null. So the current behaviour of the site doesn't change even though we may still not have set CsvOnly for all preexisting data sets.

Migration may take a while as in many cases we have no way of checking whether a data set has extra CsvOnly geog lvls without checking the source data csv blob file.

After migrating all data sets, any left over geog lvls where CsvOnly == null will need to be manually investigated and fixed.

:rotating_light: After this is deployed, the BAU endpoint needs running until Remaining is 0. EES-7584 then removes the endpoint and makes CsvOnly non-nullable. :rotating_light:

This PR doesn't expose CsvOnly to the frontend - that will be done in conjunction with the frontend work.