### PR TITLE
EES-7367 Strip html from release file data guidance

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/StripReleaseFileSummaryHtmlControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/StripReleaseFileSummaryHtmlControllerTests.cs
@@ -128,16 +128,17 @@ public abstract class StripReleaseFileSummaryHtmlControllerTests
     public class StripSummaryHtmlTests : StripReleaseFileSummaryHtmlControllerTests
     {
         [Fact]
-        public async Task WhenSummaryIsHtml_ConvertsItToPlainTextAfterBackingItUp()
+        public async Task ReleaseFileSummariesContainHtml_HtmlTagsAreStrippedAfterBackingThemUp()
         {
             // Arrange
             ReleaseFile releaseFile = DefaultReleaseFile().WithSummary(HtmlSummary);
+            ReleaseFile anotherReleaseFile = DefaultReleaseFile().WithSummary("<p>Another summary</p>");
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                context.ReleaseFiles.Add(releaseFile);
+                context.ReleaseFiles.AddRange(releaseFile, anotherReleaseFile);
                 await context.SaveChangesAsync();
             }
 
@@ -165,7 +166,8 @@ public abstract class StripReleaseFileSummaryHtmlControllerTests
                 // Assert
                 var report = result.AssertOkResult();
 
-                Assert.Equal(1, report.ChangeCount);
+                Assert.Equal(2, report.CandidateCount);
+                Assert.Equal(2, report.ChangeCount);
 
                 VerifyAllMocks(sqlExecutor);
             }
@@ -175,7 +177,11 @@ public abstract class StripReleaseFileSummaryHtmlControllerTests
 
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                Assert.Equal(HtmlSummaryAsPlainText, context.ReleaseFiles.Single().Summary);
+                var summaries = context.ReleaseFiles.ToDictionary(rf => rf.Id, rf => rf.Summary);
+
+                Assert.Equal(2, summaries.Count);
+                Assert.Equal(HtmlSummaryAsPlainText, summaries[releaseFile.Id]);
+                Assert.Equal("Another summary", summaries[anotherReleaseFile.Id]);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/StripReleaseFileSummaryHtmlControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/StripReleaseFileSummaryHtmlControllerTests.cs
@@ -1,0 +1,271 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Bau;
+
+public abstract class StripReleaseFileSummaryHtmlControllerTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    private const string HtmlSummary = "<p>Test paragraph with <strong>bold text</strong></p>";
+    private const string HtmlSummaryAsPlainText = "Test paragraph with bold text";
+
+    public class DryRunStripSummaryHtmlTests : StripReleaseFileSummaryHtmlControllerTests
+    {
+        [Fact]
+        public async Task WhenSummaryIsHtml_ReportsChangeWithoutApplyingIt()
+        {
+            // Arrange
+            ReleaseFile releaseFile = DefaultReleaseFile().WithSummary(HtmlSummary);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.Add(releaseFile);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sqlExecutor = new Mock<IRawSqlExecutor>(Strict);
+                var controller = BuildController(context, sqlExecutor.Object);
+
+                // Act
+                var result = await controller.DryRunStripSummaryHtml();
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(1, report.CandidateCount);
+                var change = Assert.Single(report.Changes);
+                Assert.Equal(releaseFile.Id, change.ReleaseFileId);
+                Assert.Equal(HtmlSummary, change.Current);
+                Assert.Equal(HtmlSummaryAsPlainText, change.PlainText);
+
+                // The summary itself is left untouched, and no backup is taken.
+                VerifyAllMocks(sqlExecutor);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                Assert.Equal(HtmlSummary, context.ReleaseFiles.Single().Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenSummaryIsPlainTextContainingAmpersand_ReportsNoChange()
+        {
+            // Arrange
+            // This matches the query looking for character entities, but converting it changes nothing.
+            ReleaseFile releaseFile = DefaultReleaseFile().WithSummary("Fees & charges; see notes");
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.Add(releaseFile);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var controller = BuildController(context);
+
+                // Act
+                var result = await controller.DryRunStripSummaryHtml();
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(1, report.CandidateCount);
+                Assert.Empty(report.Changes);
+            }
+        }
+
+        [Fact]
+        public async Task WhenSummaryIsPlainText_IsNotACandidate()
+        {
+            // Arrange
+            ReleaseFile releaseFile = DefaultReleaseFile().WithSummary("A plain text summary");
+
+            ReleaseFile releaseFileWithoutSummary = DefaultReleaseFile().WithSummary(null);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.AddRange(releaseFile, releaseFileWithoutSummary);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var controller = BuildController(context);
+
+                // Act
+                var result = await controller.DryRunStripSummaryHtml();
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(0, report.CandidateCount);
+                Assert.Empty(report.Changes);
+            }
+        }
+    }
+
+    public class StripSummaryHtmlTests : StripReleaseFileSummaryHtmlControllerTests
+    {
+        [Fact]
+        public async Task WhenSummaryIsHtml_ConvertsItToPlainTextAfterBackingItUp()
+        {
+            // Arrange
+            ReleaseFile releaseFile = DefaultReleaseFile().WithSummary(HtmlSummary);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.Add(releaseFile);
+                await context.SaveChangesAsync();
+            }
+
+            var capturedSql = new List<string>();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sqlExecutor = new Mock<IRawSqlExecutor>(Strict);
+
+                sqlExecutor
+                    .Setup(s =>
+                        s.ExecuteSqlRaw(
+                            It.IsAny<ContentDbContext>(),
+                            Capture.In(capturedSql),
+                            It.IsAny<CancellationToken>()
+                        )
+                    )
+                    .Returns(Task.CompletedTask);
+
+                var controller = BuildController(context, sqlExecutor.Object);
+
+                // Act
+                var result = await controller.StripSummaryHtml();
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(1, report.ChangeCount);
+
+                VerifyAllMocks(sqlExecutor);
+            }
+
+            var backupSql = Assert.Single(capturedSql);
+            Assert.Contains("ReleaseFiles_Ees7367_SummaryBackup", backupSql, StringComparison.Ordinal);
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                Assert.Equal(HtmlSummaryAsPlainText, context.ReleaseFiles.Single().Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenSummaryIsPlainText_LeavesItUnchanged()
+        {
+            // Arrange
+            const string summary = "Fees & charges; see notes";
+
+            ReleaseFile releaseFile = DefaultReleaseFile().WithSummary(summary);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.Add(releaseFile);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var controller = BuildController(context);
+
+                // Act
+                var result = await controller.StripSummaryHtml();
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(0, report.ChangeCount);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                Assert.Equal(summary, context.ReleaseFiles.Single().Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenMoreCandidatesThanLimit_ConvertsUpToLimitAndReportsTheRest()
+        {
+            // Arrange
+            var releaseFiles = DefaultReleaseFile().WithSummary(HtmlSummary).GenerateList(3);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.ReleaseFiles.AddRange(releaseFiles);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var controller = BuildController(context);
+
+                // Act
+                var result = await controller.StripSummaryHtml(limit: 2);
+
+                // Assert
+                var report = result.AssertOkResult();
+
+                Assert.Equal(3, report.CandidateCount);
+                Assert.Equal(2, report.ChangeCount);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                // Only the remaining summary still contains HTML, so a further request would convert it.
+                var summaries = context.ReleaseFiles.Select(rf => rf.Summary).ToList();
+
+                Assert.Equal(2, summaries.Count(summary => summary == HtmlSummaryAsPlainText));
+                Assert.Single(summaries, summary => summary == HtmlSummary);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Release files are filtered by whether their release version is soft deleted, so each one needs a
+    /// release version to be visible to the controller's queries at all.
+    /// </summary>
+    private Generator<ReleaseFile> DefaultReleaseFile()
+    {
+        ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+        return _dataFixture.DefaultReleaseFile().WithReleaseVersion(releaseVersion);
+    }
+
+    private static StripReleaseFileSummaryHtmlController BuildController(
+        ContentDbContext contentDbContext,
+        IRawSqlExecutor? sqlExecutor = null
+    ) => new(contentDbContext, sqlExecutor ?? Mock.Of<IRawSqlExecutor>());
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
@@ -531,52 +531,6 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
-        public async Task WhenDataSetSummaryIsHtml_ReturnsPlainTextSummary()
-        {
-            // Arrange
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
-            var release = publication.Releases[0];
-            var releaseVersion = release.Versions[0];
-
-            ReleaseFile dataSet = _dataFixture
-                .DefaultReleaseFile()
-                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
-                .WithReleaseVersion(releaseVersion)
-                .WithSummary(
-                    "<div><p>Test paragraph with <strong>bold text</strong> and <em>italic text</em></p></div>"
-                );
-
-            DataImport dataImport = _dataFixture
-                .DefaultDataImport()
-                .WithFile(dataSet.File)
-                .WithStatus(DataImportStatus.COMPLETE);
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                context.DataImports.Add(dataImport);
-                context.Publications.Add(publication);
-                context.ReleaseFiles.Add(dataSet);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                var sut = BuildService(context);
-
-                // Act
-                var outcome = await sut.GetReleaseDataContent(releaseVersion.Id);
-
-                // Assert
-                var result = outcome.AssertRight();
-
-                Assert.Equal("Test paragraph with bold text and italic text", result.DataSets[0].Summary);
-            }
-        }
-
-        [Fact]
         public async Task WhenDataSetHasPublicApiDataSetId_IsApiEnabledIsTrueAndPublicApiDataSetIdIsSet()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/StripReleaseFileSummaryHtmlController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/StripReleaseFileSummaryHtmlController.cs
@@ -1,0 +1,138 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+/// <summary>
+/// Converts any <see cref="ReleaseFile.Summary"/> still containing HTML to plain text.
+///
+/// EES-4353 changed the data guidance content field from a rich text field to a plain text one, but did not
+/// migrate the summaries created before it. Until they have been converted, this field can hold either.
+/// </summary>
+[Route("api/bau")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class StripReleaseFileSummaryHtmlController(ContentDbContext contentDbContext, IRawSqlExecutor sqlExecutor)
+    : ControllerBase
+{
+    private const string BackupTable = "ReleaseFiles_Ees7367_SummaryBackup";
+
+    private const string BackupSql = $"""
+        IF OBJECT_ID('dbo.{BackupTable}', 'U') IS NULL
+            SELECT Id, Summary
+            INTO dbo.{BackupTable}
+            FROM dbo.ReleaseFiles
+            WHERE Summary IS NOT NULL;
+        """;
+
+    /// <summary>
+    /// Reports the changes that <see cref="StripSummaryHtml"/> would make, without making them.
+    /// </summary>
+    // TODO EES-7367 Remove once run in all environments
+    [HttpGet("strip-release-file-summary-html")]
+    public async Task<ActionResult<StripSummaryHtmlReportViewModel>> DryRunStripSummaryHtml(
+        [FromQuery] int limit = 500,
+        CancellationToken cancellationToken = default
+    ) => await BuildReport(limit, cancellationToken);
+
+    /// <summary>
+    /// Converts the summaries reported by <see cref="DryRunStripSummaryHtml"/> to plain text, backing up all
+    /// existing summaries beforehand.
+    ///
+    /// Only <paramref name="limit"/> summaries are converted per request, to avoid exceeding the request
+    /// timeout. Converted summaries no longer match the query, so call this repeatedly until the reported
+    /// <see cref="StripSummaryHtmlReportViewModel.CandidateCount"/> is zero.
+    /// </summary>
+    // TODO EES-7367 Remove once run in all environments
+    [HttpPut("strip-release-file-summary-html")]
+    public async Task<ActionResult<StripSummaryHtmlReportViewModel>> StripSummaryHtml(
+        [FromQuery] int limit = 500,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Back up every existing summary before changing any of them. This is a no-op once the backup exists,
+        // so the backup is always of the summaries as they were before the first of these requests.
+        await sqlExecutor.ExecuteSqlRaw(contentDbContext, BackupSql, cancellationToken);
+
+        var report = await BuildReport(limit, cancellationToken);
+
+        var plainTextByReleaseFileId = report.Changes.ToDictionary(
+            change => change.ReleaseFileId,
+            change => change.PlainText
+        );
+
+        var releaseFiles = await contentDbContext
+            .ReleaseFiles.Where(rf => plainTextByReleaseFileId.Keys.Contains(rf.Id))
+            .ToListAsync(cancellationToken);
+
+        releaseFiles.ForEach(releaseFile => releaseFile.Summary = plainTextByReleaseFileId[releaseFile.Id]);
+
+        await contentDbContext.SaveChangesAsync(cancellationToken);
+
+        return report;
+    }
+
+    private async Task<StripSummaryHtmlReportViewModel> BuildReport(int limit, CancellationToken cancellationToken)
+    {
+        var candidates = contentDbContext
+            .ReleaseFiles.AsNoTracking()
+            .Where(rf =>
+                rf.Summary != null
+                // Summaries containing markup or a character entity may not be plain text. Anything else
+                // cannot be HTML, so is left alone.
+                && (
+                    (rf.Summary.Contains("<") && rf.Summary.Contains(">"))
+                    || (rf.Summary.Contains("&") && rf.Summary.Contains(";"))
+                )
+            );
+
+        var releaseFiles = await candidates
+            .OrderBy(rf => rf.Id)
+            .Select(rf => new { rf.Id, rf.Summary })
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+
+        var changes = releaseFiles
+            .Select(rf => new SummaryChangeViewModel
+            {
+                ReleaseFileId = rf.Id,
+                Current = rf.Summary!,
+                PlainText = HtmlToTextUtils.HtmlToText(rf.Summary!),
+            })
+            // A character entity match is only a candidate. Discard the ones that are already plain text.
+            .Where(change => change.PlainText != change.Current)
+            .ToList();
+
+        return new StripSummaryHtmlReportViewModel
+        {
+            CandidateCount = await candidates.CountAsync(cancellationToken),
+            Changes = changes,
+        };
+    }
+}
+
+public record StripSummaryHtmlReportViewModel
+{
+    /// <summary>
+    /// The total number of summaries matching the query, which may exceed the number inspected.
+    /// </summary>
+    public required int CandidateCount { get; init; }
+
+    public required List<SummaryChangeViewModel> Changes { get; init; }
+
+    public int ChangeCount => Changes.Count;
+}
+
+public record SummaryChangeViewModel
+{
+    public required Guid ReleaseFileId { get; init; }
+    public required string Current { get; init; }
+    public required string PlainText { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
@@ -54,10 +53,8 @@ public record ReleaseDataContentDataSetDto
             FileId = releaseFile.File.Id,
             SubjectId = releaseFile.File.SubjectId ?? throw new ArgumentException("File must have SubjectId"),
             Meta = ReleaseDataContentDataSetMetaDto.FromReleaseFile(releaseFile),
-            // Summaries created before EES-4353 may contain HTML. Convert them to plain text here.
-            // TODO: Remove HtmlToText after migrating all summaries to plain text.
             // Summary is only set when data guidance has been added, so a data set can initially have no summary.
-            Summary = releaseFile.Summary != null ? HtmlToTextUtils.HtmlToText(releaseFile.Summary) : null,
+            Summary = releaseFile.Summary,
             Title = releaseFile.Name ?? throw new ArgumentException("ReleaseFile must have Name"),
             PublicApiDataSetId = releaseFile.PublicApiDataSetId,
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1566,45 +1566,6 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 pagedResult.AssertEmptyResults();
             }
-
-            [Fact]
-            // TODO Remove this once we do further work to remove all HTML from summaries at source
-            public async Task ReleaseFileSummariesContainHtml_HtmlTagsAreStripped()
-            {
-                Publication publication = DataFixture
-                    .DefaultPublication()
-                    .WithReleases([DataFixture.DefaultRelease(publishedVersions: 1)])
-                    .WithTheme(DataFixture.DefaultTheme());
-
-                var release1Version1Files = GenerateDataSetFilesForReleaseVersion(publication.Releases[0].Versions[0]);
-
-                release1Version1Files.ForEach(releaseFile =>
-                {
-                    releaseFile.Summary = $"<p>{releaseFile.Summary}</p>";
-                });
-
-                await fixture
-                    .GetContentDbContext()
-                    .AddTestData(context =>
-                    {
-                        context.ReleaseFiles.AddRange(release1Version1Files);
-                    });
-
-                var query = new DataSetFileListRequest();
-                var response = await ListDataSetFiles(query);
-
-                var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
-
-                Assert.All(
-                    pagedResult.Results,
-                    item =>
-                    {
-                        var content = item.Content;
-                        Assert.DoesNotContain("<p>", content);
-                        Assert.DoesNotContain("</p>", content);
-                    }
-                );
-            }
         }
 
         private async Task<HttpResponseMessage> ListDataSetFiles(DataSetFileListRequest request)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
@@ -120,11 +120,8 @@ public class DataGuidanceFileWriterTests : IDisposable
                 Filename = "test-1.csv",
                 Name = "Test data 1",
                 Content =
-                    @"
-                        <p>
-                            Local authority level data on care leavers aged 17 to 21, by accommodation type (as 
-                            measured on or around their birthday).
-                        </p>",
+                    "Local authority level data on care leavers aged 17 to 21, by accommodation type "
+                    + "(as measured on or around their birthday).",
                 GeographicLevels = new List<string> { "Local Authority", "National", "Regional" },
                 TimePeriods = new TimePeriodLabels("2018", "2020"),
                 Variables = new List<LabelValue>
@@ -145,11 +142,8 @@ public class DataGuidanceFileWriterTests : IDisposable
                 Filename = "test-2.csv",
                 Name = "Test data 2",
                 Content =
-                    @"
-                        <p>
-                            Number and proportion of population participating in education, training and employment 
-                            by age, gender and labour market status.
-                        </p>",
+                    "Number and proportion of population participating in education, training and employment "
+                    + "by age, gender and labour market status.",
                 GeographicLevels = new List<string> { "National" },
                 TimePeriods = new TimePeriodLabels("2018", "2018"),
                 Variables = new List<LabelValue>
@@ -216,11 +210,8 @@ public class DataGuidanceFileWriterTests : IDisposable
                 Filename = "test-1.csv",
                 Name = "Test data 1",
                 Content =
-                    @"
-                        <p>
-                            Local authority level data on care leavers aged 17 to 21, by accommodation type (as 
-                            measured on or around their birthday). See <a href=""https://test.com"">reference information</a>.
-                        </p>",
+                    "Local authority level data on care leavers aged 17 to 21, by accommodation type "
+                    + "(as measured on or around their birthday). See reference information (https://test.com).",
                 GeographicLevels = new List<string> { "Local Authority", "National", "Regional" },
                 TimePeriods = new TimePeriodLabels("2018", "2020"),
                 Variables = new List<LabelValue>
@@ -286,11 +277,8 @@ public class DataGuidanceFileWriterTests : IDisposable
                 Filename = "test-1.csv",
                 Name = "Test data 1",
                 Content =
-                    @"
-                        <p>
-                            Local authority level data on care leavers aged 17 to 21, by accommodation type (as 
-                            measured on or around their birthday).
-                        </p>",
+                    "Local authority level data on care leavers aged 17 to 21, by accommodation type "
+                    + "(as measured on or around their birthday).",
                 GeographicLevels = new List<string> { "Local Authority", "National", "Regional" },
                 TimePeriods = new TimePeriodLabels("2018", "2020"),
                 Variables = new List<LabelValue>
@@ -389,7 +377,7 @@ public class DataGuidanceFileWriterTests : IDisposable
             {
                 Filename = "test-1.csv",
                 Name = "Test data 1",
-                Content = "<p>Test file content</p>",
+                Content = "Test file content",
                 GeographicLevels = new List<string> { "Local Authority" },
                 TimePeriods = new TimePeriodLabels("2018", "2018"),
                 Variables = new List<LabelValue> { new("Accommodation type", "accommodation_type") },

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -505,49 +505,6 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
-        public async Task WhenDataSetSummaryIsHtml_ReturnsPlainTextSummary()
-        {
-            // Arrange
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
-            var release = publication.Releases[0];
-            var releaseVersion = release.Versions[0];
-
-            ReleaseFile dataSet = _dataFixture
-                .DefaultReleaseFile()
-                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
-                .WithReleaseVersion(releaseVersion)
-                .WithSummary(
-                    "<div><p>Test paragraph with <strong>bold text</strong> and <em>italic text</em></p></div>"
-                );
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                context.Publications.Add(publication);
-                context.ReleaseFiles.Add(dataSet);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                var sut = BuildService(context);
-
-                // Act
-                var outcome = await sut.GetReleaseDataContent(
-                    publicationSlug: publication.Slug,
-                    releaseSlug: release.Slug
-                );
-
-                // Assert
-                var result = outcome.AssertRight();
-
-                Assert.Equal("Test paragraph with bold text and italic text", result.DataSets[0].Summary);
-            }
-        }
-
-        [Fact]
         public async Task WhenDataSetHasPublicApiDataSetId_IsApiEnabledIsTrueAndPublicApiDataSetIdIsSet()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -123,8 +123,7 @@ public class DataGuidanceFileWriter : IDataGuidanceFileWriter
 
                     if (!dataSet.Content.IsNullOrWhitespace())
                     {
-                        var content = HtmlToTextUtils.HtmlToText(dataSet.Content);
-                        await file.WriteLineAsync($"Content summary: {content}");
+                        await file.WriteLineAsync($"Content summary: {dataSet.Content}");
                     }
 
                     var variables = dataSet

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -5,7 +5,6 @@ using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -105,9 +104,7 @@ public class DataSetFileService(
         }
 
         return new PaginatedListViewModel<DataSetFileSummaryViewModel>(
-            // Summaries created before EES-4353 may contain HTML. Convert them to plain text here.
-            // TODO: Remove ChangeSummaryHtmlToText after migrating all summaries to plain text
-            ChangeSummaryHtmlToText(results),
+            results,
             totalResults: await query.CountAsync(cancellationToken: cancellationToken),
             page,
             pageSize
@@ -184,13 +181,6 @@ public class DataSetFileService(
             })
             .ToListAsync(cancellationToken);
     }
-
-    private static List<DataSetFileSummaryViewModel> ChangeSummaryHtmlToText(
-        IList<DataSetFileSummaryViewModel> results
-    ) =>
-        results
-            .Select(viewModel => viewModel with { Content = HtmlToTextUtils.HtmlToText(viewModel.Content) })
-            .ToList();
 
     public async Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
         Guid dataSetFileId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -1,5 +1,4 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
@@ -53,10 +52,8 @@ public record ReleaseDataContentDataSetDto
             FileId = releaseFile.File.Id,
             SubjectId = releaseFile.File.SubjectId ?? throw new ArgumentException("File must have SubjectId"),
             Meta = ReleaseDataContentDataSetMetaDto.FromReleaseFile(releaseFile),
-            // Summaries created before EES-4353 may contain HTML. Convert them to plain text here.
-            // TODO: Remove HtmlToText after migrating all summaries to plain text.
             // Default to an empty summary for older data sets that predate the summary requirement.
-            Summary = releaseFile.Summary != null ? HtmlToTextUtils.HtmlToText(releaseFile.Summary) : "",
+            Summary = releaseFile.Summary ?? "",
             Title = releaseFile.Name ?? throw new ArgumentException("ReleaseFile must have Name"),
             PublicApiDataSetId = releaseFile.PublicApiDataSetId,
         };

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -23,7 +23,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import { ApiDataSet, DataSetStatus } from '@admin/services/apiDataSetService';
 import apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
-import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryCard from '@common/components/SummaryCard';
 import SummaryList from '@common/components/SummaryList';
@@ -398,7 +398,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                 </Tag>
               </SummaryListItem>
               <SummaryListItem term="Summary">
-                <ContentHtml html={dataSet.summary} />
+                <PlainTextContent text={dataSet.summary} />
               </SummaryListItem>
             </SummaryList>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -11,6 +11,7 @@ import Form from '@common/components/form/Form';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import WarningMessage from '@common/components/WarningMessage';
 import Link from '@admin/components/Link';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
@@ -198,8 +199,8 @@ const ReleaseDataGuidanceSection = ({
                                         maxLength={contentMaxLength}
                                       />
                                     ) : (
-                                      <ContentHtml
-                                        html={values.dataSets[index].content}
+                                      <PlainTextContent
+                                        text={values.dataSets[index].content}
                                         testId="fileGuidanceContent"
                                       />
                                     )

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -21,7 +21,7 @@ describe('ReleaseDataGuidanceSection', () => {
         fileId: 'file-1',
         name: 'Data set 1',
         filename: 'data-1.csv',
-        content: '<p>Test data set 1 content</p>',
+        content: 'Test data set 1 content',
         geographicLevels: ['Local authority', 'National'],
         timePeriods: {
           from: '2018',
@@ -46,7 +46,7 @@ describe('ReleaseDataGuidanceSection', () => {
         fileId: 'file-2',
         name: 'Data set 2',
         filename: 'data-2.csv',
-        content: '<p>Test data set 2 content</p>',
+        content: 'Test data set 2 content',
         geographicLevels: ['Regional', 'Ward'],
         timePeriods: {
           from: '2020',
@@ -154,7 +154,7 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       expect(dataSet1.getByLabelText('File guidance content')).toHaveValue(
-        '<p>Test data set 1 content</p>',
+        'Test data set 1 content',
       );
 
       await user.click(
@@ -202,7 +202,7 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       expect(dataSet2.getByLabelText('File guidance content')).toHaveValue(
-        '<p>Test data set 2 content</p>',
+        'Test data set 2 content',
       );
 
       await user.click(
@@ -291,14 +291,8 @@ describe('ReleaseDataGuidanceSection', () => {
         dataSet1.queryByLabelText('File guidance content'),
       ).not.toBeInTheDocument();
 
-      expect(
-        dataSet1.getByTestId('fileGuidanceContent').innerHTML,
-      ).toMatchInlineSnapshot(
-        `
-        <p>
-          Test data set 1 content
-        </p>
-      `,
+      expect(dataSet1.getByTestId('fileGuidanceContent')).toHaveTextContent(
+        'Test data set 1 content',
       );
 
       await user.click(
@@ -349,14 +343,8 @@ describe('ReleaseDataGuidanceSection', () => {
         dataSet2.queryByLabelText('File guidance content'),
       ).not.toBeInTheDocument();
 
-      expect(
-        dataSet2.getByTestId('fileGuidanceContent').innerHTML,
-      ).toMatchInlineSnapshot(
-        `
-        <p>
-          Test data set 2 content
-        </p>
-      `,
+      expect(dataSet2.getByTestId('fileGuidanceContent')).toHaveTextContent(
+        'Test data set 2 content',
       );
 
       await user.click(
@@ -762,12 +750,9 @@ describe('ReleaseDataGuidanceSection', () => {
         '2018 to 2019',
       );
 
-      expect(dataSet1.getByTestId('fileGuidanceContent').innerHTML)
-        .toMatchInlineSnapshot(`
-              <p>
-                Test data set 1 content
-              </p>
-          `);
+      expect(dataSet1.getByTestId('fileGuidanceContent')).toHaveTextContent(
+        'Test data set 1 content',
+      );
 
       await user.click(
         dataSet1.getByText(/Variable names and descriptions/, {
@@ -813,12 +798,9 @@ describe('ReleaseDataGuidanceSection', () => {
         '2020 to 2021',
       );
 
-      expect(dataSet2.getByTestId('fileGuidanceContent').innerHTML)
-        .toMatchInlineSnapshot(`
-              <p>
-                Test data set 2 content
-              </p>
-          `);
+      expect(dataSet2.getByTestId('fileGuidanceContent')).toHaveTextContent(
+        'Test data set 2 content',
+      );
 
       await user.click(
         dataSet2.getByRole('button', {

--- a/src/explore-education-statistics-common/src/components/PlainTextContent.tsx
+++ b/src/explore-education-statistics-common/src/components/PlainTextContent.tsx
@@ -1,0 +1,30 @@
+import classNames from 'classnames';
+import React from 'react';
+
+export interface PlainTextContentProps {
+  className?: string;
+  testId?: string;
+  text: string;
+}
+
+/**
+ * Renders a plain text field, preserving the line breaks the author entered.
+ *
+ * Use this instead of `ContentHtml` for fields that hold plain text rather than HTML. Passing plain text
+ * through `ContentHtml` both loses its line breaks and mangles any `<` or `&` it contains, as those are
+ * parsed as markup.
+ */
+export default function PlainTextContent({
+  className,
+  testId,
+  text,
+}: PlainTextContentProps) {
+  return (
+    <div
+      className={classNames('dfe-white-space--pre-wrap', className)}
+      data-testid={testId}
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ReleaseDataListItem.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ReleaseDataListItem.tsx
@@ -25,7 +25,7 @@ export default function ReleaseDataListItem({
         {tag}
         {metaInfo && <p className="govuk-!-margin-bottom-1">{metaInfo}</p>}
         {description && (
-          <p className="dfe-colour--dark-grey govuk-!-margin-bottom-0">
+          <p className="dfe-colour--dark-grey govuk-!-margin-bottom-0 dfe-white-space--pre-wrap">
             {description}
           </p>
         )}

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
@@ -1,5 +1,6 @@
 import Details from '@common/components/Details';
 import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import { DataSetDataGuidance } from '@common/types/releaseDataGuidance';
@@ -45,7 +46,7 @@ const ReleaseDataGuidanceDataFile = ({ dataSet, renderContent }: Props) => {
 
     return (
       <SummaryListItem term="Content">
-        <ContentHtml html={dataSet.content} testId="fileGuidanceContent" />
+        <PlainTextContent text={dataSet.content} testId="fileGuidanceContent" />
       </SummaryListItem>
     );
   }, [renderContent, dataSet]);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetDetailsList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetDetailsList.tsx
@@ -1,4 +1,4 @@
-import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import CollapsibleList from '@common/components/CollapsibleList';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
@@ -60,7 +60,7 @@ export default function DataSetDetailsList({ subject }: Props) {
       )}
       {content && (
         <SummaryListItem term="Content">
-          <ContentHtml html={content} />
+          <PlainTextContent text={content} />
         </SummaryListItem>
       )}
     </SummaryList>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
@@ -16,7 +16,7 @@ describe('DataSetStep', () => {
     {
       id: 'subject-1',
       name: 'Subject 1',
-      content: '<p>Test content 1</p>',
+      content: 'Test content 1',
       timePeriods: {
         from: '2018/19',
         to: '2020/21',
@@ -37,7 +37,7 @@ describe('DataSetStep', () => {
     {
       id: 'subject-2',
       name: 'Subject 2',
-      content: '<p>Test content 2</p>',
+      content: 'Test content 2',
       timePeriods: {
         from: '2015',
         to: '2020',
@@ -133,11 +133,9 @@ describe('DataSetStep', () => {
     expect(radios[1]).toEqual(screen.getByLabelText('Subject 2'));
 
     const subject1Hint = within(getDescribedBy(radios[0]));
-    expect(
-      within(subject1Hint.getByTestId('Content')).getByText('Test content 1', {
-        selector: 'p',
-      }),
-    ).toBeInTheDocument();
+    expect(subject1Hint.getByTestId('Content')).toHaveTextContent(
+      'Test content 1',
+    );
     expect(subject1Hint.getByTestId('Geographic levels')).toHaveTextContent(
       'Local Authority District; Ward',
     );
@@ -159,11 +157,9 @@ describe('DataSetStep', () => {
     expect(filters1[0]).toHaveTextContent('School type');
 
     const subject2Hint = within(getDescribedBy(radios[1]));
-    expect(
-      within(subject2Hint.getByTestId('Content')).getByText('Test content 2', {
-        selector: 'p',
-      }),
-    ).toBeInTheDocument();
+    expect(subject2Hint.getByTestId('Content')).toHaveTextContent(
+      'Test content 2',
+    );
     expect(subject2Hint.getByTestId('Geographic levels')).toHaveTextContent(
       'Local Authority; National',
     );
@@ -483,11 +479,7 @@ describe('DataSetStep', () => {
       screen.getByRole('heading', { name: 'Data set details' }),
     ).toBeInTheDocument();
 
-    expect(
-      within(screen.getByTestId('Content')).getByText('Test content 1', {
-        selector: 'p',
-      }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('Content')).toHaveTextContent('Test content 1');
     expect(screen.getByTestId('Geographic levels')).toHaveTextContent(
       'Local Authority District; Ward',
     );

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -1,5 +1,5 @@
 import Button from '@common/components/Button';
-import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import FormattedDate from '@common/components/FormattedDate';
 import PageNav, { NavItem } from '@common/components/PageNav';
 import SectionBreak from '@common/components/SectionBreak';
@@ -230,7 +230,7 @@ export default function DataSetFilePage({
           </div>
 
           <div className={styles.subscribeContainer}>
-            <ContentHtml className="dfe-flex-grow--1" html={summary} />
+            <PlainTextContent className="dfe-flex-grow--1" text={summary} />
             {apiDataSet && (
               <SubscribeLink
                 url={`/api-subscriptions/new-subscription/${dataSetFile.id}`}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -1,7 +1,7 @@
 import AccordionToggleButton from '@common/components/AccordionToggleButton';
 import ButtonText from '@common/components/ButtonText';
 import CollapsibleList from '@common/components/CollapsibleList';
-import ContentHtml from '@common/components/ContentHtml';
+import PlainTextContent from '@common/components/PlainTextContent';
 import FormattedDate from '@common/components/FormattedDate';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
@@ -107,12 +107,12 @@ export default function DataSetFileSummary({
         </Link>,
       )}
 
-      <ContentHtml
+      <PlainTextContent
         className={classNames({
           [styles.content]: truncateContent,
           [styles.expanded]: showMoreContent,
         })}
-        html={content}
+        text={content}
       />
 
       {truncateContent && (


### PR DESCRIPTION
EES-4353 made the data guidance content field plain teext but didn't migrate existing summaries. This PR adds a temporary endpoint that performs a migration (Dry run using GET, execute migration using PUT) which strips HTML from the field where it finds there is HTML. 
We've used this way of migrating data before because
- it lets us review real before/after content before writing anything
- T-SQL can't reproduce `HtmlToTextUtils`, so a SQL migration would change displayed text
- an `ICustomMigration` has no applied-record and would re-run on every deploy forever

I have created a ticket EES-7620 which is there to delete this endpoint after it's been used.