### PR TITLE
EES-7642 Add PublishingOrganisations to ReleaseSearchableDocumentDto returned by Content API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseSearchableDocumentDtoBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseSearchableDocumentDtoBuilder.cs
@@ -17,6 +17,10 @@ public class ReleaseSearchableDocumentDtoBuilder
     private Guid _themeId = Guid.NewGuid();
     private string _themeTitle = "Theme title";
     private ReleaseType _type = ReleaseType.OfficialStatistics;
+    private SearchableDocumentPublishingOrganisationDto[] _publishingOrganisations =
+    [
+        new() { Id = Guid.NewGuid(), Title = "Department for Education" },
+    ];
     private string _htmlContent = "HTML content";
 
     public ReleaseSearchableDocumentDto Build() =>
@@ -34,6 +38,7 @@ public class ReleaseSearchableDocumentDtoBuilder
             ThemeTitle = _themeTitle,
             Type = _type.ToString(),
             TypeBoost = _type.ToSearchDocumentTypeBoost(),
+            PublishingOrganisations = _publishingOrganisations,
             HtmlContent = _htmlContent,
         };
 
@@ -100,6 +105,14 @@ public class ReleaseSearchableDocumentDtoBuilder
     public ReleaseSearchableDocumentDtoBuilder WithType(ReleaseType type)
     {
         _type = type;
+        return this;
+    }
+
+    public ReleaseSearchableDocumentDtoBuilder WithPublishingOrganisations(
+        params SearchableDocumentPublishingOrganisationDto[] publishingOrganisations
+    )
+    {
+        _publishingOrganisations = publishingOrganisations;
         return this;
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseSearchableDocumentsServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseSearchableDocumentsServiceTests.cs
@@ -28,6 +28,7 @@ public abstract class ReleaseSearchableDocumentsServiceTests
                 .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
             var release = publication.Releases[0];
             var releaseVersion = release.Versions[0];
+            releaseVersion.PublishingOrganisations = _dataFixture.DefaultOrganisation().GenerateList(2);
 
             releaseVersion.HeadlinesSection = _dataFixture
                 .DefaultContentSection(ContentSectionType.Headlines)
@@ -103,8 +104,69 @@ public abstract class ReleaseSearchableDocumentsServiceTests
                     () => Assert.Equal(publication.Theme.Title, actual.ThemeTitle),
                     () => Assert.Equal(releaseVersion.Type.ToString(), actual.Type),
                     () => Assert.Equal(releaseVersion.Type.ToSearchDocumentTypeBoost(), actual.TypeBoost),
+                    () =>
+                        Assert.Equal(
+                            releaseVersion.PublishingOrganisations.Select(organisation => organisation.Id),
+                            actual.PublishingOrganisations.Select(publishingOrganisation => publishingOrganisation.Id)
+                        ),
+                    () =>
+                        Assert.Equal(
+                            releaseVersion.PublishingOrganisations.Select(organisation => organisation.Title),
+                            actual.PublishingOrganisations.Select(publishingOrganisation =>
+                                publishingOrganisation.Title
+                            )
+                        ),
                     .. GetAssertTrimmedLinesEqual(expectedHtmlContent, actual.HtmlContent),
                 ]);
+            }
+        }
+
+        [Fact]
+        public async Task WhenPublishingOrganisationsExist_ReturnsPublishingOrganisationsOrderedByTitle()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithTheme(_dataFixture.DefaultTheme())
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            releaseVersion.PublishingOrganisations = _dataFixture
+                .DefaultOrganisation()
+                .ForIndex(0, s => s.SetTitle("Organisation C"))
+                .ForIndex(1, s => s.SetTitle("Organisation A"))
+                .ForIndex(2, s => s.SetTitle("Organisation B"))
+                .GenerateList(3);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetLatestReleaseAsSearchableDocument(publication.Slug);
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                var expectedOrganisations = releaseVersion.PublishingOrganisations.OrderBy(o => o.Title).ToArray();
+
+                Assert.Equal(expectedOrganisations.Length, result.PublishingOrganisations.Length);
+                Assert.All(
+                    expectedOrganisations,
+                    (expectedOrganisation, index) =>
+                    {
+                        var actualOrganisation = result.PublishingOrganisations[index];
+                        Assert.Equal(expectedOrganisation.Id, actualOrganisation.Id);
+                        Assert.Equal(expectedOrganisation.Title, actualOrganisation.Title);
+                    }
+                );
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseSearchableDocumentDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseSearchableDocumentDto.cs
@@ -20,6 +20,7 @@ public record ReleaseSearchableDocumentDto
     public required string ThemeTitle { get; init; }
     public required string Type { get; init; }
     public required int TypeBoost { get; init; }
+    public required SearchableDocumentPublishingOrganisationDto[] PublishingOrganisations { get; init; }
     public required string HtmlContent { get; init; }
 
     public static ReleaseSearchableDocumentDto FromReleaseVersion(ReleaseVersion releaseVersion) =>
@@ -39,6 +40,12 @@ public record ReleaseSearchableDocumentDto
             ThemeTitle = releaseVersion.Release.Publication.Theme.Title,
             Type = releaseVersion.Type.ToString(),
             TypeBoost = releaseVersion.Type.ToSearchDocumentTypeBoost(),
+            PublishingOrganisations =
+            [
+                .. releaseVersion
+                    .PublishingOrganisations.OrderBy(organisation => organisation.Title)
+                    .Select(SearchableDocumentPublishingOrganisationDto.FromOrganisation),
+            ],
             HtmlContent = RenderSearchableHtmlContent(releaseVersion),
         };
 
@@ -124,4 +131,13 @@ public record ReleaseSearchableDocumentDto
 
     private static string? RemoveComments(string? input) =>
         string.IsNullOrEmpty(input) ? input : ContentFilterUtils.CommentsRegex().Replace(input, string.Empty);
+}
+
+public record SearchableDocumentPublishingOrganisationDto
+{
+    public required Guid Id { get; init; }
+    public required string Title { get; init; }
+
+    public static SearchableDocumentPublishingOrganisationDto FromOrganisation(Organisation organisation) =>
+        new() { Id = organisation.Id, Title = organisation.Title };
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseSearchableDocumentsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseSearchableDocumentsService.cs
@@ -36,6 +36,7 @@ public class ReleaseSearchableDocumentsService(ContentDbContext contentDbContext
     ) =>
         contentDbContext
             .ReleaseVersions.AsNoTracking()
+            .AsSplitQuery()
             .Include(rv => rv.Release.Publication.Theme)
             .Include(rv => rv.PublishingOrganisations)
             .Include(rv => rv.Content)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseSearchableDocumentsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/ReleaseSearchableDocumentsService.cs
@@ -37,6 +37,7 @@ public class ReleaseSearchableDocumentsService(ContentDbContext contentDbContext
         contentDbContext
             .ReleaseVersions.AsNoTracking()
             .Include(rv => rv.Release.Publication.Theme)
+            .Include(rv => rv.PublishingOrganisations)
             .Include(rv => rv.Content)
                 .ThenInclude(cs => cs.Content)
             .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken);


### PR DESCRIPTION
This PR adds `PublishingOrganisations` to `ReleaseSearchableDocumentDto` returned by the Content API's `GET publications/{publicationSlug}/releases/latest/searchable` endpoint.

This endpoint is used by the Searchable Documents function app. It will use `PublishingOrganisations` to populate new fields in the Azure AI Search index, ultimately so that 'Published by' can be exposed as a new filterable field in the Combined Search's 'Statistical releases' tab.