### PR TITLE
EES-7358 Expose CsvOnly geographic levels on the frontend

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -100,6 +100,7 @@ public class FootnoteControllerTests
                         content: "Test content",
                         timePeriods: new TimePeriodLabels(),
                         geographicLevels: new List<string>(),
+                        geographicLevelsCsvOnly: new List<string>(),
                         filters: new List<string>(),
                         indicators: new List<string>(),
                         file: new FileInfo

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
@@ -485,7 +485,7 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
-        public async Task WhenDataSetHasCsvOnlyGeographicLevels_ExcludesThemFromGeographicLevels()
+        public async Task WhenDataSetHasCsvOnlyGeographicLevels_SplitsThemIntoGeographicLevelsCsvOnly()
         {
             // Arrange
             Publication publication = _dataFixture
@@ -529,6 +529,7 @@ public abstract class ReleaseDataContentServiceTests
                 var result = outcome.AssertRight();
 
                 Assert.Equal(["National"], result.DataSets[0].Meta.GeographicLevels);
+                Assert.Equal(["School"], result.DataSets[0].Meta.GeographicLevelsCsvOnly);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -64,6 +64,7 @@ public record ReleaseDataContentDataSetMetaDto
 {
     public required string[] Filters { get; init; }
     public required string[] GeographicLevels { get; init; }
+    public required string[] GeographicLevelsCsvOnly { get; init; }
     public required string[] Indicators { get; init; }
     public required int NumDataFileRows { get; init; }
     public required ReleaseDataContentDataSetMetaTimePeriodRangeDto TimePeriodRange { get; init; }
@@ -75,7 +76,11 @@ public record ReleaseDataContentDataSetMetaDto
         return new ReleaseDataContentDataSetMetaDto
         {
             Filters = GetOrderedFilters(meta.Filters, releaseFile.FilterSequence),
-            GeographicLevels = GetOrderedGeographicLevels(file.DataSetFileVersionGeographicLevels),
+            GeographicLevels = GetOrderedGeographicLevels(file.DataSetFileVersionGeographicLevels, csvOnly: false),
+            GeographicLevelsCsvOnly = GetOrderedGeographicLevels(
+                file.DataSetFileVersionGeographicLevels,
+                csvOnly: true
+            ),
             Indicators = GetOrderedIndicators(meta.Indicators, releaseFile.IndicatorSequence),
             NumDataFileRows = meta.NumDataFileRows,
             TimePeriodRange = ReleaseDataContentDataSetMetaTimePeriodRangeDto.FromTimePeriodRangeMeta(
@@ -85,11 +90,12 @@ public record ReleaseDataContentDataSetMetaDto
     }
 
     private static string[] GetOrderedGeographicLevels(
-        IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels
+        IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels,
+        bool csvOnly
     ) =>
         [
             .. dataSetFileVersionGeographicLevels
-                .Where(level => level.CsvOnly != true)
+                .Where(level => (level.CsvOnly == true) == csvOnly) // TODO EES-7584 update once CsvOnly isn't nullable
                 .Select(level => level.GeographicLevel.GetEnumLabel())
                 .Order(),
         ];

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseDataContentDtoBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseDataContentDtoBuilder.cs
@@ -142,6 +142,7 @@ public class ReleaseDataContentDataSetMetaDtoBuilder
 {
     private string[] _filters = ["Filter 1"];
     private string[] _geographicLevels = ["Geographic level 1"];
+    private string[] _geographicLevelsCsvOnly = [];
     private string[] _indicators = ["Indicator 1"];
     private int _numDataFileRows = 100;
     private ReleaseDataContentDataSetMetaTimePeriodRangeDto _timePeriodRange =
@@ -152,6 +153,7 @@ public class ReleaseDataContentDataSetMetaDtoBuilder
         {
             Filters = _filters,
             GeographicLevels = _geographicLevels,
+            GeographicLevelsCsvOnly = _geographicLevelsCsvOnly,
             Indicators = _indicators,
             NumDataFileRows = _numDataFileRows,
             TimePeriodRange = _timePeriodRange,
@@ -166,6 +168,12 @@ public class ReleaseDataContentDataSetMetaDtoBuilder
     public ReleaseDataContentDataSetMetaDtoBuilder WithGeographicLevels(string[] geographicLevels)
     {
         _geographicLevels = geographicLevels;
+        return this;
+    }
+
+    public ReleaseDataContentDataSetMetaDtoBuilder WithGeographicLevelsCsvOnly(string[] geographicLevelsCsvOnly)
+    {
+        _geographicLevelsCsvOnly = geographicLevelsCsvOnly;
         return this;
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -69,6 +69,7 @@ public abstract class DataSetFilesControllerCachingTests
                     {
                         NumDataFileRows = 9393,
                         GeographicLevels = [GeographicLevel.Country.GetEnumLabel()],
+                        GeographicLevelsCsvOnly = [],
                         TimePeriodRange = new DataSetFileTimePeriodRangeViewModel { From = "2000", To = "2001" },
                         Filters = ["Filter 1"],
                         Indicators = ["Indicator 1"],

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -144,7 +144,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
             }
 
             [Fact]
-            public async Task FilterByGeographicLevel_CsvOnlyLevelsAreExcluded()
+            public async Task FilterByGeographicLevel_CsvOnlyLevelsAreIncluded()
             {
                 Publication publication = DataFixture
                     .DefaultPublication()
@@ -168,9 +168,15 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
                 );
                 var csvOnlyResponse = await ListDataSetFiles(csvOnlyQuery);
 
-                csvOnlyResponse
-                    .AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>()
-                    .AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0);
+                var csvOnlyPagedResult = csvOnlyResponse.AssertOk<
+                    PaginatedListViewModel<DataSetFileSummaryViewModel>
+                >();
+
+                csvOnlyPagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 1);
+
+                var viewModel = Assert.Single(csvOnlyPagedResult.Results);
+                Assert.Equal([GeographicLevel.Country.GetEnumLabel()], viewModel.Meta.GeographicLevels);
+                Assert.Equal([GeographicLevel.Institution.GetEnumLabel()], viewModel.Meta.GeographicLevelsCsvOnly);
 
                 var importedQuery = new DataSetFileListRequest(GeographicLevel: GeographicLevel.Country.GetEnumValue());
                 var importedResponse = await ListDataSetFiles(importedQuery);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
@@ -431,7 +431,7 @@ public class DataGuidanceFileWriterTests : IDisposable
             {
                 Filename = "test-1.csv",
                 Name = "Test data 1",
-                Content = "<p>Test file content</p>",
+                Content = "Test file content",
                 GeographicLevels = new List<string> { "Local authority", "National", "Ward" },
                 GeographicLevelsCsvOnly = new List<string> { "School" },
                 TimePeriods = new TimePeriodLabels("2018", "2018"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataSetFileServiceTests.cs
@@ -106,7 +106,7 @@ public class DataSetFileServiceTests
         }
 
         [Fact]
-        public async Task CsvOnlyGeographicLevels_ExcludedFromViewModel()
+        public async Task CsvOnlyGeographicLevels_SplitIntoGeographicLevelsCsvOnly()
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
@@ -141,11 +141,12 @@ public class DataSetFileServiceTests
 
                 var viewModel = Assert.Single(pagedResult.Results);
                 Assert.Equal([GeographicLevel.Country.GetEnumLabel()], viewModel.Meta.GeographicLevels);
+                Assert.Equal([GeographicLevel.Institution.GetEnumLabel()], viewModel.Meta.GeographicLevelsCsvOnly);
             }
         }
 
         [Fact]
-        public async Task FilterByGeographicLevel_CsvOnlyLevelsDoNotMatchWhenMultipleGeogLvls()
+        public async Task FilterByGeographicLevel_CsvOnlyLevelsMatchWhenMultipleGeogLvls()
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
@@ -182,8 +183,9 @@ public class DataSetFileServiceTests
 
                 var pagedResult = result.AssertRight();
 
-                var viewModel = Assert.Single(pagedResult.Results);
-                Assert.Equal(releaseFiles[0].FileId, viewModel.FileId);
+                Assert.Equal(2, pagedResult.Results.Count);
+                Assert.Contains(pagedResult.Results, viewModel => viewModel.FileId == releaseFiles[0].FileId);
+                Assert.Contains(pagedResult.Results, viewModel => viewModel.FileId == releaseFiles[1].FileId);
             }
         }
 
@@ -522,8 +524,8 @@ public class DataSetFileServiceTests
                 var meta = releaseFile.File.DataSetFileMeta!;
 
                 Assert.Equal(meta.NumDataFileRows, viewModel.File.Meta.NumDataFileRows);
-                // Csv-only geographic levels should be excluded
                 Assert.Equal([GeographicLevel.Country.GetEnumLabel()], viewModel.File.Meta.GeographicLevels);
+                Assert.Equal([GeographicLevel.Institution.GetEnumLabel()], viewModel.File.Meta.GeographicLevelsCsvOnly);
                 Assert.Equal(
                     TimePeriodLabelFormatter.Format(
                         meta.TimePeriodRange.Start.Period,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -462,7 +462,7 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
-        public async Task WhenDataSetHasCsvOnlyGeographicLevels_ExcludesThemFromGeographicLevels()
+        public async Task WhenDataSetHasCsvOnlyGeographicLevels_SplitsThemIntoGeographicLevelsCsvOnly()
         {
             // Arrange
             Publication publication = _dataFixture
@@ -503,6 +503,7 @@ public abstract class ReleaseDataContentServiceTests
                 var result = outcome.AssertRight();
 
                 Assert.Equal(["National"], result.DataSets[0].Meta.GeographicLevels);
+                Assert.Equal(["School"], result.DataSets[0].Meta.GeographicLevelsCsvOnly);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -92,16 +92,22 @@ public class DataSetFileService(
             .Where(file => results.Select(r => r.FileId).ToList().Contains(file.Id))
             .ToDictionaryAsync(
                 file => file.Id,
-                file =>
-                    file.DataSetFileVersionGeographicLevels.Where(gl => gl.CsvOnly != true)
-                        .Select(gl => gl.GeographicLevel.GetEnumLabel())
-                        .Order()
-                        .ToList(),
+                file => file.DataSetFileVersionGeographicLevels,
                 cancellationToken: cancellationToken
             );
         foreach (var result in results)
         {
-            result.Meta.GeographicLevels = geogLvlsDict[result.FileId];
+            // TODO EES-7584 update once CsvOnly isn't nullable
+            result.Meta.GeographicLevels = geogLvlsDict[result.FileId]
+                .Where(gl => gl.CsvOnly != true)
+                .Select(gl => gl.GeographicLevel.GetEnumLabel())
+                .Order()
+                .ToList();
+            result.Meta.GeographicLevelsCsvOnly = geogLvlsDict[result.FileId]
+                .Where(gl => gl.CsvOnly == true)
+                .Select(gl => gl.GeographicLevel.GetEnumLabel())
+                .Order()
+                .ToList();
         }
 
         return new PaginatedListViewModel<DataSetFileSummaryViewModel>(
@@ -329,9 +335,15 @@ public class DataSetFileService(
         return new DataSetFileMetaViewModel
         {
             NumDataFileRows = meta.NumDataFileRows,
+            // TODO EES-7584 update once CsvOnly isn't nullable
             GeographicLevels = dataSetFileVersionGeographicLevels
                 .Where(gl => gl.CsvOnly != true)
                 .Select(gl => gl.GeographicLevel.GetEnumLabel())
+                .ToList(),
+            GeographicLevelsCsvOnly = dataSetFileVersionGeographicLevels
+                .Where(gl => gl.CsvOnly == true)
+                .Select(gl => gl.GeographicLevel.GetEnumLabel())
+                .Order()
                 .ToList(),
             TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
             {
@@ -574,9 +586,7 @@ internal static class ReleaseFileQueryableExtensions
     {
         return geographicLevel.HasValue
             ? query.Where(rf =>
-                rf.File.DataSetFileVersionGeographicLevels.Any(gl =>
-                    gl.GeographicLevel == geographicLevel && gl.CsvOnly != true
-                )
+                rf.File.DataSetFileVersionGeographicLevels.Any(gl => gl.GeographicLevel == geographicLevel)
             )
             : query;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDtos.cs
@@ -63,6 +63,7 @@ public record ReleaseDataContentDataSetMetaDto
 {
     public required string[] Filters { get; init; }
     public required string[] GeographicLevels { get; init; }
+    public required string[] GeographicLevelsCsvOnly { get; init; }
     public required string[] Indicators { get; init; }
     public required int NumDataFileRows { get; init; }
     public required ReleaseDataContentDataSetMetaTimePeriodRangeDto TimePeriodRange { get; init; }
@@ -74,7 +75,11 @@ public record ReleaseDataContentDataSetMetaDto
         return new ReleaseDataContentDataSetMetaDto
         {
             Filters = GetOrderedFilters(meta.Filters, releaseFile.FilterSequence),
-            GeographicLevels = GetOrderedGeographicLevels(file.DataSetFileVersionGeographicLevels),
+            GeographicLevels = GetOrderedGeographicLevels(file.DataSetFileVersionGeographicLevels, csvOnly: false),
+            GeographicLevelsCsvOnly = GetOrderedGeographicLevels(
+                file.DataSetFileVersionGeographicLevels,
+                csvOnly: true
+            ),
             Indicators = GetOrderedIndicators(meta.Indicators, releaseFile.IndicatorSequence),
             NumDataFileRows = meta.NumDataFileRows,
             TimePeriodRange = ReleaseDataContentDataSetMetaTimePeriodRangeDto.FromTimePeriodRangeMeta(
@@ -84,11 +89,12 @@ public record ReleaseDataContentDataSetMetaDto
     }
 
     private static string[] GetOrderedGeographicLevels(
-        IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels
+        IEnumerable<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels,
+        bool csvOnly
     ) =>
         [
             .. dataSetFileVersionGeographicLevels
-                .Where(level => level.CsvOnly != true)
+                .Where(level => (level.CsvOnly == true) == csvOnly) // TODO EES-7584 update once CsvOnly isn't nullable
                 .Select(level => level.GeographicLevel.GetEnumLabel())
                 .Order(),
         ];

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -4,6 +4,7 @@ public record DataSetFileMetaViewModel
 {
     public required int NumDataFileRows { get; set; }
     public required List<string> GeographicLevels { get; set; }
+    public required List<string> GeographicLevelsCsvOnly { get; set; }
     public required DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; }
     public required List<string> Filters { get; init; }
     public required List<string> Indicators { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -130,9 +130,10 @@ public class PublicationControllerTests
             0,
             "Content",
             new TimePeriodLabels { From = "2020", To = "2022" },
-            ["level1"],
-            ["filter1"],
-            ["indicator1", "indicator2", "indicator3", "indicator4"],
+            new List<string> { "level1" },
+            new List<string> { "csvOnlyLevel1" },
+            new List<string> { "filter1" },
+            new List<string> { "indicator1", "indicator2", "indicator3", "indicator4" },
             new FileInfo
             {
                 Created = DateTime.Now,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -183,6 +183,9 @@ public class ReleaseServiceTests
             Assert.Equal("Local authority", subjects[0].GeographicLevels[0]);
             Assert.Equal("Local authority district", subjects[0].GeographicLevels[1]);
 
+            Assert.Single(subjects[0].GeographicLevelsCsvOnly);
+            Assert.Equal("School", subjects[0].GeographicLevelsCsvOnly[0]);
+
             Assert.Equal(2, subjects[0].Filters.Count);
             Assert.Equal("subject 1 filter 1", subjects[0].Filters[0]);
             Assert.Equal("subject 1 filter 2", subjects[0].Filters[1]);
@@ -207,6 +210,8 @@ public class ReleaseServiceTests
 
             Assert.Single(subjects[1].GeographicLevels);
             Assert.Equal("National", subjects[1].GeographicLevels[0]);
+
+            Assert.Empty(subjects[1].GeographicLevelsCsvOnly);
 
             Assert.Single(subjects[1].Filters);
             Assert.Equal("subject 2 filter 1", subjects[1].Filters[0]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -98,6 +98,7 @@ public class ReleaseService : IReleaseService
                     content: releaseFile.Summary ?? string.Empty,
                     timePeriods: await _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
                     geographicLevels: await GetGeographicLevels(rs.SubjectId),
+                    geographicLevelsCsvOnly: await GetGeographicLevels(rs.SubjectId, csvOnly: true),
                     filters: await GetFilters(rs.SubjectId, releaseFile.FilterSequence),
                     indicators: await GetIndicators(rs.SubjectId, releaseFile.IndicatorSequence),
                     file: releaseFile.ToFileInfo(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/SubjectViewModel.cs
@@ -16,6 +16,8 @@ public record SubjectViewModel
 
     public List<string> GeographicLevels { get; }
 
+    public List<string> GeographicLevelsCsvOnly { get; }
+
     public List<string> Filters { get; }
 
     public List<string> Indicators { get; }
@@ -31,6 +33,7 @@ public record SubjectViewModel
         string content,
         TimePeriodLabels timePeriods,
         List<string> geographicLevels,
+        List<string> geographicLevelsCsvOnly,
         List<string> filters,
         List<string> indicators,
         FileInfo file,
@@ -43,6 +46,7 @@ public record SubjectViewModel
         Content = content;
         TimePeriods = timePeriods;
         GeographicLevels = geographicLevels;
+        GeographicLevelsCsvOnly = geographicLevelsCsvOnly;
         Filters = filters;
         Indicators = indicators;
         File = file;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePageTabExploreData.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePageTabExploreData.tsx
@@ -159,56 +159,61 @@ const ReleasePageTabExploreData = ({
         />
       }
     >
-      {dataContent?.dataSets.map(dataset => (
-        <ReleaseDataListItem
-          key={dataset.fileId}
-          title={dataset.title}
-          description={dataset.summary}
-          metaInfo={[
-            ...dataset.meta.geographicLevels,
-            ...dataset.meta.geographicLevelsCsvOnly.map(
-              level => `${level} (CSV only)`,
-            ),
-          ].join(', ')}
-          tag={
-            dataset.isApiEnabled && (
-              <Tag className="govuk-!-margin-bottom-2" colour="grey">
-                Available by API
-              </Tag>
-            )
-          }
-          actions={
-            <>
-              <span>
-                Create table{' '}
-                <VisuallyHidden>using {dataset.title}</VisuallyHidden> (public
-                site only)
-              </span>
-              <ButtonText
-                onClick={() => {
-                  releaseFileService.downloadFilesAsZip(release.id, [
-                    dataset.fileId,
-                  ]);
-                }}
-              >
-                Download <VisuallyHidden>{dataset.title}</VisuallyHidden> (ZIP)
-              </ButtonText>
-            </>
-          }
-        >
-          <ReleaseDataSetFileSummary
-            dataSetFile={dataset}
-            expanded={showAllDataSetDetails}
-            renderLink={
-              <span>
-                Data set information page{' '}
-                <VisuallyHidden>for {dataset.title}</VisuallyHidden> (public
-                site only)
-              </span>
+      {dataContent?.dataSets.map(dataset => {
+        const geographicLevels = [
+          ...dataset.meta.geographicLevels,
+          ...dataset.meta.geographicLevelsCsvOnly.map(
+            level => `${level} (CSV only)`,
+          ),
+        ];
+
+        return (
+          <ReleaseDataListItem
+            key={dataset.fileId}
+            title={dataset.title}
+            description={dataset.summary}
+            metaInfo={geographicLevels.join(', ')}
+            tag={
+              dataset.isApiEnabled && (
+                <Tag className="govuk-!-margin-bottom-2" colour="grey">
+                  Available by API
+                </Tag>
+              )
             }
-          />
-        </ReleaseDataListItem>
-      ))}
+            actions={
+              <>
+                <span>
+                  Create table{' '}
+                  <VisuallyHidden>using {dataset.title}</VisuallyHidden> (public
+                  site only)
+                </span>
+                <ButtonText
+                  onClick={() => {
+                    releaseFileService.downloadFilesAsZip(release.id, [
+                      dataset.fileId,
+                    ]);
+                  }}
+                >
+                  Download <VisuallyHidden>{dataset.title}</VisuallyHidden>{' '}
+                  (ZIP)
+                </ButtonText>
+              </>
+            }
+          >
+            <ReleaseDataSetFileSummary
+              dataSetFile={dataset}
+              expanded={showAllDataSetDetails}
+              renderLink={
+                <span>
+                  Data set information page{' '}
+                  <VisuallyHidden>for {dataset.title}</VisuallyHidden> (public
+                  site only)
+                </span>
+              }
+            />
+          </ReleaseDataListItem>
+        );
+      })}
     </ReleaseDataList>
   ) : (
     <InsetText>No data sets added for this release yet.</InsetText>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePageTabExploreData.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePageTabExploreData.tsx
@@ -164,7 +164,12 @@ const ReleasePageTabExploreData = ({
           key={dataset.fileId}
           title={dataset.title}
           description={dataset.summary}
-          metaInfo={dataset.meta.geographicLevels.join(', ')}
+          metaInfo={[
+            ...dataset.meta.geographicLevels,
+            ...dataset.meta.geographicLevelsCsvOnly.map(
+              level => `${level} (CSV only)`,
+            ),
+          ].join(', ')}
           tag={
             dataset.isApiEnabled && (
               <Tag className="govuk-!-margin-bottom-2" colour="grey">

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleasePageTabExploreData.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleasePageTabExploreData.test.tsx
@@ -73,6 +73,7 @@ describe('ReleasePageTabExploreData', () => {
             'Local authority district',
             'National',
           ],
+          geographicLevelsCsvOnly: ['School'],
           indicators: [
             'Authorised absence rate',
             'Authorised absence rate exact',
@@ -94,6 +95,7 @@ describe('ReleasePageTabExploreData', () => {
         meta: {
           filters: ['Characteristic', 'School type'],
           geographicLevels: ['Local authority', 'National', 'Regional'],
+          geographicLevelsCsvOnly: [],
           indicators: [
             'Authorised absence rate',
             'Number of authorised absence sessions',
@@ -253,6 +255,11 @@ describe('ReleasePageTabExploreData', () => {
       within(dataSetItems[0]).getByRole('heading', {
         name: 'Test dataset 1',
       }),
+    ).toBeInTheDocument();
+    expect(
+      within(dataSetItems[0]).getByText(
+        'Local authority, Local authority district, National, School (CSV only)',
+      ),
     ).toBeInTheDocument();
     expect(
       within(dataSetItems[0]).getByRole('button', {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -151,6 +151,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1.getByTestId('Geographic levels')).toHaveTextContent(
         'Local authority; National',
       );
+      expect(
+        dataSet1.getByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).toHaveTextContent('School');
       expect(dataSet1.getByTestId('Time period')).toHaveTextContent(
         '2018 to 2019',
       );
@@ -199,6 +204,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2.getByTestId('Geographic levels')).toHaveTextContent(
         'Regional; Ward',
       );
+      expect(
+        dataSet2.queryByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).not.toBeInTheDocument();
       expect(dataSet2.getByTestId('Time period')).toHaveTextContent(
         '2020 to 2021',
       );
@@ -285,6 +295,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1.getByTestId('Geographic levels')).toHaveTextContent(
         'Local authority; National',
       );
+      expect(
+        dataSet1.getByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).toHaveTextContent('School');
       expect(dataSet1.getByTestId('Time period')).toHaveTextContent(
         '2018 to 2019',
       );
@@ -337,6 +352,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2.getByTestId('Geographic levels')).toHaveTextContent(
         'Regional; Ward',
       );
+      expect(
+        dataSet2.queryByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).not.toBeInTheDocument();
       expect(dataSet2.getByTestId('Time period')).toHaveTextContent(
         '2020 to 2021',
       );
@@ -748,6 +768,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1.getByTestId('Geographic levels')).toHaveTextContent(
         'Local authority; National',
       );
+      expect(
+        dataSet1.getByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).toHaveTextContent('School');
       expect(dataSet1.getByTestId('Time period')).toHaveTextContent(
         '2018 to 2019',
       );
@@ -796,6 +821,11 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2.getByTestId('Geographic levels')).toHaveTextContent(
         'Regional; Ward',
       );
+      expect(
+        dataSet2.queryByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).not.toBeInTheDocument();
       expect(dataSet2.getByTestId('Time period')).toHaveTextContent(
         '2020 to 2021',
       );

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataGuidanceDataFile.tsx
@@ -21,6 +21,11 @@ const ReleaseDataGuidanceDataFile = ({ dataSet, renderContent }: Props) => {
     [dataSet.geographicLevels],
   );
 
+  const geographicLevelsCsvOnly = useMemo(
+    () => dataSet.geographicLevelsCsvOnly.sort().join('; '),
+    [dataSet.geographicLevelsCsvOnly],
+  );
+
   const timePeriod = useMemo(() => {
     const { from, to } = dataSet.timePeriods;
 
@@ -58,6 +63,11 @@ const ReleaseDataGuidanceDataFile = ({ dataSet, renderContent }: Props) => {
         {geographicLevels && (
           <SummaryListItem term="Geographic levels">
             {geographicLevels}
+          </SummaryListItem>
+        )}
+        {geographicLevelsCsvOnly && (
+          <SummaryListItem term="Geographic levels (only available via download / public API)">
+            {geographicLevelsCsvOnly}
           </SummaryListItem>
         )}
         {timePeriod && (

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataSetFileSummary.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataSetFileSummary.test.tsx
@@ -17,6 +17,7 @@ const testDataSetItem: DataSetItem = {
       'Local authority district',
       'National',
     ],
+    geographicLevelsCsvOnly: [],
     indicators: ['Authorised absence rate', 'Authorised absence rate exact'],
     numDataFileRows: 1000,
     timePeriodRange: {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetDetailsList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataSetDetailsList.tsx
@@ -12,7 +12,14 @@ interface Props {
 }
 
 export default function DataSetDetailsList({ subject }: Props) {
-  const { content, filters, geographicLevels, indicators, name } = subject;
+  const {
+    content,
+    filters,
+    geographicLevels,
+    geographicLevelsCsvOnly,
+    indicators,
+    name,
+  } = subject;
   const timePeriod = getTimePeriodString(subject.timePeriods);
 
   return (
@@ -21,6 +28,11 @@ export default function DataSetDetailsList({ subject }: Props) {
       {geographicLevels.length > 0 && (
         <SummaryListItem term="Geographic levels">
           {orderBy(geographicLevels).join('; ')}
+        </SummaryListItem>
+      )}
+      {geographicLevelsCsvOnly && geographicLevelsCsvOnly.length > 0 && (
+        <SummaryListItem term="Geographic levels (only available via download / public API)">
+          {orderBy(geographicLevelsCsvOnly).join('; ')}
         </SummaryListItem>
       )}
       {timePeriod && (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataSetStep.test.tsx
@@ -22,6 +22,7 @@ describe('DataSetStep', () => {
         to: '2020/21',
       },
       geographicLevels: ['Local Authority District', 'Ward'],
+      geographicLevelsCsvOnly: ['School'],
       file: {
         id: 'file-1',
         name: 'Subject 1',
@@ -139,6 +140,11 @@ describe('DataSetStep', () => {
     expect(subject1Hint.getByTestId('Geographic levels')).toHaveTextContent(
       'Local Authority District; Ward',
     );
+    expect(
+      subject1Hint.getByTestId(
+        'Geographic levels (only available via download / public API)',
+      ),
+    ).toHaveTextContent('School');
     expect(subject1Hint.getByTestId('Time period')).toHaveTextContent(
       '2018/19 to 2020/21',
     );
@@ -163,6 +169,11 @@ describe('DataSetStep', () => {
     expect(subject2Hint.getByTestId('Geographic levels')).toHaveTextContent(
       'Local Authority; National',
     );
+    expect(
+      subject2Hint.queryByTestId(
+        'Geographic levels (only available via download / public API)',
+      ),
+    ).not.toBeInTheDocument();
     expect(subject2Hint.getByTestId('Time period')).toHaveTextContent(
       '2015 to 2020',
     );

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -236,6 +236,7 @@ export interface DataSetItem {
   meta: {
     filters: string[];
     geographicLevels: string[];
+    geographicLevelsCsvOnly: string[];
     indicators: string[];
     numDataFileRows: number;
     timePeriodRange: {

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -88,6 +88,8 @@ export interface Subject {
     to?: string;
   };
   geographicLevels: string[];
+  // Optional as subject responses cached before this field was added won't include it - will be made nonoptional in EES-7625
+  geographicLevelsCsvOnly?: string[];
   file: FileInfo;
   filters: string[];
   indicators: string[];

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -192,6 +192,7 @@ export const testDataSetFile: DataSetFile = {
       },
       filters: ['Filter 1', 'Filter 2'],
       geographicLevels: ['Local authority', 'National'],
+      geographicLevelsCsvOnly: [],
       indicators: ['Indicator 1', 'Indicator 2'],
     },
     dataCsvPreview: testDataSetCsvPreview,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
@@ -32,6 +32,7 @@ export default function DataSetFileDetails({
         timePeriodRange,
         filters,
         geographicLevels,
+        geographicLevelsCsvOnly,
         indicators,
       },
     },
@@ -88,6 +89,11 @@ export default function DataSetFileDetails({
         {geographicLevels && geographicLevels.length > 0 && (
           <SummaryListItem term="Geographic levels">
             {orderBy(geographicLevels).join(', ')}
+          </SummaryListItem>
+        )}
+        {geographicLevelsCsvOnly && geographicLevelsCsvOnly.length > 0 && (
+          <SummaryListItem term="Geographic levels (only available via download / public API)">
+            {orderBy(geographicLevelsCsvOnly).join(', ')}
           </SummaryListItem>
         )}
         {indicators && indicators.length > 0 && (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -51,6 +51,7 @@ export default function DataSetFileSummary({
       },
       filters = [],
       geographicLevels = [],
+      geographicLevelsCsvOnly = [],
       indicators = [],
     },
     api,
@@ -173,6 +174,16 @@ export default function DataSetFileSummary({
             term="Geographic levels"
           >
             {orderBy(geographicLevels).join(', ')}
+          </SummaryListItem>
+        )}
+        {geographicLevelsCsvOnly && geographicLevelsCsvOnly.length > 0 && (
+          <SummaryListItem
+            className={classNames({
+              'dfe-js-hidden': !showDetails,
+            })}
+            term="Geographic levels (only available via download / public API)"
+          >
+            {orderBy(geographicLevelsCsvOnly).join(', ')}
           </SummaryListItem>
         )}
         {indicators && indicators.length > 0 && (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileDetails.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileDetails.test.tsx
@@ -36,6 +36,11 @@ describe('DataSetFileDetails', () => {
       ),
     ).toBeInTheDocument();
     expect(
+      screen.queryByTestId(
+        'Geographic levels (only available via download / public API)',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
       within(screen.getByTestId('Indicators')).getByText('Indicator 1'),
     ).toBeInTheDocument();
     expect(
@@ -49,6 +54,36 @@ describe('DataSetFileDetails', () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('Time period')).getByText('2023 to 2024'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders csv-only geographic levels in a separate row', async () => {
+    render(
+      <DataSetFileDetails
+        dataSetFile={{
+          ...testDataSetFile,
+          file: {
+            ...testDataSetFile.file,
+            meta: {
+              ...testDataSetFile.file.meta,
+              geographicLevelsCsvOnly: ['School', 'Institution'],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Geographic levels')).getByText(
+        'Local authority, National',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).getByText('Institution, School'),
     ).toBeInTheDocument();
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
@@ -75,6 +75,11 @@ describe('DataSetFileSummary', () => {
       ),
     ).toBeInTheDocument();
     expect(
+      screen.queryByTestId(
+        'Geographic levels (only available via download / public API)',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
       within(screen.getByTestId('Indicators')).getByText('Indicator 2'),
     ).toBeInTheDocument();
     expect(
@@ -130,6 +135,34 @@ describe('DataSetFileSummary', () => {
       screen.getByRole('button', {
         name: 'Hide details about Data set 1',
       }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders csv-only geographic levels in a separate row in the expanded view', () => {
+    render(
+      <DataSetFileSummary
+        dataSetFile={{
+          ...testDataSetFileSummaries[0],
+          meta: {
+            ...testDataSetFileSummaries[0].meta,
+            geographicLevelsCsvOnly: ['School', 'Institution'],
+          },
+        }}
+        expanded
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Geographic levels')).getByText(
+        'Local authority, National, Regional',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByTestId(
+          'Geographic levels (only available via download / public API)',
+        ),
+      ).getByText('Institution, School'),
     ).toBeInTheDocument();
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseExploreDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseExploreDataPage.tsx
@@ -126,7 +126,12 @@ const ReleaseExploreDataPage = ({
           key={dataset.fileId}
           title={dataset.title}
           description={dataset.summary}
-          metaInfo={dataset.meta.geographicLevels.join(', ')}
+          metaInfo={[
+            ...dataset.meta.geographicLevels,
+            ...dataset.meta.geographicLevelsCsvOnly.map(
+              level => `${level} (CSV only)`,
+            ),
+          ].join(', ')}
           tag={
             dataset.isApiEnabled && (
               <Tag className="govuk-!-margin-bottom-2" colour="grey">

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseExploreDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseExploreDataPage.tsx
@@ -121,64 +121,69 @@ const ReleaseExploreDataPage = ({
         />
       }
     >
-      {dataSets.map(dataset => (
-        <ReleaseDataListItem
-          key={dataset.fileId}
-          title={dataset.title}
-          description={dataset.summary}
-          metaInfo={[
-            ...dataset.meta.geographicLevels,
-            ...dataset.meta.geographicLevelsCsvOnly.map(
-              level => `${level} (CSV only)`,
-            ),
-          ].join(', ')}
-          tag={
-            dataset.isApiEnabled && (
-              <Tag className="govuk-!-margin-bottom-2" colour="grey">
-                Available by API
-              </Tag>
-            )
-          }
-          actions={
-            <>
-              <Link
-                to={`/data-tables/${publicationSummary.slug}/${releaseVersionSummary.slug}?subjectId=${dataset.subjectId}`}
-              >
-                Create table{' '}
-                <VisuallyHidden>using {dataset.title}</VisuallyHidden>
-              </Link>
-              <ButtonText
-                onClick={async () => {
-                  await downloadService.downloadZip(
-                    releaseVersionSummary.id,
-                    'ReleaseDownloads',
-                    dataset.fileId,
-                  );
+      {dataSets.map(dataset => {
+        const geographicLevels = [
+          ...dataset.meta.geographicLevels,
+          ...dataset.meta.geographicLevelsCsvOnly.map(
+            level => `${level} (CSV only)`,
+          ),
+        ];
 
-                  logEvent({
-                    category: 'Downloads',
-                    action: 'Release page data set file download',
-                    label: `Publication: ${publicationSummary.title}, Release: ${releaseVersionSummary.title}, Data set: ${dataset.title}`,
-                  });
-                }}
-              >
-                Download <VisuallyHidden>{dataset.title}</VisuallyHidden> (ZIP)
-              </ButtonText>
-            </>
-          }
-        >
-          <ReleaseDataSetFileSummary
-            dataSetFile={dataset}
-            expanded={showAllDataSetDetails}
-            renderLink={
-              <Link to={`/data-catalogue/data-set/${dataset.dataSetFileId}`}>
-                Data set information page{' '}
-                <VisuallyHidden>for {dataset.title}</VisuallyHidden>
-              </Link>
+        return (
+          <ReleaseDataListItem
+            key={dataset.fileId}
+            title={dataset.title}
+            description={dataset.summary}
+            metaInfo={geographicLevels.join(', ')}
+            tag={
+              dataset.isApiEnabled && (
+                <Tag className="govuk-!-margin-bottom-2" colour="grey">
+                  Available by API
+                </Tag>
+              )
             }
-          />
-        </ReleaseDataListItem>
-      ))}
+            actions={
+              <>
+                <Link
+                  to={`/data-tables/${publicationSummary.slug}/${releaseVersionSummary.slug}?subjectId=${dataset.subjectId}`}
+                >
+                  Create table{' '}
+                  <VisuallyHidden>using {dataset.title}</VisuallyHidden>
+                </Link>
+                <ButtonText
+                  onClick={async () => {
+                    await downloadService.downloadZip(
+                      releaseVersionSummary.id,
+                      'ReleaseDownloads',
+                      dataset.fileId,
+                    );
+
+                    logEvent({
+                      category: 'Downloads',
+                      action: 'Release page data set file download',
+                      label: `Publication: ${publicationSummary.title}, Release: ${releaseVersionSummary.title}, Data set: ${dataset.title}`,
+                    });
+                  }}
+                >
+                  Download <VisuallyHidden>{dataset.title}</VisuallyHidden>{' '}
+                  (ZIP)
+                </ButtonText>
+              </>
+            }
+          >
+            <ReleaseDataSetFileSummary
+              dataSetFile={dataset}
+              expanded={showAllDataSetDetails}
+              renderLink={
+                <Link to={`/data-catalogue/data-set/${dataset.dataSetFileId}`}>
+                  Data set information page{' '}
+                  <VisuallyHidden>for {dataset.title}</VisuallyHidden>
+                </Link>
+              }
+            />
+          </ReleaseDataListItem>
+        );
+      })}
     </ReleaseDataList>
   );
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/ReleaseExploreDataPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/ReleaseExploreDataPage.test.tsx
@@ -141,7 +141,7 @@ describe('ReleaseExploreDataPage', () => {
     ).toBeInTheDocument();
     expect(
       within(dataSetItems[0]).getByText(
-        'Local authority, Local authority district, National',
+        'Local authority, Local authority district, National, School (CSV only)',
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
@@ -317,6 +317,7 @@ export const testReleaseDataContent: ReleaseVersionDataContent = {
           'Local authority district',
           'National',
         ],
+        geographicLevelsCsvOnly: ['School'],
         indicators: [
           'Authorised absence rate',
           'Authorised absence rate exact',
@@ -338,6 +339,7 @@ export const testReleaseDataContent: ReleaseVersionDataContent = {
       meta: {
         filters: ['Characteristic', 'School type'],
         geographicLevels: ['Local authority', 'National', 'Regional'],
+        geographicLevelsCsvOnly: [],
         indicators: [
           'Authorised absence rate',
           'Number of authorised absence sessions',

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -30,6 +30,7 @@ export interface DataSetFile {
     meta: {
       numDataFileRows: number;
       geographicLevels: string[];
+      geographicLevelsCsvOnly: string[];
       timePeriodRange: {
         from: string;
         to: string;
@@ -91,6 +92,8 @@ export interface DataSetFileSummary {
   meta: {
     numDataFileRows: number;
     geographicLevels: string[];
+    // Optional as not currently provided by the azure search index used by the search-data page
+    geographicLevelsCsvOnly?: string[];
     timePeriodRange: {
       from: string;
       to: string;

--- a/tests/test-data/files/small-files/all_geographies_messy.csv
+++ b/tests/test-data/files/small-files/all_geographies_messy.csv
@@ -1,0 +1,181 @@
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,planning_area_code,planning_area_name,admission_numbers
+2011,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,3962
+2015,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,8123
+2014,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,5669
+2020,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,2399
+2014,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,8530
+2014,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,5032
+2008,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,6981
+2005,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,4180
+2017,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,8856
+2019,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,7419
+2019,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,8427
+2008,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,3548
+2017,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,9303
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,1134
+2017,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,6114
+2013,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,9790
+2012,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,3708
+2014,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,9854
+2015,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,8247
+2005,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,1054
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,6765
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,8024
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,2911
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,5456
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,6480
+2014,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,2284
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,4195
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,6005
+2016,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,2014
+2007,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,7769
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,3758
+2015,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,2787
+2011,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,9043
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,3001
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,9123
+2006,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,8052
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,1506
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,1090
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,8730
+2018,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,7423
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,5876
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,5124
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,2076
+2018,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,6170
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,3085
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,4503
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,1574
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,3221
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,4368
+2006,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,7360
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,6385
+2012,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,9216
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,1816
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,6078
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,5018
+2015,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,6882
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,6493
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,3902
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,8179
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,2701
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,3908
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,9023
+2018,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,7612
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,7916
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,8639
+2016,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,5346
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,6888
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,6526
+2010,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,6781
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,9961
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,6637
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,4896
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,4890
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,7242
+2015,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,2748
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,1010
+2009,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,4900
+2006,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,3338
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,1258
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,1023
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000984,Bolton 001,,,,,,,8533
+2008,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000985,Bolton 002,,,,,,,4587
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000986,Bolton 003,,,,,,,4621
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000987,Bolton 004,,,,,,,6031
+2009,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,5815
+2016,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,5831
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,1028
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,3481
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,6373
+2006,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,9341
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,6641
+2005,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,8557
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,3837
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,5680
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,1869
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,8427
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,5595
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,6945
+2014,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,8084
+2018,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,8630
+2018,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,5549
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,6676
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,2409
+2010,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,2321
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,5653
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,1433
+2006,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,1605
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,7569
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,1617
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,9468
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,8650
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,3004
+2011,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,5099
+2005,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,2179
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,4066
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,2003
+2017,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,4465
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,9208
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,8322
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,3927
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,2287
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,7357
+2006,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,7066
+2007,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,7004
+2015,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,6850
+2005,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,7988
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,1695
+2015,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,5872
+2018,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,4496
+2010,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,2266
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,6296
+2008,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,5901
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,4157
+2015,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,7731
+2012,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,6383
+2011,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,7904
+2017,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,1615
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,9207
+2009,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,2848
+2009,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,2192
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,1959
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,9857
+2005,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,3612
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,4415
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,9914
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,6772
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,4198
+2015,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,4613
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,6060
+2014,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,3646
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,9304
+2020,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,6650
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,1109
+2018,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,1926
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,8150
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,4035
+2008,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,5505
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,7499
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,9603
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,9884
+2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000984,Bolton 001,8533
+2008,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000985,Bolton 002,4587
+2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000986,Bolton 003,4621
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000987,Bolton 004,6031
+2009,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,5815
+2016,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,5831
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,1028
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,3481
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,6373
+2006,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,9341
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,6641
+2005,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,8557
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,3837
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,5680
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,1869
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,8427
+2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,5595
+2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,6945
+2014,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,8084
+2018,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,8630

--- a/tests/test-data/files/small-files/all_geographies_messy.meta.csv
+++ b/tests/test-data/files/small-files/all_geographies_messy.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,


### PR DESCRIPTION
EES-7358: Expose CsvOnly geographic levels in the frontend

This PR exposes CSV only geographic levels on the frontend.

It follows two broad designs, depending on whether the geographic levels are displayed in a table or not:

<img width="914" height="310" alt="csvOnly1" src="https://github.com/user-attachments/assets/31f173c7-62d5-43b7-9f6b-376e827f2cba" />
<img width="1197" height="483" alt="csvOnly2" src="https://github.com/user-attachments/assets/9f8afb26-da96-42aa-b2a4-a41a3296d7a4" />


Places on the public site that have been updated:
- data-guidance.txt in zip files (was updated to include csvOnly geographic levels in EES-7619)
- Data catalogue page
- Data set page
- Table tool
- Release page -> Explore and download data

We don't need to update API data sets - they pull from DuckDB or Postgres and contains all geographic levels already.

Search work will be done separately in EES-7627/7628/7629

:rotating_light: We'll need to refresh the subject cache. BAU endpoint to refresh subjects: DELETE api/bau/public-cache/publications (to be done in EES-7626) :rotating_light: 

:rotating_light: Need to merge EES-7619 before merging this :rotating_light: 

### Other changes
- Added all_geographies_messy test data set to test this work.