### PR TITLE
EES-7531 Configure Hive Slack channel to receive metric alerts

### DIFF
--- a/infrastructure/templates/core/application/alerts/README.md
+++ b/infrastructure/templates/core/application/alerts/README.md
@@ -17,6 +17,20 @@ The [Logic App](alerts-logic-app.bicep) receives JSON payloads from metric alert
 information using a series of `Compose` actions, and then 2 HTTP actions, one for Teams and one for
 Slack, take those variables and construct POSTs in the correct format for their target platforms.
 
+The Slack action runs inside a `Foreach` over every channel in `slackAlertsChannels` and
+`hiveSlackAlertsChannels`. The two parameters exist because the channels live in different Slack
+workspaces, and each workspace needs its own app token - channels listed in `hiveSlackAlertsChannels`
+are posted with the token from the `ees-alerts-hiveslackapptoken` Key Vault secret, and all others
+with the token from `ees-alerts-slackapptoken`. Both Slack apps need the `chat:write` scope and must
+be invited to their channels, otherwise `chat.postMessage` returns HTTP 200 with `"ok": false` and
+the alert is dropped without the Logic App run failing.
+
+`hiveSlackAlertsChannels` is only populated in production; the other environments inherit the empty
+default in [main.bicep](../../main.bicep) and never post to Hive. The
+`ees-alerts-hiveslackapptoken` secret still has to exist in every environment's Key Vault, because
+Bicep resolves it at deployment time regardless of whether any channel uses it - a placeholder value
+is fine outside production.
+
 The [Logic App definition](alerts-logic-app-definition.json) defines the workflow.
 
 ## Action Group

--- a/infrastructure/templates/core/application/alerts/README.md
+++ b/infrastructure/templates/core/application/alerts/README.md
@@ -18,18 +18,19 @@ information using a series of `Compose` actions, and then 2 HTTP actions, one fo
 Slack, take those variables and construct POSTs in the correct format for their target platforms.
 
 The Slack action runs inside a `Foreach` over every channel in `slackAlertsChannels` and
-`hiveSlackAlertsChannels`. The two parameters exist because the channels live in different Slack
-workspaces, and each workspace needs its own app token - channels listed in `hiveSlackAlertsChannels`
-are posted with the token from the `ees-alerts-hiveslackapptoken` Key Vault secret, and all others
-with the token from `ees-alerts-slackapptoken`. Both Slack apps need the `chat:write` scope and must
-be invited to their channels, otherwise `chat.postMessage` returns HTTP 200 with `"ok": false` and
-the alert is dropped without the Logic App run failing.
+`secondarySlackAlertsChannels`. Two parameters exist so that alerts can be posted to channels in two
+different Slack workspaces, each of which needs its own app token - channels listed in
+`secondarySlackAlertsChannels` are posted with the token from the `ees-alerts-secondaryslackapptoken`
+Key Vault secret, and all others with the token from `ees-alerts-slackapptoken`. Both Slack apps need
+the `chat:write` scope and must be invited to their channels, otherwise `chat.postMessage` returns
+HTTP 200 with `"ok": false` and the alert is dropped without the Logic App run failing.
 
-`hiveSlackAlertsChannels` is only populated in production; the other environments inherit the empty
-default in [main.bicep](../../main.bicep) and never post to Hive. The
-`ees-alerts-hiveslackapptoken` secret still has to exist in every environment's Key Vault, because
-Bicep resolves it at deployment time regardless of whether any channel uses it - a placeholder value
-is fine outside production.
+`secondarySlackAlertsChannels` is only populated in production, where alerts are mirrored to our
+support partner's workspace; the other environments inherit the empty default in
+[main.bicep](../../main.bicep) and post to a single workspace. The
+`ees-alerts-secondaryslackapptoken` secret still has to exist in every environment's Key Vault,
+because Bicep resolves it at deployment time regardless of whether any channel uses it - a
+placeholder value is fine outside production.
 
 The [Logic App definition](alerts-logic-app-definition.json) defines the workflow.
 

--- a/infrastructure/templates/core/application/alerts/alerts-logic-app-definition.json
+++ b/infrastructure/templates/core/application/alerts/alerts-logic-app-definition.json
@@ -12,10 +12,16 @@
     "resourceGroup": {
       "type": "string"
     },
-    "slackAlertsChannel": {
-      "type": "string"
+    "slackAlertsChannels": {
+      "type": "Array"
+    },
+    "hiveSlackAlertsChannels": {
+      "type": "Array"
     },
     "slackAppToken": {
+      "type": "securestring"
+    },
+    "hiveSlackAppToken": {
       "type": "securestring"
     },
     "teamsPowerAutomateWebhookUrl": {
@@ -177,60 +183,67 @@
         "alertLinkTeams": "@{if(equals(outputs('variables')?['monitorCondition'], 'Resolved'), '', concat(triggerBody()?['data']?['essentials']?['description'], '\n'))}\n@{if(equals(outputs('variables')?['monitorCondition'], 'Resolved'), outputs('fragments')?['withinThresholdMessage'], outputs('fragments')?['outsideThresholdMessage'])}\n[Link to alert](@{outputs('fragments')?['alertRuleUrl']})\n[Link to resource](@{outputs('fragments')?['alertTargetResourceUrl']})"
       }
     },
-    "Post message to Slack": {
+    "Post messages to Slack": {
       "runAfter": {
         "fields": [
           "Succeeded"
         ]
       },
-      "type": "Http",
-      "inputs": {
-        "method": "POST",
-        "uri": "https://slack.com/api/chat.postMessage",
-        "body": {
-          "channel": "@parameters('slackAlertsChannel')",
-          "text": "@outputs('fields')?['titleSlack']",
-          "attachments": [
-            {
-              "color": "@outputs('fields')?['colourSlack']",
-              "fields": [
+      "type": "Foreach",
+      "description": "Post the alert to every configured Slack channel. Channels listed in hiveSlackAlertsChannels belong to the Hive workspace and are posted with the Hive app token; all others use the DfE app token.",
+      "foreach": "@union(parameters('slackAlertsChannels'), parameters('hiveSlackAlertsChannels'))",
+      "actions": {
+        "Post message to Slack": {
+          "type": "Http",
+          "inputs": {
+            "method": "POST",
+            "uri": "https://slack.com/api/chat.postMessage",
+            "body": {
+              "channel": "@items('Post messages to Slack')",
+              "text": "@outputs('fields')?['titleSlack']",
+              "attachments": [
                 {
-                  "title": "Alert",
-                  "value": "@outputs('variables')?['alertName']",
-                  "short": true
-                },
-                {
-                  "title": "Severity",
-                  "value": "@outputs('fields')?['severity']",
-                  "short": true
-                },
-                {
-                  "title": "@{outputs('variables')?['monitorCondition']} at",
-                  "value": "@outputs('fields')?['alertTime']",
-                  "short": false
-                },
-                {
-                  "title": "Window start",
-                  "value": "@outputs('fields')?['windowStart']",
-                  "short": true
-                },
-                {
-                  "title": "Window end",
-                  "value": "@outputs('fields')?['windowEnd']",
-                  "short": true
-                },
-                {
-                  "title": "Logic App workflow version",
-                  "value": "1.0",
-                  "short": true
+                  "color": "@outputs('fields')?['colourSlack']",
+                  "fields": [
+                    {
+                      "title": "Alert",
+                      "value": "@outputs('variables')?['alertName']",
+                      "short": true
+                    },
+                    {
+                      "title": "Severity",
+                      "value": "@outputs('fields')?['severity']",
+                      "short": true
+                    },
+                    {
+                      "title": "@{outputs('variables')?['monitorCondition']} at",
+                      "value": "@outputs('fields')?['alertTime']",
+                      "short": false
+                    },
+                    {
+                      "title": "Window start",
+                      "value": "@outputs('fields')?['windowStart']",
+                      "short": true
+                    },
+                    {
+                      "title": "Window end",
+                      "value": "@outputs('fields')?['windowEnd']",
+                      "short": true
+                    },
+                    {
+                      "title": "Logic App workflow version",
+                      "value": "1.0",
+                      "short": true
+                    }
+                  ]
                 }
               ]
+            },
+            "headers": {
+              "Content-Type": "application/json",
+              "Authorization": "@{concat('Bearer ', if(contains(parameters('hiveSlackAlertsChannels'), items('Post messages to Slack')), parameters('hiveSlackAppToken'), parameters('slackAppToken')))}"
             }
-          ]
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "Authorization": "@{concat('Bearer ', parameters('slackAppToken'))}"
+          }
         }
       }
     },

--- a/infrastructure/templates/core/application/alerts/alerts-logic-app-definition.json
+++ b/infrastructure/templates/core/application/alerts/alerts-logic-app-definition.json
@@ -15,13 +15,13 @@
     "slackAlertsChannels": {
       "type": "Array"
     },
-    "hiveSlackAlertsChannels": {
+    "secondarySlackAlertsChannels": {
       "type": "Array"
     },
     "slackAppToken": {
       "type": "securestring"
     },
-    "hiveSlackAppToken": {
+    "secondarySlackAppToken": {
       "type": "securestring"
     },
     "teamsPowerAutomateWebhookUrl": {
@@ -190,8 +190,8 @@
         ]
       },
       "type": "Foreach",
-      "description": "Post the alert to every configured Slack channel. Channels listed in hiveSlackAlertsChannels belong to the Hive workspace and are posted with the Hive app token; all others use the DfE app token.",
-      "foreach": "@union(parameters('slackAlertsChannels'), parameters('hiveSlackAlertsChannels'))",
+      "description": "Post the alert to every configured Slack channel. Channels listed in secondarySlackAlertsChannels are posted with secondarySlackAppToken; all others use slackAppToken.",
+      "foreach": "@union(parameters('slackAlertsChannels'), parameters('secondarySlackAlertsChannels'))",
       "actions": {
         "Post message to Slack": {
           "type": "Http",
@@ -241,7 +241,7 @@
             },
             "headers": {
               "Content-Type": "application/json",
-              "Authorization": "@{concat('Bearer ', if(contains(parameters('hiveSlackAlertsChannels'), items('Post messages to Slack')), parameters('hiveSlackAppToken'), parameters('slackAppToken')))}"
+              "Authorization": "@{concat('Bearer ', if(contains(parameters('secondarySlackAlertsChannels'), items('Post messages to Slack')), parameters('secondarySlackAppToken'), parameters('slackAppToken')))}"
             }
           }
         }

--- a/infrastructure/templates/core/application/alerts/alerts-logic-app.bicep
+++ b/infrastructure/templates/core/application/alerts/alerts-logic-app.bicep
@@ -6,12 +6,19 @@ param subscription string
 @description('Resource Id of the Log Analytics Workspace to link the logic app to.')
 param logAnalyticsWorkspaceId string
 
-@description('Slack channel to post Azure alerts to.')
-param slackAlertsChannel string
+@description('Slack channels in the DfE workspace to post Azure alerts to.')
+param slackAlertsChannels array
+
+@description('Slack channels in the Hive workspace to post Azure alerts to.')
+param hiveSlackAlertsChannels array
 
 @secure()
-@description('Token to securely post to the Slack channel.')
+@description('Token to securely post to the DfE workspace Slack channels.')
 param slackAppToken string
+
+@secure()
+@description('Token to securely post to the Hive workspace Slack channels.')
+param hiveSlackAppToken string
 
 @secure()
 @description('The Power Automate Webhook URL used to post messages to Teams.')
@@ -33,13 +40,21 @@ resource alertsLogicApp 'Microsoft.Logic/workflows@2019-05-01' = {
         type: 'string'
         value: resourceGroup().name
       }
-      slackAlertsChannel: {
-        type: 'string'
-        value: slackAlertsChannel
+      slackAlertsChannels: {
+        type: 'array'
+        value: slackAlertsChannels
+      }
+      hiveSlackAlertsChannels: {
+        type: 'array'
+        value: hiveSlackAlertsChannels
       }
       slackAppToken: {
         type: 'securestring'
         value: slackAppToken
+      }
+      hiveSlackAppToken: {
+        type: 'securestring'
+        value: hiveSlackAppToken
       }
       teamsPowerAutomateWebhookUrl: {
         type: 'securestring'

--- a/infrastructure/templates/core/application/alerts/alerts-logic-app.bicep
+++ b/infrastructure/templates/core/application/alerts/alerts-logic-app.bicep
@@ -6,19 +6,19 @@ param subscription string
 @description('Resource Id of the Log Analytics Workspace to link the logic app to.')
 param logAnalyticsWorkspaceId string
 
-@description('Slack channels in the DfE workspace to post Azure alerts to.')
+@description('Slack channels in the primary workspace to post Azure alerts to.')
 param slackAlertsChannels array
 
-@description('Slack channels in the Hive workspace to post Azure alerts to.')
-param hiveSlackAlertsChannels array
+@description('Slack channels in the secondary workspace to post Azure alerts to.')
+param secondarySlackAlertsChannels array
 
 @secure()
-@description('Token to securely post to the DfE workspace Slack channels.')
+@description('Token to securely post to the primary workspace Slack channels.')
 param slackAppToken string
 
 @secure()
-@description('Token to securely post to the Hive workspace Slack channels.')
-param hiveSlackAppToken string
+@description('Token to securely post to the secondary workspace Slack channels.')
+param secondarySlackAppToken string
 
 @secure()
 @description('The Power Automate Webhook URL used to post messages to Teams.')
@@ -44,17 +44,17 @@ resource alertsLogicApp 'Microsoft.Logic/workflows@2019-05-01' = {
         type: 'array'
         value: slackAlertsChannels
       }
-      hiveSlackAlertsChannels: {
+      secondarySlackAlertsChannels: {
         type: 'array'
-        value: hiveSlackAlertsChannels
+        value: secondarySlackAlertsChannels
       }
       slackAppToken: {
         type: 'securestring'
         value: slackAppToken
       }
-      hiveSlackAppToken: {
+      secondarySlackAppToken: {
         type: 'securestring'
-        value: hiveSlackAppToken
+        value: secondarySlackAppToken
       }
       teamsPowerAutomateWebhookUrl: {
         type: 'securestring'

--- a/infrastructure/templates/core/application/alerts/alerts.bicep
+++ b/infrastructure/templates/core/application/alerts/alerts.bicep
@@ -7,8 +7,11 @@ param keyVaultName string
 @description('Resource Id of the Log Analytics Workspace to link the logic app to.')
 param logAnalyticsWorkspaceId string
 
-@description('Slack channel to post Azure alerts to.')
-param slackAlertsChannel string
+@description('Slack channels in the DfE workspace to post Azure alerts to.')
+param slackAlertsChannels array
+
+@description('Slack channels in the Hive workspace to post Azure alerts to.')
+param hiveSlackAlertsChannels array
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
@@ -19,8 +22,10 @@ module alertsLogicAppModule 'alerts-logic-app.bicep' = {
   params: {
     subscription: subscription
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
-    slackAlertsChannel: slackAlertsChannel
+    slackAlertsChannels: slackAlertsChannels
+    hiveSlackAlertsChannels: hiveSlackAlertsChannels
     slackAppToken: keyVault.getSecret('ees-alerts-slackapptoken')
+    hiveSlackAppToken: keyVault.getSecret('ees-alerts-hiveslackapptoken')
     teamsPowerAutomateWebhookUrl: keyVault.getSecret('ees-alerts-teamswebhookurl')
   }
 }

--- a/infrastructure/templates/core/application/alerts/alerts.bicep
+++ b/infrastructure/templates/core/application/alerts/alerts.bicep
@@ -7,11 +7,11 @@ param keyVaultName string
 @description('Resource Id of the Log Analytics Workspace to link the logic app to.')
 param logAnalyticsWorkspaceId string
 
-@description('Slack channels in the DfE workspace to post Azure alerts to.')
+@description('Slack channels in the primary workspace to post Azure alerts to.')
 param slackAlertsChannels array
 
-@description('Slack channels in the Hive workspace to post Azure alerts to.')
-param hiveSlackAlertsChannels array
+@description('Slack channels in the secondary workspace to post Azure alerts to.')
+param secondarySlackAlertsChannels array
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
@@ -23,9 +23,9 @@ module alertsLogicAppModule 'alerts-logic-app.bicep' = {
     subscription: subscription
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     slackAlertsChannels: slackAlertsChannels
-    hiveSlackAlertsChannels: hiveSlackAlertsChannels
+    secondarySlackAlertsChannels: secondarySlackAlertsChannels
     slackAppToken: keyVault.getSecret('ees-alerts-slackapptoken')
-    hiveSlackAppToken: keyVault.getSecret('ees-alerts-hiveslackapptoken')
+    secondarySlackAppToken: keyVault.getSecret('ees-alerts-secondaryslackapptoken')
     teamsPowerAutomateWebhookUrl: keyVault.getSecret('ees-alerts-teamswebhookurl')
   }
 }

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -10,8 +10,11 @@ param location string = resourceGroup().location
 @description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
 param environmentName string
 
-@description('Slack channel to post alerts to.')
-param slackAlertsChannel string = ''
+@description('Slack channels in the DfE workspace to post alerts to.')
+param slackAlertsChannels array = []
+
+@description('Slack channels in the Hive workspace to post alerts to.')
+param hiveSlackAlertsChannels array = []
 
 @description('The public site URL for use with Azure Front Door.')
 param publicSiteUrl string = ''
@@ -132,7 +135,8 @@ module alertsModule 'application/alerts/alerts.bicep' = {
     subscription: subscription
     keyVaultName: keyVaultModule.outputs.keyVaultName
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
-    slackAlertsChannel: slackAlertsChannel
+    slackAlertsChannels: slackAlertsChannels
+    hiveSlackAlertsChannels: hiveSlackAlertsChannels
   }
 }
 

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -10,11 +10,11 @@ param location string = resourceGroup().location
 @description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
 param environmentName string
 
-@description('Slack channels in the DfE workspace to post alerts to.')
+@description('Slack channels in the primary workspace to post alerts to.')
 param slackAlertsChannels array = []
 
-@description('Slack channels in the Hive workspace to post alerts to.')
-param hiveSlackAlertsChannels array = []
+@description('Slack channels in the secondary workspace to post alerts to.')
+param secondarySlackAlertsChannels array = []
 
 @description('The public site URL for use with Azure Front Door.')
 param publicSiteUrl string = ''
@@ -136,7 +136,7 @@ module alertsModule 'application/alerts/alerts.bicep' = {
     keyVaultName: keyVaultModule.outputs.keyVaultName
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceModule.outputs.logAnalyticsWorkspaceId
     slackAlertsChannels: slackAlertsChannels
-    hiveSlackAlertsChannels: hiveSlackAlertsChannels
+    secondarySlackAlertsChannels: secondarySlackAlertsChannels
   }
 }
 

--- a/infrastructure/templates/core/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/core/parameters/main-dev.bicepparam
@@ -8,4 +8,4 @@ param publicSiteInternalServiceFqdn = 's101d01-ees-fde-eve8c8hmd6gxgqcr.a03.azur
 param publicApiApplicationGatewayFqdn = 'dev.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-dev'
 
-param slackAlertsChannel = 'C067Z1K68UD'
+param slackAlertsChannels = ['C067Z1K68UD']

--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -8,6 +8,6 @@ param publicSiteInternalServiceFqdn = 's101p02-ees-fde-euhyh8d6cdeagqdu.a02.azur
 param publicApiApplicationGatewayFqdn = 'pre-production.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-preprod'
 
-param slackAlertsChannel = 'C0681S50SP5'
+param slackAlertsChannels = ['C0681S50SP5']
 
 param recoveryServicesVaultImmutable = true

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -10,6 +10,10 @@ param publicSiteInternalServiceFqdn = 's101p01-ees-fde-hzgvd4b5effuaua2.a02.azur
 param publicApiApplicationGatewayFqdn = 'statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'
 
-param slackAlertsChannel = 'C01MCTX47E3'
+param slackAlertsChannels = ['C01MCTX47E3']
+
+// Alerts are mirrored to the Hive workspace in production only. The other environments inherit the
+// empty default in main.bicep, which stops the Logic App posting to Hive at all.
+param hiveSlackAlertsChannels = ['C0BSTE3G6KY']
 
 param recoveryServicesVaultImmutable = true

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -12,8 +12,8 @@ param publicApiPublicUrl = 'https://api.education.gov.uk/statistics'
 
 param slackAlertsChannels = ['C01MCTX47E3']
 
-// Alerts are mirrored to the Hive workspace in production only. The other environments inherit the
-// empty default in main.bicep, which stops the Logic App posting to Hive at all.
-param hiveSlackAlertsChannels = ['C0BSTE3G6KY']
+// Alerts are mirrored to Hive's Slack workspace in production only. The other environments inherit
+// the empty default in main.bicep, which stops the Logic App posting to a second workspace at all.
+param secondarySlackAlertsChannels = ['C0BSTE3G6KY']
 
 param recoveryServicesVaultImmutable = true

--- a/infrastructure/templates/core/parameters/main-test.bicepparam
+++ b/infrastructure/templates/core/parameters/main-test.bicepparam
@@ -8,4 +8,4 @@ param publicSiteInternalServiceFqdn = 's101t01-ees-fde-dscafufydubae2fg.a02.azur
 param publicApiApplicationGatewayFqdn = 'test.statistics.api.education.gov.uk'
 param publicApiPublicUrl = 'https://pp-api.education.gov.uk/statistics-test'
 
-param slackAlertsChannel = 'C0681S23291'
+param slackAlertsChannels = ['C0681S23291']


### PR DESCRIPTION
This PR sets up plumbing to send metric alerts raised within EES production environment only to a new Hive Slack workspace channel called 'dfe-alerts'. 

This replicates the alerts sent to DfE's Slack workspace (which is soon going to be retired) and is set up on Hive's workspace for convenience.

There is a new Keyvault secret containing the Hive slack workspace's authentication token that has been added to every environment in order to allow smooth deployment of this change.

Instead of storing a second key vault secret, we opted for storing both slack app tokens for Hive and DfE in a JSON. Please see PR comments for more details.