### PR TITLE
Hotfix EES-7570 - again

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       govuk-frontend:
-        specifier: ^6.4.0
-        version: 6.4.0
+        specifier: ^6.3.0
+        version: 6.3.0
       history:
         specifier: ^4.10.1
         version: 4.10.1
@@ -562,8 +562,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       govuk-frontend:
-        specifier: ^6.4.0
-        version: 6.4.0
+        specifier: ^6.3.0
+        version: 6.3.0
       html-react-parser:
         specifier: ^5.2.17
         version: 5.2.17(@types/react@19.2.18)(react@19.2.7)
@@ -791,8 +791,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       govuk-frontend:
-        specifier: ^6.4.0
-        version: 6.4.0
+        specifier: ^6.3.0
+        version: 6.3.0
       helmet:
         specifier: ^4.1.1
         version: 4.6.0
@@ -7380,8 +7380,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  govuk-frontend@6.4.0:
-    resolution: {integrity: sha512-jU3oaVFXqK1yDVIdZs1YZ6JD7YDB4PFUHF3rFMWJye9ArImp42F9wCsFzzB1+udjuzGCryJGcHHbBQ5HY+8rqQ==}
+  govuk-frontend@6.3.0:
+    resolution: {integrity: sha512-cXIQxm5PHCsbic47GXZrVBZhAeeshTLRL6ZBKilLsR6rMCjJuWb7Fruq0VUNMBJFlJk/srsRj/q8d5bM9cgKoA==}
     engines: {node: '>= 4.2.0'}
 
   graceful-fs@4.2.11:
@@ -16007,7 +16007,7 @@ snapshots:
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
-      '@jest/reporters': 30.4.1(supports-color@8.1.1)
+      '@jest/reporters': 30.4.1(supports-color@10.2.2)
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(supports-color@10.2.2)
       '@jest/types': 30.4.1
@@ -16110,7 +16110,7 @@ snapshots:
       '@types/node': 22.19.7
       jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.4.1(supports-color@8.1.1)':
+  '@jest/reporters@30.4.1(supports-color@10.2.2)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 30.4.1
@@ -16127,7 +16127,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3(supports-color@10.2.2)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
+      istanbul-lib-source-maps: 5.0.6(supports-color@10.2.2)
       istanbul-reports: 3.2.0
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -20867,7 +20867,7 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  govuk-frontend@6.4.0: {}
+  govuk-frontend@6.3.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -21568,10 +21568,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
+  istanbul-lib-source-maps@5.0.6(supports-color@10.2.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -20,7 +20,7 @@
     "explore-education-statistics-ckeditor": "workspace:*",
     "explore-education-statistics-common": "workspace:*",
     "geojson": "^0.5.0",
-    "govuk-frontend": "^6.4.0",
+    "govuk-frontend": "^6.3.0",
     "history": "^4.10.1",
     "immer": "^10.2.0",
     "leaflet": "^1.9.4",

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -18,7 +18,7 @@
     "date-fns-tz": "^3.2.0",
     "domhandler": "^5.0.3",
     "geojson": "^0.5.0",
-    "govuk-frontend": "^6.4.0",
+    "govuk-frontend": "^6.3.0",
     "html-react-parser": "^5.2.17",
     "html2canvas": "^1.4.1",
     "identity-obj-proxy": "^3.0.0",

--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -109,6 +109,7 @@ const nextConfig = {
 
     return config;
   },
+  sassOptions: { charset: false }, // prod CSS was breaking due to BOMs being included in the middle of files
   transpilePackages:
     process.env.NEXT_CONFIG_MODE !== 'server'
       ? ['explore-education-statistics-common']

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -20,7 +20,7 @@
     "explore-education-statistics-common": "workspace:*",
     "express": "^4.22.2",
     "express-basic-auth": "^1.2.1",
-    "govuk-frontend": "^6.4.0",
+    "govuk-frontend": "^6.3.0",
     "helmet": "^4.1.1",
     "immer": "^10.2.0",
     "leaflet": "^1.9.4",

--- a/src/explore-education-statistics-frontend/src/modules/home/components/HomePageMasthead.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/home/components/HomePageMasthead.module.scss
@@ -30,15 +30,7 @@
 
 .mastheadTitle {
   @include govuk-media-query($until: tablet) {
-    // N.b not using govuk-visually-hidden as it seems to break the prod css build
-    border: 0;
-    clip-path: inset(50%);
-    height: 1px;
-    margin: 0;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+    @include govuk-visually-hidden;
   }
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/home/components/HomePageMasthead.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/home/components/HomePageMasthead.module.scss
@@ -7,10 +7,14 @@
   --search-bar-input-size: 53px;
 
   background-color: govuk-colour('blue');
-  color: govuk-functional-colour('inverse-text');
+  color: govuk-colour('white');
 
   *:is(:link, :visited, h1, h2, label) {
-    color: govuk-functional-colour('inverse-text');
+    color: govuk-colour('white');
+  }
+
+  *:is(:link, :visited):focus {
+    color: govuk-functional-colour('focus-text');
   }
 
   :global(.autocomplete__input) {
@@ -39,5 +43,5 @@
 }
 
 .mastheadSubtitle {
-  color: govuk-functional-colour('inverse-text');
+  color: govuk-colour('white');
 }


### PR DESCRIPTION
Fixes a couple of issues we noticed before deploying to prod.

Reverted the govuk minor update as it caused the Notification Banner title to appear black instead of white ([the title now assumes colour inheritance from the notification banner header](https://github.com/alphagov/govuk-frontend/compare/v6.3.0...v6.4.0#diff-b3507960e470a94081d5bca8bcf7826a5c71da1a9f8d4f3cb739d473c2f0b8a8L41) but we are defining heading colours in our typography css, so it needs a wider fix)

Changed next config SASS compile option to not insert BOMs into the stylesheet, which caused certain rulesets to be ignored when parsed by the browser.