### PR TITLE
EES-6910 Add extra PAPI testing

### DIFF
--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -213,6 +213,7 @@ def validate_environment_variables():
         "PENDING_INVITE_USER_EMAIL",
         "PENDING_INVITE_USER_PASSWORD",
         "PUBLISHER_FUNCTIONS_URL",
+        "PUBLIC_API_URL",
     ]
 
     for env_var in required_env_vars:

--- a/tests/robot-tests/tests/admin_and_public/bau/filter_groups_ignored.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/filter_groups_ignored.robot
@@ -2,7 +2,7 @@
 Resource            ../../libs/admin/manage-content-common.robot
 Resource            ../../libs/public-common.robot
 
-Force Tags          Admin    PublicApi    Local    Dev    AltersData
+Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -1163,7 +1163,7 @@ user navigates to
 check that variable is not empty
     [Arguments]    ${variable_name}    ${variable_value}
     IF    '${variable_value}'=='${EMPTY}'
-        Variable "${variable_name}" is empty.
+        Fail    Variable "${variable_name}" is empty.
     END
 
 user waits until table tool wizard step is available

--- a/tests/robot-tests/tests/libs/public-api-common.robot
+++ b/tests/robot-tests/tests/libs/public-api-common.robot
@@ -16,6 +16,10 @@ user creates API data set and opens details
     user clicks link in table cell    1    4    View details    testid:draft-api-data-sets
     user waits until h3 is visible    Draft version details
 
+user checks response status code
+    [Arguments]    ${response}    ${expected_status}
+    should be equal as integers    ${response.status_code}    ${expected_status}
+
 response should be json
     [Arguments]    ${response}
     should be equal as strings    ${response.headers['Content-Type']}    application/json; charset=utf-8

--- a/tests/robot-tests/tests/libs/public_api.py
+++ b/tests/robot-tests/tests/libs/public_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Any
 
@@ -11,9 +12,19 @@ class PublicApiClient:
     ROBOT_AUTO_KEYWORDS = False
 
     @staticmethod
-    def __request(method: str, url: str, params: dict[str, Any] | None = None):
+    def __request(
+        method: str,
+        url: str,
+        params: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        preview_token: str | None = None,
+    ):
         assert method and url
         assert os.getenv("PUBLIC_API_URL") is not None
+
+        headers = {"Content-Type": "application/json"}
+        if preview_token:
+            headers["Preview-Token"] = preview_token
 
         requests.sessions.HTTPAdapter(pool_connections=50, pool_maxsize=50, max_retries=3)
         session = requests.Session()
@@ -22,16 +33,44 @@ class PublicApiClient:
             method,
             url=f'{os.getenv("PUBLIC_API_URL")}{url}',
             params=params,
-            headers={"Content-Type": "application/json"},
+            json=body,
+            headers=headers,
             stream=True,
             verify=False,
         )
 
-    def get(self, url: str, params: dict[str, Any] | None = None):
-        return self.__request("GET", url, params)
+    def get(self, url: str, params: dict[str, Any] | None = None, preview_token: str | None = None):
+        return self.__request("GET", url, params=params, preview_token=preview_token)
+
+    def post(
+        self,
+        url: str,
+        body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        preview_token: str | None = None,
+    ):
+        return self.__request("POST", url, params=params, body=body, preview_token=preview_token)
 
 
 public_api_client = PublicApiClient()
+
+
+def user_makes_get_request_to_public_api(
+    url: str, params: dict[str, Any] | None = None, preview_token: str | None = None
+):
+    return public_api_client.get(url, params=params, preview_token=preview_token)
+
+
+def user_makes_post_request_to_public_api(
+    url: str,
+    body: str | dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+    preview_token: str | None = None,
+):
+    if isinstance(body, str):
+        body = json.loads(body)
+
+    return public_api_client.post(url, body=body, params=params, preview_token=preview_token)
 
 
 def user_gets_api_data_set_meta_via_api(data_set_id: str) -> dict[str, Any]:

--- a/tests/robot-tests/tests/public_api/api/public_api_list_publications.robot
+++ b/tests/robot-tests/tests/public_api/api/public_api_list_publications.robot
@@ -1,10 +1,9 @@
 *** Settings ***
-Library         RequestsLibrary
+Library         ../../libs/public_api.py
 Resource        ../../libs/public-api-common.robot
 
 Force Tags      GeneralPublic    PublicApi    Local    Dev    Test    Preprod
 
-Suite Setup     create session    papi    %{PUBLIC_API_URL}
 Test Setup      fail test fast if required
 
 
@@ -16,10 +15,8 @@ ${DEFAULT_PAGE_SIZE}=       10
 List publications with a search term to find matching publications returns a non-empty paginated list
     [Tags]    NotAgainstLocal
     &{params}=    create dictionary    search=test    pageSize=${DEFAULT_PAGE_SIZE}
-    ${response}=    GET On Session    papi
-    ...    url=publications
-    ...    params=${params}
-    ...    expected_status=ok
+    ${response}=    user makes get request to public api    /publications    params=${params}
+    user checks response status code    ${response}    200
     ${response_json}=    response should be json    ${response}
     response should contain pagination info
     ...    ${response_json}
@@ -29,12 +26,90 @@ List publications with a search term to find matching publications returns a non
 List publications with a short search term less than 3 characters returns a validation error
     [Tags]    NotAgainstLocal
     &{params}=    create dictionary    search=aa
-    ${response}=    GET On Session    papi
-    ...    url=publications
-    ...    params=${params}
-    ...    expected_status=bad_request
+    ${response}=    user makes get request to public api    /publications    params=${params}
+    user checks response status code    ${response}    400
     ${response_json}=    response should be json    ${response}
     response should contain validation error for path
     ...    ${response_json}
     ...    path=search
     ...    expected_message=Must be at least 3 characters (was 2).
+
+List publications returns a non-empty paginated list
+    [Tags]    NotAgainstLocal
+    &{params}=    create dictionary    pageSize=${DEFAULT_PAGE_SIZE}
+    ${response}=    user makes get request to public api    /publications    params=${params}
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    response should contain pagination info
+    ...    ${response_json}
+    ...    expected_page_size=${DEFAULT_PAGE_SIZE}
+    paginated response should contain non-empty results    ${response_json}
+
+    ${PUBLICATION_ID}=    set variable    ${response_json['results'][0]['id']}
+    set suite variable    ${PUBLICATION_ID}
+
+Get a publication returns the publication
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api    /publications/${PUBLICATION_ID}
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    should be equal    ${response_json['id']}    ${PUBLICATION_ID}
+
+List a publication's data sets returns a non-empty paginated list
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api    /publications/${PUBLICATION_ID}/data-sets
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    paginated response should contain non-empty results    ${response_json}
+
+    # Every publication in PAPI will have at least one data set associated with it.
+    ${DATA_SET_ID}=    set variable    ${response_json['results'][0]['id']}
+    set suite variable    ${DATA_SET_ID}
+
+Get a data set returns the data set with a latest version
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api    /data-sets/${DATA_SET_ID}
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    should be equal    ${response_json['id']}    ${DATA_SET_ID}
+    should be equal    ${response_json['status']}    Published
+
+    ${DATA_SET_VERSION}=    set variable    ${response_json['latestVersion']['version']}
+    set suite variable    ${DATA_SET_VERSION}
+
+Get a data set's meta returns the data set meta
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api    /data-sets/${DATA_SET_ID}/meta
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    should not be empty    ${response_json['indicators']}
+    should not be empty    ${response_json['timePeriods']}
+
+    ${INDICATOR_ID}=    set variable    ${response_json['indicators'][0]['id']}
+    set suite variable    ${INDICATOR_ID}
+
+Query a data set returns a non-empty paginated list of results
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes post request to public api    /data-sets/${DATA_SET_ID}/query
+    ...    body={"indicators":["${INDICATOR_ID}"],"pageSize":1}
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    response should contain pagination info    ${response_json}    expected_page_size=1
+    paginated response should contain non-empty results    ${response_json}
+    dictionary should contain key    ${response_json['results'][0]['values']}    ${INDICATOR_ID}
+
+List a data set's versions returns a non-empty paginated list
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api    /data-sets/${DATA_SET_ID}/versions
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    paginated response should contain non-empty results    ${response_json}
+
+Get a data set version returns the version
+    [Tags]    NotAgainstLocal
+    ${response}=    user makes get request to public api
+    ...    /data-sets/${DATA_SET_ID}/versions/${DATA_SET_VERSION}
+    user checks response status code    ${response}    200
+    ${response_json}=    response should be json    ${response}
+    should be equal    ${response_json['version']}    ${DATA_SET_VERSION}
+    should be equal    ${response_json['status']}    Published

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Library             DateTime
 Library             ../libs/admin_api.py
+Library             ../libs/public_api.py
 Resource            ../libs/admin-common.robot
 Resource            ../libs/admin/manage-content-common.robot
 Resource            ../libs/public-api-common.robot
@@ -71,6 +72,11 @@ Verify the contents inside 'Draft API data sets' table
 Click on 'View Details' link for API data set
     user clicks link in table cell    1    4    View details    testid:draft-api-data-sets
     user waits until h3 is visible    Draft version details
+
+    ${current_url}=    get location
+    ${API_DATA_SET_ID}=    fetch from right    ${current_url}    /
+    check that variable is not empty    API_DATA_SET_ID    ${API_DATA_SET_ID}
+    set suite variable    ${API_DATA_SET_ID}
 
 User verifies the 'Draft API data set' summary list
     user checks summary list contains    Version    v1.0
@@ -317,6 +323,69 @@ User verifies the relevant fields on the active preview token page
     user checks page contains link    View preview token log
     user checks page contains    API data set endpoints quick start
 
+User copies the preview token for use with the API
+    ${PREVIEW_TOKEN}=    get value    id:copy-preview-token
+    check that variable is not empty    PREVIEW_TOKEN    ${PREVIEW_TOKEN}
+    set suite variable    ${PREVIEW_TOKEN}
+
+User cannot access the draft API data set via the API without the preview token
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}
+    user checks response status code    ${response}    403
+
+    &{params}=    create dictionary    dataSetVersion=1.0
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/meta    params=${params}
+    user checks response status code    ${response}    403
+
+User accesses the draft API data set via the API using the preview token
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}
+    ...    preview_token=${PREVIEW_TOKEN}
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    should be equal    ${json['title']}    ${SUBJECT_NAME}
+
+User gets the draft API data set meta via the API using the preview token
+    &{params}=    create dictionary    dataSetVersion=1.0
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/meta
+    ...    params=${params}
+    ...    preview_token=${PREVIEW_TOKEN}
+    user checks response status code    ${response}    200
+    ${meta}=    response should be json    ${response}
+
+    ${MEDIAN_INDICATOR_ID}=    user gets API data set indicator id    ${meta}    Median annualised earnings
+    set suite variable    ${MEDIAN_INDICATOR_ID}
+
+User queries the draft API data set via the API using the preview token
+    &{params}=    create dictionary    dataSetVersion=1.0
+    ${response}=    user makes post request to public api    /data-sets/${API_DATA_SET_ID}/query
+    ...    body={"indicators":["${MEDIAN_INDICATOR_ID}"]}
+    ...    params=${params}
+    ...    preview_token=${PREVIEW_TOKEN}
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    paginated response should contain results    ${json}    3270
+
+User downloads the draft API data set CSV via the API using the preview token
+    &{params}=    create dictionary    dataSetVersion=1.0
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/csv
+    ...    params=${params}
+    ...    preview_token=${PREVIEW_TOKEN}
+    user checks response status code    ${response}    200
+    ${row_count}=    evaluate    len($response.text.strip().splitlines())
+    should be equal as integers    ${row_count}    3271
+
+User revokes the preview token used for API access
+    user clicks button    Revoke preview token
+    ${modal}=    user waits until modal is visible    Revoke preview token
+    user clicks button    Confirm
+    user waits until page finishes loading
+    user waits until modal is not visible    Revoke preview token    %{WAIT_LONG}
+    user waits until page contains    API data set preview token log
+
+User cannot access the draft API data set via the API with a revoked preview token
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}
+    ...    preview_token=${PREVIEW_TOKEN}
+    user checks response status code    ${response}    403
+
 Add headline text block to Content page
     user clicks link    Back to API data set details
     user navigates to content page    ${PUBLICATION_NAME}
@@ -413,3 +482,81 @@ User verifies 'API version history' section
     user checks table cell contains    1    1    1.0 (current)    id:apiVersionHistory
     user checks table cell contains    1    2    ${RELEASE_NAME}    id:apiVersionHistory
     user checks table cell contains    1    3    Published    id:apiVersionHistory
+
+User checks the published API data set via the API
+    ${json}=    wait until keyword succeeds    10x    %{WAIT_SMALL}s
+    ...    user checks API data set is published    ${API_DATA_SET_ID}
+    should be equal    ${json['title']}    ${SUBJECT_NAME}
+    should be equal    ${json['latestVersion']['version']}    1.0
+
+User lists the published API data set versions via the API
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/versions
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    paginated response should contain results    ${json}    1
+    should be equal    ${json['results'][0]['version']}    1.0
+    should be equal    ${json['results'][0]['status']}    Published
+
+User gets the published API data set version via the API
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/versions/1.0
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    should be equal    ${json['version']}    1.0
+    should be equal    ${json['status']}    Published
+
+User queries the published API data set via the API for a known result
+    ${meta}=    user gets api data set meta via api    ${API_DATA_SET_ID}
+    ${median_id}=    user gets API data set indicator id    ${meta}    Median annualised earnings
+    ${gender_id}=    user gets API data set filter option id    ${meta}    Gender    Total
+    ${ethnicity_id}=    user gets API data set filter option id    ${meta}    Ethnicity group    Total
+    ${provision_id}=    user gets API data set filter option id    ${meta}    Provision    Total
+    ${level_id}=    user gets API data set filter option id    ${meta}    Level of learning    Total
+    ${years_id}=    user gets API data set filter option id    ${meta}
+    ...    Number of years after achievement of learning aim    1 year after study
+    ${colour_id}=    user gets API data set filter option id    ${meta}    Colour    Orange
+    ${cheese_id}=    user gets API data set filter option id    ${meta}    Cheese    Feta
+
+    # These filters narrow the data set down to a single row of the source CSV
+    # (the first data row of seven_filters.csv, where Median is 3).
+    ${body}=    catenate    SEPARATOR=
+    ...    {"criteria":{"and":[
+    ...    {"filters":{"eq":"${gender_id}"}},
+    ...    {"filters":{"eq":"${ethnicity_id}"}},
+    ...    {"filters":{"eq":"${provision_id}"}},
+    ...    {"filters":{"eq":"${level_id}"}},
+    ...    {"filters":{"eq":"${years_id}"}},
+    ...    {"filters":{"eq":"${colour_id}"}},
+    ...    {"filters":{"eq":"${cheese_id}"}}
+    ...    ]},"indicators":["${median_id}"]}
+
+    ${response}=    user makes post request to public api    /data-sets/${API_DATA_SET_ID}/query
+    ...    body=${body}
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    paginated response should contain results    ${json}    1
+    should be equal    ${json['results'][0]['values']['${median_id}']}    3
+
+User queries the published API data set via the API using a GET query
+    &{params}=    create dictionary    indicators=${MEDIAN_INDICATOR_ID}
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/query
+    ...    params=${params}
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    paginated response should contain results    ${json}    3270
+
+User downloads the published API data set CSV via the API
+    ${response}=    user makes get request to public api    /data-sets/${API_DATA_SET_ID}/csv
+    user checks response status code    ${response}    200
+    should contain    ${response.headers['Content-Type']}    text/csv
+    ${row_count}=    evaluate    len($response.text.strip().splitlines())
+    should be equal as integers    ${row_count}    3271
+
+
+*** Keywords ***
+user checks API data set is published
+    [Arguments]    ${data_set_id}
+    ${response}=    user makes get request to public api    /data-sets/${data_set_id}
+    user checks response status code    ${response}    200
+    ${json}=    response should be json    ${response}
+    should be equal    ${json['status']}    Published
+    RETURN    ${json}


### PR DESCRIPTION
This PR adds extra PAPI testing to give us extra coverage. There were certain parts of PAPI that we haven't been testing: most importantly the ability to get meta data and query a live API data set. But we also didn't explicitly test that preview tokens functioned correctly.

### Other changes
- Added PUBLIC_API_URL to be required in the .env variable list - could argue that this shouldn't be here, but I'm inclined to as someone adding it when they don't need it is easy, while you can waste a lot of time if the variable isn't there when you need it.
- Removed unneeded PublicApi tag from filter_groups_ignored.robot
- Made the common keyword "check that variable is not empty" fail if the variable is empty.