### PR TITLE
EES-7624 BOM fixing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,9 @@ indent_size = 4
 
 [*.sql]
 indent_size = 4
+
+# EES-7624: Save without a UTF-8 BOM: it is redundant in UTF-8 and breaks tooling
+# that treats the leading bytes as significant, such as concatenated CSS bundles
+# and JSON.parse.
+[*.{ts,tsx,js,jsx,scss,css}]
+charset = utf-8

--- a/src/explore-education-statistics-admin/config/webpack.config.js
+++ b/src/explore-education-statistics-admin/config/webpack.config.js
@@ -148,6 +148,14 @@ module.exports = webpackEnv => {
           loader: require.resolve(preProcessor),
           options: {
             sourceMap: true,
+            sassOptions: {
+              // EES-7624 Dart Sass prepends a UTF-8 BOM to any compiled stylesheet that
+              // contains non-ASCII characters Production builds concatenate the
+              // compiled modules into shared stylesheets, so the BOM ends up mid-file
+              // where it's a parse error - making the browser silently drop
+              // the rule that follows it.
+              charset: false,
+            },
           },
         },
       );

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/getContentErrors.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/getContentErrors.test.tsx
@@ -1,4 +1,4 @@
-﻿import { render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import checkMaxLength from '@admin/components/editable/utils/checkMaxLength';
 import getContentErrors from '@admin/components/editable/utils/getContentErrors';
 import getInvalidContent from '@admin/components/editable/utils/getInvalidContent';

--- a/src/explore-education-statistics-admin/src/components/editable/utils/getContentErrors.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/utils/getContentErrors.tsx
@@ -1,4 +1,4 @@
-﻿import React, { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import InvalidContentDetails from '@admin/components/editable/InvalidContentDetails';
 import checkMaxLength from '@admin/components/editable/utils/checkMaxLength';
 import getInvalidContent from '@admin/components/editable/utils/getInvalidContent';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementDifferencesTable.tsx
@@ -1,4 +1,4 @@
-﻿import startCase from 'lodash/startCase';
+import startCase from 'lodash/startCase';
 import TagGroup from '@common/components/TagGroup';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import React, { useMemo } from 'react';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementMappingCountsTag.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementMappingCountsTag.tsx
@@ -1,4 +1,4 @@
-﻿import Tag from '@common/components/Tag';
+import Tag from '@common/components/Tag';
 import React from 'react';
 import { TypeMapping } from '@admin/pages/release/data/components/DataFileReplacementDifferencesTable';
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
@@ -1,4 +1,4 @@
-﻿import _releaseDataFileService, {
+import _releaseDataFileService, {
   DataSetUpload,
 } from '@admin/services/releaseDataFileService';
 import render from '@common-test/render';

--- a/src/explore-education-statistics-admin/src/pages/release/data/types/PreviewTokenCreateValues.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/types/PreviewTokenCreateValues.ts
@@ -1,4 +1,4 @@
-﻿export interface PreviewTokenCreateValues {
+export interface PreviewTokenCreateValues {
   label: string;
   datePresetSpan?: number;
   activates?: Date;

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/previewTokenDateHelper.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/previewTokenDateHelper.test.tsx
@@ -1,4 +1,4 @@
-﻿import PreviewTokenDateHelper from '@admin/pages/release/data/utils/previewTokenDateHelper';
+import PreviewTokenDateHelper from '@admin/pages/release/data/utils/previewTokenDateHelper';
 import UkTimeHelper from '@common/utils/date/ukTimeHelper';
 import mockDate from '@common-test/mockDate';
 import { formatInTimeZone } from 'date-fns-tz';

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/previewTokenDateHelper.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/previewTokenDateHelper.ts
@@ -1,4 +1,4 @@
-﻿import { isToday } from 'date-fns';
+import { isToday } from 'date-fns';
 import UkTimeHelper, { DateRange } from '@common/utils/date/ukTimeHelper';
 
 export default class PreviewTokenDateHelper {

--- a/src/explore-education-statistics-common/src/styles/_header.scss
+++ b/src/explore-education-statistics-common/src/styles/_header.scss
@@ -1,4 +1,4 @@
-﻿@use '~govuk-frontend/dist/govuk/base' as *;
+@use '~govuk-frontend/dist/govuk/base' as *;
 
 // Legacy 5.x styles to add back header text and menus
 // mostly copied from the original govuk v5 library, with the rebrand overrides directly applied

--- a/src/explore-education-statistics-common/src/utils/__tests__/isPatchVersions.test.ts
+++ b/src/explore-education-statistics-common/src/utils/__tests__/isPatchVersions.test.ts
@@ -1,4 +1,4 @@
-﻿import isPatchVersion from '../isPatchVersion';
+import isPatchVersion from '../isPatchVersion';
 
 describe('isPatchVersion', () => {
   it('returns false for undefined', () => {

--- a/src/explore-education-statistics-common/src/utils/date/__tests__/ukTimeHelper.test.ts
+++ b/src/explore-education-statistics-common/src/utils/date/__tests__/ukTimeHelper.test.ts
@@ -1,4 +1,4 @@
-﻿import UkTimeHelper from '@common/utils/date/ukTimeHelper';
+import UkTimeHelper from '@common/utils/date/ukTimeHelper';
 
 describe('UkTimeHelper', () => {
   test('should return correct UK start of day in UTC during DST', () => {

--- a/src/explore-education-statistics-common/src/utils/date/ukTimeHelper.ts
+++ b/src/explore-education-statistics-common/src/utils/date/ukTimeHelper.ts
@@ -1,4 +1,4 @@
-﻿import { fromZonedTime, formatInTimeZone, toZonedTime } from 'date-fns-tz';
+import { fromZonedTime, formatInTimeZone, toZonedTime } from 'date-fns-tz';
 import { addDays, format } from 'date-fns';
 
 export type DateRange = { startDate: Date; endDate: Date };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/__tests__/sortPatchVersions.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/__tests__/sortPatchVersions.test.ts
@@ -1,4 +1,4 @@
-﻿import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
+import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
 import sortVersionChanges from '@frontend/modules/data-catalogue/utils/sortVersionChanges';
 
 describe('change log versions sorting order using sortVersionChanges utiltiy function', () => {

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/sortVersionChanges.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/sortVersionChanges.ts
@@ -1,4 +1,4 @@
-﻿import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
+import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
 
 /**
  * Sorts an array of version changes in descending order (newer versions first).


### PR DESCRIPTION
- Amends sass to not add BOMs in outputted CSS as this was being bundled and causing issues
- Strips BOMs from FE files
- Adds charset to editorconfig to prevent files being saved as UTF-8 with BOM