### PR TITLE
EES-7431 - reduced length of module deploy names for Azure Storage Ac…

### DIFF
--- a/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
@@ -357,7 +357,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 }
 
 module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site.bicep' = {
-  name: '${functionApp.name}AzureStorageAccountsConfigModuleDeploy'
+  name: '${functionApp.name}StorageAccountsConfigDeploy'
   params: {
     siteName: functionApp.name
     azureFileShares: azureFileShares

--- a/infrastructure/templates/common/components/function-app/functionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/functionApp.bicep
@@ -315,7 +315,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 }
 
 module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site.bicep' = {
-  name: '${functionApp.name}AzureStorageAccountsConfigModuleDeploy'
+  name: '${functionApp.name}StorageAccountsConfigDeploy'
   params: {
     siteName: functionApp.name
     azureFileShares: azureFileShares
@@ -323,7 +323,7 @@ module azureStorageAccountsConfigModule '../storage/file-share-mounts-for-site.b
 }
 
 module keyVaultRoleAssignmentModule '../key-vault/keyVaultRoleAssignment.bicep' = {
-  name: '${functionAppName}KeyVaultRoleAssignmentModuleDeploy'
+  name: '${functionAppName}KeyVaultSecretsUserRoleAssignment'
   params: {
     principalIds: [functionApp.identity.principalId]
     keyVaultName: keyVault.name

--- a/infrastructure/templates/public-api/components/appServiceSlotConfig.bicep
+++ b/infrastructure/templates/public-api/components/appServiceSlotConfig.bicep
@@ -52,7 +52,7 @@ resource appStagingSlotSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = 
 }
 
 module azureStorageAccountsConfigModule '../../common/components/storage/file-share-mounts-for-site-slot.bicep' = {
-  name: '${appName}${stagingSlotName}AzureStorageAccountsConfigModuleDeploy'
+  name: '${appName}${stagingSlotName}StorageAccountsConfigDeploy'
   params: {
     siteName: appName
     slotName: stagingSlotName

--- a/infrastructure/templates/public-api/components/durableFunctionApp.bicep
+++ b/infrastructure/templates/public-api/components/durableFunctionApp.bicep
@@ -352,7 +352,7 @@ var keyVaultPrincipalIds = userAssignedManagedIdentityParams != null
   : [functionApp.identity.principalId, stagingSlot.identity.principalId]
 
 module functionAppKeyVaultRoleAssignments '../../common/components/key-vault/keyVaultRoleAssignment.bicep' = {
-  name: '${functionAppName}FunctionAppKeyVaultRoleAssignment'
+  name: '${functionAppName}KeyVaultSecretsUserRoleAssignment'
   params: {
     keyVaultName: keyVaultName
     principalIds: keyVaultPrincipalIds
@@ -361,7 +361,7 @@ module functionAppKeyVaultRoleAssignments '../../common/components/key-vault/key
 }
 
 module azureStorageAccountsConfigModule '../../common/components/storage/file-share-mounts-for-site.bicep' = {
-  name: '${functionApp.name}AzureStorageAccountsConfigModuleDeploy'
+  name: '${functionApp.name}StorageAccountsConfigDeploy'
   params: {
     siteName: functionApp.name
     azureFileShares: azureFileShares


### PR DESCRIPTION
This PR:
- reduces the length of Bicep module deploy names for Function Apps to be line with that of App Services, so that they fall within ARM's 64-character limit. 