### PR TITLE
EES-7431 - correcting issue with inaccessible file mount on the Content API

### DIFF
--- a/infrastructure/templates/common/components/app-service/app-service.bicep
+++ b/infrastructure/templates/common/components/app-service/app-service.bicep
@@ -104,6 +104,10 @@ resource appSettings 'Microsoft.Web/sites/config@2025-03-01' = {
     WEBSITE_RUN_FROM_PACKAGE: '1'
     WEBSITE_LOAD_CERTIFICATES: '*'
     ASPNETCORE_DETAILEDERRORS: detailedErrors
+    
+    // Enable the App Service to access file shares over the VNet if
+    // file shares are available for this App Service. 
+    WEBSITE_CONTENTOVERVNET: length(azureFileShares ?? []) > 0 ? '1' : null
   })
 }
 


### PR DESCRIPTION
This PR:
- adds a missing piece of config that allows file shares on the VNet to be visible as file mounts. 