### PR TITLE
EES-7619 Fetch data set geographic levels from DataSetFileVersionGeog…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
@@ -430,6 +430,61 @@ public class DataGuidanceFileWriterTests : IDisposable
     }
 
     [Fact]
+    public async Task WriteToStream_FileWithCsvOnlyGeographicLevels()
+    {
+        ReleaseVersion releaseVersion = _dataFixture
+            .DefaultReleaseVersion()
+            .WithRelease(_dataFixture.DefaultRelease().WithPublication(_dataFixture.DefaultPublication()))
+            .WithDataGuidance(TestBasicDataGuidance);
+
+        var dataSets = new List<DataGuidanceDataSetViewModel>
+        {
+            new()
+            {
+                Filename = "test-1.csv",
+                Name = "Test data 1",
+                Content = "<p>Test file content</p>",
+                GeographicLevels = new List<string> { "Local authority", "National", "Ward" },
+                GeographicLevelsCsvOnly = new List<string> { "School" },
+                TimePeriods = new TimePeriodLabels("2018", "2018"),
+                Variables = new List<LabelValue> { new("Accommodation type", "accommodation_type") },
+                Footnotes = new List<FootnoteViewModel> { new(Guid.NewGuid(), "Footnote 1") },
+            },
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
+
+        dataGuidanceDataSetService
+            .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
+            .ReturnsAsync(dataSets);
+
+        await using (var contentDbContext = InMemoryContentDbContext(contextId))
+        {
+            await contentDbContext.Entry(releaseVersion).ReloadAsync();
+
+            var writer = BuildDataGuidanceFileWriter(
+                contentDbContext: contentDbContext,
+                dataGuidanceDataSetService: dataGuidanceDataSetService.Object
+            );
+
+            await using var stream = new MemoryStream();
+            await writer.WriteToStream(stream, releaseVersion);
+
+            Snapshot.Match(stream.ReadToEnd());
+        }
+
+        VerifyAllMocks(dataGuidanceDataSetService);
+    }
+
+    [Fact]
     public async Task WriteToStream_FileWithEmptyProperties()
     {
         ReleaseVersion releaseVersion = _dataFixture

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithCsvOnlyGeographicLevels.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithCsvOnlyGeographicLevels.snap
@@ -1,0 +1,23 @@
+﻿Publication 0 :: Title
+Academic year 2000/01
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv
+Geographic levels: Local authority; National; School; Ward
+Time period: 2018
+Content summary: Test file content
+
+Variable names and descriptions for this file are provided below:
+
+Variable name       |  Variable description
+------------------  |  ------------------
+accommodation_type  |  Accommodation type
+
+Footnotes:
+
+1. Footnote 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -109,9 +109,14 @@ public class DataGuidanceFileWriter : IDataGuidanceFileWriter
 
                     await file.WriteLineAsync("Filename: " + dataSet.Filename);
 
-                    if (dataSet.GeographicLevels.Any())
+                    var geographicLevels = dataSet
+                        .GeographicLevels.Concat(dataSet.GeographicLevelsCsvOnly)
+                        .Order()
+                        .ToList();
+
+                    if (geographicLevels.Any())
                     {
-                        await file.WriteLineAsync("Geographic levels: " + string.Join("; ", dataSet.GeographicLevels));
+                        await file.WriteLineAsync("Geographic levels: " + string.Join("; ", geographicLevels));
                     }
 
                     var timePeriodsLabel = dataSet.TimePeriods.ToLabel();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceDataSetServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/DataGuidanceDataSetServiceTests.cs
@@ -210,6 +210,13 @@ public class DataGuidanceDataSetServiceTests
                 SubjectId = subject1.Id,
                 Filename = "file1.csv",
                 Type = FileType.Data,
+                DataSetFileVersionGeographicLevels =
+                [
+                    new() { GeographicLevel = GeographicLevel.Country },
+                    new() { GeographicLevel = GeographicLevel.LocalAuthority },
+                    new() { GeographicLevel = GeographicLevel.LocalAuthorityDistrict },
+                    new() { GeographicLevel = GeographicLevel.School, CsvOnly = true },
+                ],
             },
             Summary = "Data set 1 guidance",
         };
@@ -223,6 +230,11 @@ public class DataGuidanceDataSetServiceTests
                 SubjectId = subject2.Id,
                 Filename = "file2.csv",
                 Type = FileType.Data,
+                DataSetFileVersionGeographicLevels =
+                [
+                    new() { GeographicLevel = GeographicLevel.Country },
+                    new() { GeographicLevel = GeographicLevel.Region },
+                ],
             },
             Summary = "Data set 2 guidance",
         };
@@ -254,9 +266,10 @@ public class DataGuidanceDataSetServiceTests
             Assert.Equal("2020/21 Q3", result[0].TimePeriods.From);
             Assert.Equal("2021/22 Q1", result[0].TimePeriods.To);
             Assert.Equal(
-                new List<string> { "National", "Local authority", "Local authority district" },
+                new List<string> { "Local authority", "Local authority district", "National" },
                 result[0].GeographicLevels
             );
+            Assert.Equal(new List<string> { "School" }, result[0].GeographicLevelsCsvOnly);
 
             Assert.Equal(2, result[0].Variables.Count);
             Assert.Equal("Subject 1 Filter - Hint", result[0].Variables[0].Label);
@@ -280,6 +293,7 @@ public class DataGuidanceDataSetServiceTests
             Assert.Equal("2020/21 Summer term", result[1].TimePeriods.From);
             Assert.Equal("2021/22 Spring term", result[1].TimePeriods.To);
             Assert.Equal(new List<string> { "National", "Regional" }, result[1].GeographicLevels);
+            Assert.Empty(result[1].GeographicLevelsCsvOnly);
 
             Assert.Equal(2, result[1].Variables.Count);
             Assert.Equal("Subject 2 Filter", result[1].Variables[0].Label);
@@ -697,92 +711,6 @@ public class DataGuidanceDataSetServiceTests
             Assert.Empty(version2ViewModels[1].TimePeriods.To);
             Assert.Empty(version2ViewModels[1].GeographicLevels);
             Assert.Empty(version2ViewModels[1].Variables);
-        }
-    }
-
-    [Fact]
-    public async Task ListGeographicLevels()
-    {
-        var releaseVersion = new ReleaseVersion();
-
-        var subject = new Subject();
-
-        var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
-
-        var subjectObservation1 = new Observation
-        {
-            Location = new Location { GeographicLevel = GeographicLevel.Country },
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = TimeIdentifier.AcademicYearQ3,
-        };
-
-        var subjectObservation2 = new Observation
-        {
-            Location = new Location { GeographicLevel = GeographicLevel.LocalAuthority },
-            Subject = subject,
-            Year = 2020,
-            TimeIdentifier = TimeIdentifier.AcademicYearQ4,
-        };
-
-        var subjectObservation3 = new Observation
-        {
-            Location = new Location { GeographicLevel = GeographicLevel.LocalAuthorityDistrict },
-            Subject = subject,
-            Year = 2021,
-            TimeIdentifier = TimeIdentifier.AcademicYearQ1,
-        };
-
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            statisticsDbContext.ReleaseVersion.AddRange(releaseVersion);
-            statisticsDbContext.Subject.AddRange(subject);
-            statisticsDbContext.ReleaseSubject.AddRange(releaseSubject);
-            statisticsDbContext.Observation.AddRange(subjectObservation1, subjectObservation2, subjectObservation3);
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = SetupService(statisticsDbContext: statisticsDbContext);
-
-            var result = await service.ListGeographicLevels(subject.Id);
-
-            Assert.Equal(3, result.Count);
-            Assert.Equal("National", result[0]);
-            Assert.Equal("Local authority", result[1]);
-            Assert.Equal("Local authority district", result[2]);
-        }
-    }
-
-    [Fact]
-    public async Task ListGeographicLevels_NoObservations()
-    {
-        var releaseVersion = new ReleaseVersion();
-
-        var subject = new Subject();
-
-        var releaseSubject = new ReleaseSubject { ReleaseVersion = releaseVersion, Subject = subject };
-
-        var statisticsDbContextId = Guid.NewGuid().ToString();
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            statisticsDbContext.ReleaseVersion.AddRange(releaseVersion);
-            statisticsDbContext.Subject.AddRange(subject);
-            statisticsDbContext.ReleaseSubject.AddRange(releaseSubject);
-            await statisticsDbContext.SaveChangesAsync();
-        }
-
-        await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-        {
-            var service = SetupService(statisticsDbContext: statisticsDbContext);
-
-            var result = await service.ListGeographicLevels(subject.Id);
-
-            Assert.Empty(result);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
@@ -34,7 +34,6 @@ public class ReleaseServicePermissionTests
         IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
         StatisticsDbContext? statisticsDbContext = null,
         IUserService? userService = null,
-        IDataGuidanceDataSetService? dataGuidanceDataSetService = null,
         ITimePeriodService? timePeriodService = null
     )
     {
@@ -43,7 +42,6 @@ public class ReleaseServicePermissionTests
             persistenceHelper ?? DefaultPersistenceHelperMock().Object,
             statisticsDbContext ?? Mock.Of<StatisticsDbContext>(),
             userService ?? Mock.Of<IUserService>(),
-            dataGuidanceDataSetService ?? Mock.Of<IDataGuidanceDataSetService>(),
             timePeriodService ?? Mock.Of<ITimePeriodService>()
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -103,6 +104,12 @@ public class ReleaseServiceTests
                 ContentLength = 10240,
                 Type = FileType.Data,
                 SubjectId = releaseSubject1.Subject.Id,
+                DataSetFileVersionGeographicLevels =
+                [
+                    new() { GeographicLevel = GeographicLevel.LocalAuthority },
+                    new() { GeographicLevel = GeographicLevel.LocalAuthorityDistrict },
+                    new() { GeographicLevel = GeographicLevel.School, CsvOnly = true },
+                ],
             },
             Summary = "Data set 1 guidance",
         };
@@ -117,6 +124,7 @@ public class ReleaseServiceTests
                 ContentLength = 20480,
                 Type = FileType.Data,
                 SubjectId = releaseSubject2.Subject.Id,
+                DataSetFileVersionGeographicLevels = [new() { GeographicLevel = GeographicLevel.Country }],
             },
             Summary = "Data set 2 guidance",
         };
@@ -136,7 +144,6 @@ public class ReleaseServiceTests
         await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
         await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
         {
-            var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
             var timePeriodService = new Mock<ITimePeriodService>(Strict);
 
             timePeriodService
@@ -147,24 +154,15 @@ public class ReleaseServiceTests
                 .Setup(s => s.GetTimePeriodLabels(releaseSubject2.SubjectId))
                 .ReturnsAsync(new TimePeriodLabels("2030", "2031"));
 
-            dataGuidanceDataSetService
-                .Setup(s => s.ListGeographicLevels(releaseSubject1.SubjectId, default))
-                .ReturnsAsync(ListOf("Local Authority", "Local Authority District"));
-
-            dataGuidanceDataSetService
-                .Setup(s => s.ListGeographicLevels(releaseSubject2.SubjectId, default))
-                .ReturnsAsync(ListOf("National"));
-
             var service = BuildReleaseService(
                 contentDbContext: contentDbContext,
                 statisticsDbContext: statisticsDbContext,
-                dataGuidanceDataSetService: dataGuidanceDataSetService.Object,
                 timePeriodService: timePeriodService.Object
             );
 
             var result = await service.ListSubjects(contentReleaseVersion.Id);
 
-            MockUtils.VerifyAllMocks(dataGuidanceDataSetService, timePeriodService);
+            MockUtils.VerifyAllMocks(timePeriodService);
 
             var subjects = result.AssertRight();
 
@@ -182,8 +180,8 @@ public class ReleaseServiceTests
             Assert.Equal("2021/22", subjects[0].TimePeriods.To);
 
             Assert.Equal(2, subjects[0].GeographicLevels.Count);
-            Assert.Equal("Local Authority", subjects[0].GeographicLevels[0]);
-            Assert.Equal("Local Authority District", subjects[0].GeographicLevels[1]);
+            Assert.Equal("Local authority", subjects[0].GeographicLevels[0]);
+            Assert.Equal("Local authority district", subjects[0].GeographicLevels[1]);
 
             Assert.Equal(2, subjects[0].Filters.Count);
             Assert.Equal("subject 1 filter 1", subjects[0].Filters[0]);
@@ -392,12 +390,7 @@ public class ReleaseServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
-
-        dataGuidanceDataSetService
-            .Setup(s => s.ListGeographicLevels(It.IsAny<Guid>(), default))
-            .ReturnsAsync(new List<string>());
 
         timePeriodService.Setup(s => s.GetTimePeriodLabels(It.IsAny<Guid>())).ReturnsAsync(new TimePeriodLabels());
 
@@ -407,7 +400,6 @@ public class ReleaseServiceTests
             var service = BuildReleaseService(
                 contentDbContext: contentDbContext,
                 statisticsDbContext: statisticsDbContext,
-                dataGuidanceDataSetService: dataGuidanceDataSetService.Object,
                 timePeriodService: timePeriodService.Object
             );
 
@@ -489,12 +481,7 @@ public class ReleaseServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
-
-        dataGuidanceDataSetService
-            .Setup(s => s.ListGeographicLevels(It.IsAny<Guid>(), default))
-            .ReturnsAsync(new List<string>());
 
         timePeriodService.Setup(s => s.GetTimePeriodLabels(It.IsAny<Guid>())).ReturnsAsync(new TimePeriodLabels());
 
@@ -504,7 +491,6 @@ public class ReleaseServiceTests
             var service = BuildReleaseService(
                 contentDbContext: contentDbContext,
                 statisticsDbContext: statisticsDbContext,
-                dataGuidanceDataSetService: dataGuidanceDataSetService.Object,
                 timePeriodService: timePeriodService.Object
             );
 
@@ -689,12 +675,7 @@ public class ReleaseServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
-
-        dataGuidanceDataSetService
-            .Setup(s => s.ListGeographicLevels(It.IsAny<Guid>(), default))
-            .ReturnsAsync(new List<string>());
 
         timePeriodService.Setup(s => s.GetTimePeriodLabels(It.IsAny<Guid>())).ReturnsAsync(new TimePeriodLabels());
 
@@ -704,7 +685,6 @@ public class ReleaseServiceTests
             var service = BuildReleaseService(
                 contentDbContext: contentDbContext,
                 statisticsDbContext: statisticsDbContext,
-                dataGuidanceDataSetService: dataGuidanceDataSetService.Object,
                 timePeriodService: timePeriodService.Object
             );
 
@@ -788,12 +768,7 @@ public class ReleaseServiceTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
         var timePeriodService = new Mock<ITimePeriodService>(Strict);
-
-        dataGuidanceDataSetService
-            .Setup(s => s.ListGeographicLevels(It.IsAny<Guid>(), default))
-            .ReturnsAsync(new List<string>());
 
         timePeriodService.Setup(s => s.GetTimePeriodLabels(It.IsAny<Guid>())).ReturnsAsync(new TimePeriodLabels());
 
@@ -803,7 +778,6 @@ public class ReleaseServiceTests
             var service = BuildReleaseService(
                 contentDbContext: contentDbContext,
                 statisticsDbContext: statisticsDbContext,
-                dataGuidanceDataSetService: dataGuidanceDataSetService.Object,
                 timePeriodService: timePeriodService.Object
             );
 
@@ -1145,7 +1119,6 @@ public class ReleaseServiceTests
         IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
         StatisticsDbContext? statisticsDbContext = null,
         IUserService? userService = null,
-        IDataGuidanceDataSetService? dataGuidanceDataSetService = null,
         ITimePeriodService? timePeriodService = null
     )
     {
@@ -1154,7 +1127,6 @@ public class ReleaseServiceTests
             persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
             statisticsDbContext ?? Mock.Of<StatisticsDbContext>(),
             userService ?? MockUtils.AlwaysTrueUserService().Object,
-            dataGuidanceDataSetService ?? Mock.Of<IDataGuidanceDataSetService>(Strict),
             timePeriodService ?? Mock.Of<ITimePeriodService>(Strict)
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/DataGuidanceDataSetService.cs
@@ -51,6 +51,7 @@ public class DataGuidanceDataSetService : IDataGuidanceDataSetService
             {
                 var releaseFilesQueryable = _contentDbContext
                     .ReleaseFiles.Include(rf => rf.File)
+                        .ThenInclude(f => f.DataSetFileVersionGeographicLevels)
                     .Where(rf =>
                         rf.ReleaseVersionId == releaseVersionId
                         && rf.File.Type == FileType.Data
@@ -68,33 +69,16 @@ public class DataGuidanceDataSetService : IDataGuidanceDataSetService
                     {
                         var subjectId = releaseFile.File.SubjectId!.Value;
 
-                        var geographicLevels = await ListGeographicLevels(subjectId, cancellationToken);
                         var timePeriods = await _timePeriodService.GetTimePeriodLabels(subjectId);
                         var variables = await ListVariables(subjectId, cancellationToken);
                         var footnotes = await ListFootnotes(releaseVersionId: releaseVersionId, subjectId: subjectId);
 
-                        return BuildDataGuidanceDataSetViewModel(
-                            releaseFile,
-                            geographicLevels,
-                            timePeriods,
-                            variables,
-                            footnotes
-                        );
+                        return BuildDataGuidanceDataSetViewModel(releaseFile, timePeriods, variables, footnotes);
                     })
                     .OrderBy(viewModel => viewModel.Order)
                     .ThenBy(viewModel => viewModel.Name) // For data sets existing before ordering was added
                     .ToListAsync(cancellationToken);
             });
-    }
-
-    public async Task<List<string>> ListGeographicLevels(Guid subjectId, CancellationToken cancellationToken = default)
-    {
-        return await _statisticsDbContext
-            .Observation.AsNoTracking()
-            .Where(o => o.SubjectId == subjectId)
-            .Select(observation => observation.Location.GeographicLevel.GetEnumLabel())
-            .Distinct()
-            .ToListAsync(cancellationToken);
     }
 
     private async Task<List<LabelValue>> ListVariables(Guid subjectId, CancellationToken cancellationToken = default)
@@ -125,7 +109,6 @@ public class DataGuidanceDataSetService : IDataGuidanceDataSetService
 
     private static DataGuidanceDataSetViewModel BuildDataGuidanceDataSetViewModel(
         ReleaseFile releaseFile,
-        List<string> geographicLevels,
         TimePeriodLabels timePeriods,
         List<LabelValue> variables,
         List<FootnoteViewModel> footnotes
@@ -138,7 +121,16 @@ public class DataGuidanceDataSetService : IDataGuidanceDataSetService
             Filename = releaseFile.File.Filename,
             Order = releaseFile.Order,
             Name = releaseFile.Name ?? "",
-            GeographicLevels = geographicLevels,
+            GeographicLevels = releaseFile
+                .File.DataSetFileVersionGeographicLevels.Where(level => level.CsvOnly != true) // TODO EES-7584 update once CsvOnly isn't nullable
+                .Select(level => level.GeographicLevel.GetEnumLabel())
+                .Order()
+                .ToList(),
+            GeographicLevelsCsvOnly = releaseFile
+                .File.DataSetFileVersionGeographicLevels.Where(level => level.CsvOnly == true) // TODO EES-7584 update once CsvOnly isn't nullable
+                .Select(level => level.GeographicLevel.GetEnumLabel())
+                .Order()
+                .ToList(),
             TimePeriods = timePeriods,
             Variables = variables,
             Footnotes = footnotes,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IDataGuidanceDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IDataGuidanceDataSetService.cs
@@ -12,6 +12,4 @@ public interface IDataGuidanceDataSetService
         IList<Guid>? dataFileIds = null,
         CancellationToken cancellationToken = default
     );
-
-    Task<List<string>> ListGeographicLevels(Guid subjectId, CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -24,7 +24,6 @@ public class ReleaseService : IReleaseService
     private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
     private readonly StatisticsDbContext _statisticsDbContext;
     private readonly IUserService _userService;
-    private readonly IDataGuidanceDataSetService _dataGuidanceDataSetService;
     private readonly ITimePeriodService _timePeriodService;
 
     public ReleaseService(
@@ -32,7 +31,6 @@ public class ReleaseService : IReleaseService
         IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
         StatisticsDbContext statisticsDbContext,
         IUserService userService,
-        IDataGuidanceDataSetService dataGuidanceDataSetService,
         ITimePeriodService timePeriodService
     )
     {
@@ -40,7 +38,6 @@ public class ReleaseService : IReleaseService
         _contentPersistenceHelper = contentPersistenceHelper;
         _statisticsDbContext = statisticsDbContext;
         _userService = userService;
-        _dataGuidanceDataSetService = dataGuidanceDataSetService;
         _timePeriodService = timePeriodService;
     }
 
@@ -100,7 +97,7 @@ public class ReleaseService : IReleaseService
                     order: releaseFile.Order,
                     content: releaseFile.Summary ?? string.Empty,
                     timePeriods: await _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
-                    geographicLevels: await _dataGuidanceDataSetService.ListGeographicLevels(rs.SubjectId),
+                    geographicLevels: await GetGeographicLevels(rs.SubjectId),
                     filters: await GetFilters(rs.SubjectId, releaseFile.FilterSequence),
                     indicators: await GetIndicators(rs.SubjectId, releaseFile.IndicatorSequence),
                     file: releaseFile.ToFileInfo(),
@@ -109,6 +106,19 @@ public class ReleaseService : IReleaseService
             })
         ).OrderBy(svm => svm.Order).ThenBy(svm => svm.Name) // For subjects existing before ordering was added
         .ToList();
+    }
+
+    private async Task<List<string>> GetGeographicLevels(Guid subjectId, bool csvOnly = false)
+    {
+        var geographicLevels = await _contentDbContext
+            .Files.AsNoTracking()
+            .Where(file => file.SubjectId == subjectId && file.Type == FileType.Data)
+            .SelectMany(file => file.DataSetFileVersionGeographicLevels)
+            .Where(gl => (gl.CsvOnly == true) == csvOnly) // TODO EES-7584 update once CsvOnly isn't nullable
+            .Select(gl => gl.GeographicLevel)
+            .ToListAsync();
+
+        return geographicLevels.Select(gl => gl.GetEnumLabel()).Order().ToList();
     }
 
     private async Task<List<string>> GetFilters(Guid subjectId, List<FilterSequenceEntry>? filterSequence)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/DataGuidanceDataSetViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/DataGuidanceDataSetViewModel.cs
@@ -18,6 +18,8 @@ public record DataGuidanceDataSetViewModel
 
     public List<string> GeographicLevels { get; init; } = new();
 
+    public List<string> GeographicLevelsCsvOnly { get; init; } = new();
+
     public List<LabelValue> Variables { get; init; } = new();
 
     public List<FootnoteViewModel> Footnotes { get; init; } = new();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -23,6 +23,7 @@ describe('ReleaseDataGuidanceSection', () => {
         filename: 'data-1.csv',
         content: '<p>Test data set 1 content</p>',
         geographicLevels: ['Local authority', 'National'],
+        geographicLevelsCsvOnly: ['School'],
         timePeriods: {
           from: '2018',
           to: '2019',
@@ -48,6 +49,7 @@ describe('ReleaseDataGuidanceSection', () => {
         filename: 'data-2.csv',
         content: '<p>Test data set 2 content</p>',
         geographicLevels: ['Regional', 'Ward'],
+        geographicLevelsCsvOnly: [],
         timePeriods: {
           from: '2020',
           to: '2021',

--- a/src/explore-education-statistics-common/src/types/releaseDataGuidance.ts
+++ b/src/explore-education-statistics-common/src/types/releaseDataGuidance.ts
@@ -8,6 +8,7 @@ export interface DataSetDataGuidance {
     to: string;
   };
   geographicLevels: string[];
+  geographicLevelsCsvOnly: string[];
   variables: {
     label: string;
     value: string;


### PR DESCRIPTION
…raphicLevels

This PR prepares the way for EES-7358 by ensuring the across the service, when we fetch geographic levels, they're fetched from the DataSetFileVersionGeographicLevels table. Before this PR, data guidance fetched geographic levels directly from observations, which don't contain a data set's CsvOnly geographic levels.

CsvOnly geographic levels will be exposed on the frontend in EES-7358, so we mostly don't do that in this PR, except for data-guidance.txt which is included in zip downloads, which now includes all geographic levels in the CSVs.

### Other changes
- Geographic levels are now sorted alphabetically. This change led to a new ticket to order geographic levels by scale (EES-7621).