### PR TITLE
EES-6683 Upgrade notifications storage account to StorageV2

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2704,7 +2704,7 @@
       "name": "[variables('notificationsStorageAccountName')]",
       "apiVersion": "2023-05-01",
       "location": "[resourceGroup().location]",
-      "kind": "Storage",
+      "kind": "StorageV2",
       "sku": {
         "name": "Standard_LRS"
       },


### PR DESCRIPTION
This PR upgrade notification azure storage accounts to v2. If we don't do this before October, Azure will do it for us.